### PR TITLE
[final] invalidate purchaser info cache

### DIFF
--- a/android/common/build.gradle
+++ b/android/common/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.1.0'
-    implementation 'com.revenuecat.purchases:purchases:3.0.2'
+    implementation 'com.revenuecat.purchases:purchases:3.1.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/android/common/src/main/java/com/revenuecat/purchases/common/common.kt
+++ b/android/common/src/main/java/com/revenuecat/purchases/common/common.kt
@@ -266,6 +266,10 @@ fun checkTrialOrIntroductoryPriceEligibility(
     }.toMap()
 }
 
+fun invalidatePurchaserInfoCache() { 
+    Purchases.sharedInstance.invalidatePurchaserInfoCache();
+}
+
 private fun getMakePurchaseErrorFunction(onResult: OnResult): (PurchasesError, Boolean) -> Unit {
     return { error, userCancelled -> onResult.onError(error.map(mapOf("userCancelled" to userCancelled))) }
 }

--- a/android/common/src/main/java/com/revenuecat/purchases/common/common.kt
+++ b/android/common/src/main/java/com/revenuecat/purchases/common/common.kt
@@ -267,7 +267,7 @@ fun checkTrialOrIntroductoryPriceEligibility(
 }
 
 fun invalidatePurchaserInfoCache() { 
-    Purchases.sharedInstance.invalidatePurchaserInfoCache();
+    Purchases.sharedInstance.invalidatePurchaserInfoCache()
 }
 
 private fun getMakePurchaseErrorFunction(onResult: OnResult): (PurchasesError, Boolean) -> Unit {

--- a/ios/RCCommonFunctionality.h
+++ b/ios/RCCommonFunctionality.h
@@ -49,6 +49,8 @@ typedef void (^RCHybridResponseBlock)(NSDictionary * _Nullable, RCErrorContainer
 
 + (void)checkTrialOrIntroductoryPriceEligibility:(nonnull NSArray<NSString *> *)productIdentifiers completionBlock:(void (^)(NSDictionary<NSString *, NSDictionary *> *))completion;
 
++ (void)invalidatePurchaserInfoCache;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/RCCommonFunctionality.m
+++ b/ios/RCCommonFunctionality.m
@@ -217,6 +217,11 @@
     };
 }
 
++ (void)invalidatePurchaserInfoCache { 
+    NSAssert(RCPurchases.sharedPurchases, @"You must call setup first.");
+    [RCPurchases.sharedPurchases invalidatePurchaserInfoCache];
+}
+
 + (RCErrorContainer *)payloadForError:(NSError *)error withExtraPayload:(NSDictionary *)extraPayload
 {
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithDictionary:extraPayload];


### PR DESCRIPTION
added calls to invalidate purchaser info cache on android and iOS