### PR TITLE
[FINAL] Adds support for subscription offers

### DIFF
--- a/android/common/src/main/java/com/revenuecat/purchases/common/mappers.kt
+++ b/android/common/src/main/java/com/revenuecat/purchases/common/mappers.kt
@@ -39,8 +39,10 @@ fun SkuDetails.map(): Map<String, Any?> =
         "title" to title,
         "price" to priceAmountMicros / 1000000.0,
         "price_string" to price,
-        "currency_code" to priceCurrencyCode
-    ) + mapIntroPrice()
+        "currency_code" to priceCurrencyCode,
+        "introPrice" to mapIntroPrice(),
+        "discounts" to null
+    ) + mapIntroPriceDeprecated()
 
 fun PurchaserInfo.map(): Map<String, Any?> =
     mapOf(
@@ -90,8 +92,8 @@ private fun Package.map(offeringIdentifier: String): Map<String, Any?> =
         "offeringIdentifier" to offeringIdentifier
     )
 
-private fun SkuDetails.mapIntroPrice(): Map<String, Any?> {
-    return if (!freeTrialPeriod.isNullOrBlank()) {
+private fun SkuDetails.mapIntroPriceDeprecated(): Map<String, Any?> {
+    return if (freeTrialPeriod != null && freeTrialPeriod.isNotBlank()) {
         // Check freeTrialPeriod first to give priority to trials
         // Format using device locale. iOS will format using App Store locale, but there's no way
         // to figure out how the price in the SKUDetails is being formatted.
@@ -103,15 +105,15 @@ private fun SkuDetails.mapIntroPrice(): Map<String, Any?> {
             "intro_price_string" to format.format(0),
             "intro_price_period" to freeTrialPeriod,
             "intro_price_cycles" to 1
-        ) + freeTrialPeriod.mapPeriod()
-    } else if (!introductoryPrice.isNullOrBlank()) {
+        ) + freeTrialPeriod.mapPeriodDeprecated()
+    } else if (introductoryPrice != null || introductoryPrice.isNotBlank()) {
         mapOf(
             "intro_price" to introductoryPriceAmountMicros / 1000000.0,
             "intro_price_string" to introductoryPrice,
             "intro_price_period" to introductoryPricePeriod,
             "intro_price_cycles" to (introductoryPriceCycles?.takeUnless { it.isBlank() }?.toInt()
                 ?: 0)
-        ) + introductoryPricePeriod.mapPeriod()
+        ) + introductoryPricePeriod.mapPeriodDeprecated()
     } else {
         mapOf(
             "intro_price" to null,
@@ -124,7 +126,41 @@ private fun SkuDetails.mapIntroPrice(): Map<String, Any?> {
     }
 }
 
-private fun String?.mapPeriod(): Map<String, Any?> {
+private fun SkuDetails.mapIntroPrice(): Map<String, Any?> {
+    return if (freeTrialPeriod != null && freeTrialPeriod.isNotBlank()) {
+        // Check freeTrialPeriod first to give priority to trials
+        // Format using device locale. iOS will format using App Store locale, but there's no way
+        // to figure out how the price in the SKUDetails is being formatted.
+        val format = java.text.NumberFormat.getCurrencyInstance().apply {
+            currency = java.util.Currency.getInstance(priceCurrencyCode)
+        }
+        mapOf(
+            "price" to 0,
+            "priceString" to format.format(0),
+            "period" to freeTrialPeriod,
+            "cycles" to 1
+        ) + freeTrialPeriod.mapPeriod()
+    } else if (introductoryPrice != null && introductoryPrice.isNotBlank()) {
+        mapOf(
+            "price" to introductoryPriceAmountMicros / 1000000.0,
+            "priceString" to introductoryPrice,
+            "period" to introductoryPricePeriod,
+            "cycles" to (introductoryPriceCycles?.takeUnless { it.isBlank() }?.toInt()
+                ?: 0)
+        ) + introductoryPricePeriod.mapPeriod()
+    } else {
+        mapOf(
+            "price" to null,
+            "priceString" to null,
+            "period" to null,
+            "cycles" to null,
+            "periodUnit" to null,
+            "periodNumberOfUnits" to null
+        )
+    }
+}
+
+private fun String?.mapPeriodDeprecated(): Map<String, Any?> {
     return if (this == null || this.isBlank()) {
         mapOf(
             "intro_price_period_unit" to null,
@@ -148,6 +184,36 @@ private fun String?.mapPeriod(): Map<String, Any?> {
                 else -> mapOf(
                     "intro_price_period_unit" to "DAY",
                     "intro_price_period_number_of_units" to 0
+                )
+            }
+        }
+    }
+}
+
+private fun String?.mapPeriod(): Map<String, Any?> {
+    return if (this == null || this.isBlank()) {
+        mapOf(
+            "periodUnit" to null,
+            "periodNumberOfUnits" to null
+        )
+    } else {
+        PurchasesPeriod.parse(this).let { period ->
+            when {
+                period.years > 0 -> mapOf(
+                    "periodUnit" to "YEAR",
+                    "periodNumberOfUnits" to period.years
+                )
+                period.months > 0 -> mapOf(
+                    "periodUnit" to "MONTH",
+                    "periodNumberOfUnits" to period.months
+                )
+                period.days > 0 -> mapOf(
+                    "periodUnit" to "DAY",
+                    "periodNumberOfUnits" to period.days
+                )
+                else -> mapOf(
+                    "periodUnit" to "DAY",
+                    "periodNumberOfUnits" to 0
                 )
             }
         }

--- a/android/common/src/main/java/com/revenuecat/purchases/common/mappers.kt
+++ b/android/common/src/main/java/com/revenuecat/purchases/common/mappers.kt
@@ -8,6 +8,8 @@ import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PurchaserInfo
 import com.revenuecat.purchases.util.Iso8601Utils
+import java.text.NumberFormat
+import java.util.Currency
 
 fun EntitlementInfo.map(): Map<String, Any?> =
     mapOf(
@@ -30,7 +32,6 @@ fun EntitlementInfos.map(): Map<String, Any> =
         "all" to this.all.asIterable().associate { it.key to it.value.map() },
         "active" to this.active.asIterable().associate { it.key to it.value.map() }
     )
-
 
 fun SkuDetails.map(): Map<String, Any?> =
     mapOf(
@@ -93,13 +94,9 @@ private fun Package.map(offeringIdentifier: String): Map<String, Any?> =
     )
 
 private fun SkuDetails.mapIntroPriceDeprecated(): Map<String, Any?> {
-    return if (freeTrialPeriod != null && freeTrialPeriod.isNotBlank()) {
-        // Check freeTrialPeriod first to give priority to trials
-        // Format using device locale. iOS will format using App Store locale, but there's no way
-        // to figure out how the price in the SKUDetails is being formatted.
-        val format = java.text.NumberFormat.getCurrencyInstance().apply {
-            currency = java.util.Currency.getInstance(priceCurrencyCode)
-        }
+    val isFreeTrialAvailable = freeTrialPeriod != null && freeTrialPeriod.isNotBlank()
+    return if (isFreeTrialAvailable) {
+        val format = formatUsingDeviceLocale()
         mapOf(
             "intro_price" to 0,
             "intro_price_string" to format.format(0),
@@ -123,6 +120,12 @@ private fun SkuDetails.mapIntroPriceDeprecated(): Map<String, Any?> {
             "intro_price_period_unit" to null,
             "intro_price_period_number_of_units" to null
         )
+    }
+}
+
+private fun SkuDetails.formatUsingDeviceLocale(): NumberFormat {
+    return NumberFormat.getCurrencyInstance().apply {
+        currency = Currency.getInstance(priceCurrencyCode)
     }
 }
 

--- a/ios/RCCommonFunctionality.h
+++ b/ios/RCCommonFunctionality.h
@@ -41,13 +41,15 @@ typedef void (^RCHybridResponseBlock)(NSDictionary * _Nullable, RCErrorContainer
 
 + (void)purchaseProduct:(NSString *)productIdentifier completionBlock:(RCHybridResponseBlock)completion;
 
-+ (void)purchasePackage:(NSString *)packageIdentifier offering:(NSString *)offeringIdentifier completionBlock:(RCHybridResponseBlock)completion;
++ (void)purchasePackage:(NSString *)packageIdentifier offering:(NSString *)offeringIdentifier discount:(nullable NSString *)discountIdentifier completionBlock:(RCHybridResponseBlock)completion;
 
 + (void)makeDeferredPurchase:(RCDeferredPromotionalPurchaseBlock)deferredPurchase completionBlock:(RCHybridResponseBlock)completion;
 
 + (void)setFinishTransactions:(BOOL)finishTransactions;
 
-+ (void)checkTrialOrIntroductoryPriceEligibility:(nonnull NSArray<NSString *> *)productIdentifiers completionBlock:(void (^)(NSDictionary<NSString *, NSDictionary *> *))completion;
++ (void)checkTrialOrIntroductoryPriceEligibility:(nonnull NSArray<NSString *> *)productIdentifiers completionBlock:(RCReceiveIntroEligibilityBlock)completion;
+
++ (void)paymentDiscountForPackageIdentifier:(NSString *)packageIdentifier offering:(NSString *)offeringIdentifier completionBlock:(RCHybridResponseBlock)completion;
 
 @end
 

--- a/ios/RCCommonFunctionality.h
+++ b/ios/RCCommonFunctionality.h
@@ -39,7 +39,7 @@ typedef void (^RCHybridResponseBlock)(NSDictionary * _Nullable, RCErrorContainer
 
 + (BOOL)isAnonymous;
 
-+ (void)purchaseProduct:(NSString *)productIdentifier completionBlock:(RCHybridResponseBlock)completion;
++ (void)purchaseProduct:(NSString *)productIdentifier signedDiscountTimestamp:(nullable NSString *)discountTimestamp completionBlock:(RCHybridResponseBlock)completion;
 
 + (void)purchasePackage:(NSString *)packageIdentifier offering:(NSString *)offeringIdentifier signedDiscountTimestamp:(nullable NSString *)discountTimestamp completionBlock:(RCHybridResponseBlock)completion;
 
@@ -49,7 +49,7 @@ typedef void (^RCHybridResponseBlock)(NSDictionary * _Nullable, RCErrorContainer
 
 + (void)checkTrialOrIntroductoryPriceEligibility:(nonnull NSArray<NSString *> *)productIdentifiers completionBlock:(RCReceiveIntroEligibilityBlock)completion;
 
-+ (void)paymentDiscountForPackageIdentifier:(NSString *)packageIdentifier offering:(NSString *)offeringIdentifier discount:(nullable NSString *)discountIdentifier completionBlock:(RCHybridResponseBlock)completion;
++ (void)paymentDiscountForProductIdentifier:(NSString *)productIdentifier discount:(nullable NSString *)discountIdentifier completionBlock:(RCHybridResponseBlock)completion;
 
 @end
 

--- a/ios/RCCommonFunctionality.h
+++ b/ios/RCCommonFunctionality.h
@@ -13,6 +13,8 @@ typedef void (^RCHybridResponseBlock)(NSDictionary * _Nullable, RCErrorContainer
 
 @interface RCCommonFunctionality : NSObject
 
++ (void)configure;
+
 + (void)setAllowSharingStoreAccount:(BOOL)allowSharingStoreAccount;
 
 + (void)addAttributionData:(NSDictionary *)data network:(NSInteger)network networkUserId:(NSString *)networkUserId;

--- a/ios/RCCommonFunctionality.h
+++ b/ios/RCCommonFunctionality.h
@@ -41,7 +41,7 @@ typedef void (^RCHybridResponseBlock)(NSDictionary * _Nullable, RCErrorContainer
 
 + (void)purchaseProduct:(NSString *)productIdentifier completionBlock:(RCHybridResponseBlock)completion;
 
-+ (void)purchasePackage:(NSString *)packageIdentifier offering:(NSString *)offeringIdentifier discount:(nullable NSString *)discountIdentifier completionBlock:(RCHybridResponseBlock)completion;
++ (void)purchasePackage:(NSString *)packageIdentifier offering:(NSString *)offeringIdentifier signedDiscountTimestamp:(nullable NSString *)discountTimestamp completionBlock:(RCHybridResponseBlock)completion;
 
 + (void)makeDeferredPurchase:(RCDeferredPromotionalPurchaseBlock)deferredPurchase completionBlock:(RCHybridResponseBlock)completion;
 
@@ -49,7 +49,7 @@ typedef void (^RCHybridResponseBlock)(NSDictionary * _Nullable, RCErrorContainer
 
 + (void)checkTrialOrIntroductoryPriceEligibility:(nonnull NSArray<NSString *> *)productIdentifiers completionBlock:(RCReceiveIntroEligibilityBlock)completion;
 
-+ (void)paymentDiscountForPackageIdentifier:(NSString *)packageIdentifier offering:(NSString *)offeringIdentifier completionBlock:(RCHybridResponseBlock)completion;
++ (void)paymentDiscountForPackageIdentifier:(NSString *)packageIdentifier offering:(NSString *)offeringIdentifier discount:(nullable NSString *)discountIdentifier completionBlock:(RCHybridResponseBlock)completion;
 
 @end
 

--- a/ios/RCCommonFunctionality.m
+++ b/ios/RCCommonFunctionality.m
@@ -9,15 +9,29 @@
 #import "RCPurchaserInfo+HybridAdditions.h"
 #import "SKPaymentDiscount+HybridAdditions.h"
 
+
+API_AVAILABLE(ios(12.2))
+@interface RCCommonFunctionality ()
+
+@property(class, readonly, nonatomic, retain) NSMutableDictionary<NSString *, SKPaymentDiscount *> *discounts;
+
+@end
+
+
 @implementation RCCommonFunctionality
 
 API_AVAILABLE(ios(12.2))
-NSMutableDictionary<NSString *, SKPaymentDiscount *> *discounts;
+static NSMutableDictionary<NSString *, SKPaymentDiscount *> *_discounts = nil;
+
+
++ (NSMutableDictionary<NSString *, SKPaymentDiscount *> *)discounts API_AVAILABLE(ios(12.2)) {
+    return _discounts;
+}
 
 + (void)initialize
 {
     if (@available(iOS 12.2, *)) {
-        discounts = [NSMutableDictionary new];
+        _discounts = [NSMutableDictionary new];
     }
 }
 
@@ -167,7 +181,7 @@ NSMutableDictionary<NSString *, SKPaymentDiscount *> *discounts;
         if (aPackage) {
             if (discountIdentifier) {
                 if (@available(iOS 12.2, *)) {
-                    SKPaymentDiscount *discount = discounts[packageIdentifier];
+                    SKPaymentDiscount *discount = self.discounts[packageIdentifier];
                     if (discount.identifier == discountIdentifier) {
                         [RCPurchases.sharedPurchases purchasePackage:aPackage withDiscount:discount completionBlock:completionBlock];
                     } else {
@@ -243,7 +257,7 @@ NSMutableDictionary<NSString *, SKPaymentDiscount *> *discounts;
             if (aPackage) {
                 if (aPackage.product.discounts) {
                     [RCPurchases.sharedPurchases paymentDiscountForProductDiscount:aPackage.product.discounts[0] product:aPackage.product completion:^(SKPaymentDiscount *discount, NSError *error) {
-                        discounts[packageIdentifier] = discount;
+                        self.discounts[packageIdentifier] = discount;
                         completion(discount.dictionary, nil);
                     }];
                 } else {

--- a/ios/SKPaymentDiscount+HybridAdditions.h
+++ b/ios/SKPaymentDiscount+HybridAdditions.h
@@ -1,0 +1,12 @@
+//
+//  Created by RevenueCat.
+//  Copyright © 2019 RevenueCat. All rights reserved.
+//
+
+#import <StoreKit/StoreKit.h>
+
+@interface SKPaymentDiscount (HybridAdditions)
+
+- (NSDictionary *)dictionary;
+
+@end

--- a/ios/SKPaymentDiscount+HybridAdditions.m
+++ b/ios/SKPaymentDiscount+HybridAdditions.m
@@ -1,0 +1,23 @@
+//
+//  Created by RevenueCat.
+//  Copyright © 2019 RevenueCat. All rights reserved.
+//
+
+#import "SKPaymentDiscount+HybridAdditions.h"
+
+@implementation SKPaymentDiscount (RCPurchases)
+
+- (NSDictionary *)dictionary
+{
+    NSMutableDictionary *d = [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"identifier": self.identifier,
+                        @"keyIdentifier": self.keyIdentifier,
+                        @"nonce": self.nonce.UUIDString,
+                        @"signature": self.signature,
+                        @"timestamp": self.timestamp,
+                        }];
+    
+    return d;
+}
+
+@end

--- a/ios/SKPaymentDiscount+HybridAdditions.m
+++ b/ios/SKPaymentDiscount+HybridAdditions.m
@@ -9,15 +9,13 @@
 
 - (NSDictionary *)dictionary
 {
-    NSMutableDictionary *d = [NSMutableDictionary dictionaryWithDictionary:@{
-                        @"identifier": self.identifier,
-                        @"keyIdentifier": self.keyIdentifier,
-                        @"nonce": self.nonce.UUIDString,
-                        @"signature": self.signature,
-                        @"timestamp": self.timestamp,
-                        }];
-    
-    return d;
+    return @{
+        @"identifier": self.identifier,
+        @"keyIdentifier": self.keyIdentifier,
+        @"nonce": self.nonce.UUIDString,
+        @"signature": self.signature,
+        @"timestamp": self.timestamp,
+    };
 }
 
 @end

--- a/ios/SKProduct+HybridAdditions.h
+++ b/ios/SKProduct+HybridAdditions.h
@@ -8,5 +8,7 @@
 @interface SKProduct (HybridAdditions)
 
 - (NSDictionary *)dictionary;
++ (NSString *)normalizedSubscriptionPeriod:(SKProductSubscriptionPeriod *)subscriptionPeriod API_AVAILABLE(ios(11.2));
++ (NSString *)normalizedSubscriptionPeriodUnit:(SKProductPeriodUnit)subscriptionPeriodUnit API_AVAILABLE(ios(11.2));
 
 @end

--- a/ios/SKProduct+HybridAdditions.m
+++ b/ios/SKProduct+HybridAdditions.m
@@ -30,6 +30,14 @@
                         @"currency_code": (self.rc_currencyCode) ? self.rc_currencyCode : [NSNull null]
                         }];
     
+    d[@"intro_price"] = [NSNull null];
+    d[@"intro_price_string"] = [NSNull null];
+    d[@"intro_price_period"] = [NSNull null];
+    d[@"intro_price_period_unit"] = [NSNull null];
+    d[@"intro_price_period_number_of_units"] = [NSNull null];
+    d[@"intro_price_cycles"] = [NSNull null];
+    d[@"introPrice"] = [NSNull null];
+    
     if (@available(iOS 11.2, *)) {
         if (self.introductoryPrice) {
             d[@"intro_price"] = @(self.introductoryPrice.price.floatValue);
@@ -40,17 +48,10 @@
             d[@"intro_price_cycles"] = @(self.introductoryPrice.numberOfPeriods);
             d[@"introPrice"] = self.introductoryPrice.dictionary;
         }
-    } else {
-        d[@"intro_price"] = [NSNull null];
-        d[@"intro_price_string"] = [NSNull null];
-        d[@"intro_price_period"] = [NSNull null];
-        d[@"intro_price_period_unit"] = [NSNull null];
-        d[@"intro_price_period_number_of_units"] = [NSNull null];
-        d[@"intro_price_cycles"] = [NSNull null];
-        d[@"introPrice"] = [NSNull null];
     }
     
     d[@"discounts"] = [NSNull null];
+    
     if (@available(iOS 12.2, *)) {
         d[@"discounts"] = [NSMutableArray new];
         for (SKProductDiscount* discount in self.discounts) {

--- a/ios/SKProduct+HybridAdditions.m
+++ b/ios/SKProduct+HybridAdditions.m
@@ -4,6 +4,7 @@
 //
 
 #import "SKProduct+HybridAdditions.h"
+#import "SKProductDiscount+HybridAdditions.h"
 
 @implementation SKProduct (RCPurchases)
 
@@ -37,16 +38,25 @@
             d[@"intro_price_period_unit"] = [self normalizeSubscriptionPeriodUnit:self.introductoryPrice.subscriptionPeriod.unit];
             d[@"intro_price_period_number_of_units"] = @(self.introductoryPrice.subscriptionPeriod.numberOfUnits);
             d[@"intro_price_cycles"] = @(self.introductoryPrice.numberOfPeriods);
-            return d;
+            d[@"introPrice"] = self.introductoryPrice.dictionary;
+        }
+    } else {
+        d[@"intro_price"] = [NSNull null];
+        d[@"intro_price_string"] = [NSNull null];
+        d[@"intro_price_period"] = [NSNull null];
+        d[@"intro_price_period_unit"] = [NSNull null];
+        d[@"intro_price_period_number_of_units"] = [NSNull null];
+        d[@"intro_price_cycles"] = [NSNull null];
+        d[@"introPrice"] = [NSNull null];
+    }
+    
+    d[@"discounts"] = [NSNull null];
+    if (@available(iOS 12.2, *)) {
+        d[@"discounts"] = [NSMutableArray new];
+        for (SKProductDiscount* discount in self.discounts) {
+            [d[@"discounts"] addObject:discount.dictionary];
         }
     }
-
-    d[@"intro_price"] = [NSNull null];
-    d[@"intro_price_string"] = [NSNull null];
-    d[@"intro_price_period"] = [NSNull null];
-    d[@"intro_price_period_unit"] = [NSNull null];
-    d[@"intro_price_period_number_of_units"] = [NSNull null];
-    d[@"intro_price_cycles"] = [NSNull null];
     
     return d;
 }

--- a/ios/SKProduct+HybridAdditions.m
+++ b/ios/SKProduct+HybridAdditions.m
@@ -42,8 +42,8 @@
         if (self.introductoryPrice) {
             d[@"intro_price"] = @(self.introductoryPrice.price.floatValue);
             d[@"intro_price_string"] = [formatter stringFromNumber:self.introductoryPrice.price];
-            d[@"intro_price_period"] = [self normalizeSubscriptionPeriod:self.introductoryPrice.subscriptionPeriod];
-            d[@"intro_price_period_unit"] = [self normalizeSubscriptionPeriodUnit:self.introductoryPrice.subscriptionPeriod.unit];
+            d[@"intro_price_period"] = [SKProduct normalizedSubscriptionPeriod:self.introductoryPrice.subscriptionPeriod];
+            d[@"intro_price_period_unit"] = [SKProduct normalizedSubscriptionPeriodUnit:self.introductoryPrice.subscriptionPeriod.unit];
             d[@"intro_price_period_number_of_units"] = @(self.introductoryPrice.subscriptionPeriod.numberOfUnits);
             d[@"intro_price_cycles"] = @(self.introductoryPrice.numberOfPeriods);
             d[@"introPrice"] = self.introductoryPrice.dictionary;
@@ -62,7 +62,7 @@
     return d;
 }
 
-- (NSString *)normalizeSubscriptionPeriod:(SKProductSubscriptionPeriod *)subscriptionPeriod API_AVAILABLE(ios(11.2)){
++ (NSString *)normalizedSubscriptionPeriod:(SKProductSubscriptionPeriod *)subscriptionPeriod API_AVAILABLE(ios(11.2)){
     NSString *unit;
     switch (subscriptionPeriod.unit) {
         case SKProductPeriodUnitDay:
@@ -81,7 +81,7 @@
     return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), unit];
 }
 
-- (NSString *)normalizeSubscriptionPeriodUnit:(SKProductPeriodUnit)subscriptionPeriodUnit API_AVAILABLE(ios(11.2)){
++ (NSString *)normalizedSubscriptionPeriodUnit:(SKProductPeriodUnit)subscriptionPeriodUnit API_AVAILABLE(ios(11.2)){
     switch (subscriptionPeriodUnit) {
         case SKProductPeriodUnitDay:
             return @"DAY";

--- a/ios/SKProductDiscount+HybridAdditions.h
+++ b/ios/SKProductDiscount+HybridAdditions.h
@@ -1,0 +1,12 @@
+//
+//  Created by RevenueCat.
+//  Copyright © 2019 RevenueCat. All rights reserved.
+//
+
+#import <StoreKit/StoreKit.h>
+
+@interface SKProductDiscount (HybridAdditions)
+
+- (NSDictionary *)dictionary;
+
+@end

--- a/ios/SKProductDiscount+HybridAdditions.m
+++ b/ios/SKProductDiscount+HybridAdditions.m
@@ -1,0 +1,75 @@
+//
+//  Created by RevenueCat.
+//  Copyright © 2019 RevenueCat. All rights reserved.
+//
+
+#import "SKProductDiscount+HybridAdditions.h"
+
+@implementation SKProductDiscount (RCPurchases)
+
+- (nullable NSString *)rc_currencyCode {
+    if(@available(iOS 10.0, *)) {
+        return self.priceLocale.currencyCode;
+    } else {
+        return [self.priceLocale objectForKey:NSLocaleCurrencyCode];
+    }
+}
+
+- (NSDictionary *)dictionary
+{
+    NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+    formatter.numberStyle = NSNumberFormatterCurrencyStyle;
+    formatter.locale = self.priceLocale;
+    
+    NSMutableDictionary *d = [NSMutableDictionary dictionaryWithDictionary:@{
+       
+        @"price": @(self.price.floatValue),
+        @"priceString": [formatter stringFromNumber:self.price],
+        @"period": [self normalizeSubscriptionPeriod:self.subscriptionPeriod],
+        @"periodUnit": [self normalizeSubscriptionPeriodUnit:self.subscriptionPeriod.unit],
+        @"periodNumberOfUnits": @(self.subscriptionPeriod.numberOfUnits),
+        @"cycles": @(self.numberOfPeriods)
+    }];
+    
+    if (@available(iOS 12.2, *)) {
+        if (self.identifier) {
+            d[@"identifier"] = self.identifier;
+        }
+    }
+    
+    return d;
+}
+
+- (NSString *)normalizeSubscriptionPeriod:(SKProductSubscriptionPeriod *)subscriptionPeriod API_AVAILABLE(ios(11.2)){
+    NSString *unit;
+    switch (subscriptionPeriod.unit) {
+        case SKProductPeriodUnitDay:
+            unit = @"D";
+            break;
+        case SKProductPeriodUnitWeek:
+            unit = @"W";
+            break;
+        case SKProductPeriodUnitMonth:
+            unit = @"M";
+            break;
+        case SKProductPeriodUnitYear:
+            unit = @"Y";
+            break;
+    }
+    return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), unit];
+}
+
+- (NSString *)normalizeSubscriptionPeriodUnit:(SKProductPeriodUnit)subscriptionPeriodUnit API_AVAILABLE(ios(11.2)){
+    switch (subscriptionPeriodUnit) {
+        case SKProductPeriodUnitDay:
+            return @"DAY";
+        case SKProductPeriodUnitWeek:
+            return @"WEEK";
+        case SKProductPeriodUnitMonth:
+            return @"MONTH";
+        case SKProductPeriodUnitYear:
+            return @"YEAR";
+    }
+}
+
+@end

--- a/ios/SKProductDiscount+HybridAdditions.m
+++ b/ios/SKProductDiscount+HybridAdditions.m
@@ -3,7 +3,9 @@
 //  Copyright © 2019 RevenueCat. All rights reserved.
 //
 
+#import "SKProduct+HybridAdditions.h"
 #import "SKProductDiscount+HybridAdditions.h"
+
 
 @implementation SKProductDiscount (RCPurchases)
 
@@ -22,11 +24,10 @@
     formatter.locale = self.priceLocale;
     
     NSMutableDictionary *d = [NSMutableDictionary dictionaryWithDictionary:@{
-       
         @"price": @(self.price.floatValue),
         @"priceString": [formatter stringFromNumber:self.price],
-        @"period": [self normalizeSubscriptionPeriod:self.subscriptionPeriod],
-        @"periodUnit": [self normalizeSubscriptionPeriodUnit:self.subscriptionPeriod.unit],
+        @"period": [SKProduct normalizedSubscriptionPeriod:self.subscriptionPeriod],
+        @"periodUnit": [SKProduct normalizedSubscriptionPeriodUnit:self.subscriptionPeriod.unit],
         @"periodNumberOfUnits": @(self.subscriptionPeriod.numberOfUnits),
         @"cycles": @(self.numberOfPeriods)
     }];
@@ -38,38 +39,6 @@
     }
     
     return d;
-}
-
-- (NSString *)normalizeSubscriptionPeriod:(SKProductSubscriptionPeriod *)subscriptionPeriod API_AVAILABLE(ios(11.2)){
-    NSString *unit;
-    switch (subscriptionPeriod.unit) {
-        case SKProductPeriodUnitDay:
-            unit = @"D";
-            break;
-        case SKProductPeriodUnitWeek:
-            unit = @"W";
-            break;
-        case SKProductPeriodUnitMonth:
-            unit = @"M";
-            break;
-        case SKProductPeriodUnitYear:
-            unit = @"Y";
-            break;
-    }
-    return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), unit];
-}
-
-- (NSString *)normalizeSubscriptionPeriodUnit:(SKProductPeriodUnit)subscriptionPeriodUnit API_AVAILABLE(ios(11.2)){
-    switch (subscriptionPeriodUnit) {
-        case SKProductPeriodUnitDay:
-            return @"DAY";
-        case SKProductPeriodUnitWeek:
-            return @"WEEK";
-        case SKProductPeriodUnitMonth:
-            return @"MONTH";
-        case SKProductPeriodUnitYear:
-            return @"YEAR";
-    }
 }
 
 @end


### PR DESCRIPTION
- Deprecated the intro price properties in the root of the mapped SKUDetails/SKProduct and moved it into a nested `introPrice` object.
- Changed a couple `isNullOrBlank()` to `== null && isBlank` since the former gives issues with older kotlin stlib versions  (see this older commit https://github.com/RevenueCat/purchases-hybrid-common/commit/fcfe076fc40ed80689657d63493a75194ab566be)
- Added a way to sign a discount and modified purchasePackage to accept the signed discount. This is only available in iOS
- added SKPaymentDiscount and SKProductDiscount  mappers