### PR TITLE
[final] fix call to setPushTokenString

### DIFF
--- a/ios/RCCommonFunctionality.m
+++ b/ios/RCCommonFunctionality.m
@@ -246,7 +246,7 @@
 
 + (void)setPushToken:(nullable NSString *)pushToken {
     NSAssert(RCPurchases.sharedPurchases, @"You must call setup first.");
-    [RCPurchases.sharedPurchases setPushTokenString:pushToken];
+    [RCPurchases.sharedPurchases _setPushTokenString:pushToken];
 }
 
 + (RCErrorContainer *)payloadForError:(NSError *)error withExtraPayload:(NSDictionary *)extraPayload


### PR DESCRIPTION
I made a mistake on #5 and forgot to update the call to `setPushTokenString` -> `_setPushTokenString`. 