### PR TITLE
[final] add missing import

### DIFF
--- a/ios/RCCommonFunctionality.m
+++ b/ios/RCCommonFunctionality.m
@@ -8,6 +8,7 @@
 #import "RCOfferings+HybridAdditions.h"
 #import "RCPurchaserInfo+HybridAdditions.h"
 #import "SKPaymentDiscount+HybridAdditions.h"
+#import "RCPurchases+HybridAdditions.h"
 
 
 API_AVAILABLE(ios(12.2))


### PR DESCRIPTION
an import was missing, causing an error saying that `_setPushTokenString` wasn't declared