### PR TITLE
Checks for NSNull when setting attributes

### DIFF
--- a/ios/RCCommonFunctionality.m
+++ b/ios/RCCommonFunctionality.m
@@ -314,22 +314,30 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 
 + (void)setEmail:(nullable NSString *)email {
     NSAssert(RCPurchases.sharedPurchases, @"You must call setup first.");
-    [RCPurchases.sharedPurchases setEmail:email];
+    NSString *nonNSNullAttribute = [self nonNSNullAttribute:email];
+    [RCPurchases.sharedPurchases setEmail:nonNSNullAttribute];
 }
 
 + (void)setPhoneNumber:(nullable NSString *)phoneNumber {
     NSAssert(RCPurchases.sharedPurchases, @"You must call setup first.");
-    [RCPurchases.sharedPurchases setPhoneNumber:phoneNumber];
+    NSString *nonNSNullAttribute = [self nonNSNullAttribute:phoneNumber];
+    [RCPurchases.sharedPurchases setPhoneNumber:nonNSNullAttribute];
 }
 
 + (void)setDisplayName:(nullable NSString *)displayName {
     NSAssert(RCPurchases.sharedPurchases, @"You must call setup first.");
-    [RCPurchases.sharedPurchases setDisplayName:displayName];
+    NSString *nonNSNullAttribute = [self nonNSNullAttribute:displayName];
+    [RCPurchases.sharedPurchases setDisplayName:nonNSNullAttribute];
 }
 
 + (void)setPushToken:(nullable NSString *)pushToken {
     NSAssert(RCPurchases.sharedPurchases, @"You must call setup first.");
-    [RCPurchases.sharedPurchases _setPushTokenString:pushToken];
+    NSString *nonNSNullAttribute = [self nonNSNullAttribute:pushToken];
+    [RCPurchases.sharedPurchases _setPushTokenString:nonNSNullAttribute];
+}
+
++ (NSString * _Nullable)nonNSNullAttribute:(NSString * _Nullable)attribute {
+    return ([attribute isEqual:NSNull.null]) ? @"" : attribute;
 }
 
 #pragma errors


### PR DESCRIPTION
When passing `nil` in Flutter when calling one of the special attributes setter, the value is converted to `NSNull`. I added a check so that this is fixed for all platforms potentially doing the same.