### PR TITLE
New iOS headers for platformFlavor

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		2D6E333C2450F7A60022A971 /* SKProductDiscountHybridAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D6E333B2450F7A60022A971 /* SKProductDiscountHybridAdditionsTests.swift */; };
 		2D6E335424521B450022A971 /* NSDate+HybridAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D6E334F24521B440022A971 /* NSDate+HybridAdditions.h */; };
 		2D6E335524521B450022A971 /* NSDate+HybridAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D6E335324521B440022A971 /* NSDate+HybridAdditions.m */; };
+		2DC85B58246B2A7B003CD22E /* PurchasesHybridAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC85B57246B2A7B003CD22E /* PurchasesHybridAdditionsTests.swift */; };
 		AE97D7B7C4626314B8C1FCBB /* Pods_PurchasesHybridCommonTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0972CDE9EA5719AB932C93F /* Pods_PurchasesHybridCommonTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -76,6 +77,7 @@
 		2D6E333B2450F7A60022A971 /* SKProductDiscountHybridAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKProductDiscountHybridAdditionsTests.swift; sourceTree = "<group>"; };
 		2D6E334F24521B440022A971 /* NSDate+HybridAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+HybridAdditions.h"; sourceTree = "<group>"; };
 		2D6E335324521B440022A971 /* NSDate+HybridAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+HybridAdditions.m"; sourceTree = "<group>"; };
+		2DC85B57246B2A7B003CD22E /* PurchasesHybridAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesHybridAdditionsTests.swift; sourceTree = "<group>"; };
 		2DD4B8C524377B6A0070344F /* RCOfferings+HybridAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCOfferings+HybridAdditions.h"; sourceTree = "<group>"; };
 		2DD4B8C624377B6A0070344F /* RCPurchases+HybridAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCPurchases+HybridAdditions.h"; sourceTree = "<group>"; };
 		2DD4B8C724377B6A0070344F /* SKProduct+HybridAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SKProduct+HybridAdditions.m"; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				2D6E33232450F68C0022A971 /* Info.plist */,
 				2D6E333B2450F7A60022A971 /* SKProductDiscountHybridAdditionsTests.swift */,
 				2D6E333A2450F7A60022A971 /* PurchasesHybridCommonTests-Bridging-Header.h */,
+				2DC85B57246B2A7B003CD22E /* PurchasesHybridAdditionsTests.swift */,
 			);
 			path = PurchasesHybridCommonTests;
 			sourceTree = "<group>";
@@ -443,6 +446,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2DC85B58246B2A7B003CD22E /* PurchasesHybridAdditionsTests.swift in Sources */,
 				2D6E333C2450F7A60022A971 /* SKProductDiscountHybridAdditionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCPurchases+HybridAdditions.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCPurchases+HybridAdditions.h
@@ -17,7 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
                           appUserID:(nullable NSString *)appUserID
                        observerMode:(BOOL)observerMode
                        userDefaults:(nullable NSUserDefaults *)userDefaults
-                     platformFlavor:(NSString *)platformFlavor;
+                     platformFlavor:(nullable NSString *)platformFlavor
+              platformFlavorVersion:(nullable NSString *)platformFlavorVersion;
 
 @end
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCPurchases+HybridAdditions.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCPurchases+HybridAdditions.h
@@ -13,6 +13,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)_setPushTokenString:(nullable NSString *)pushToken;
 
++ (instancetype)configureWithAPIKey:(NSString *)APIKey
+                          appUserID:(nullable NSString *)appUserID
+                       observerMode:(BOOL)observerMode
+                       userDefaults:(nullable NSUserDefaults *)userDefaults
+                     platformFlavor:(NSString *)platformFlavor;
+
 @end
 
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridAdditionsTests.swift
@@ -1,0 +1,31 @@
+//
+//  PurchasesHybridAdditionsTests.swift
+//  PurchasesHybridCommonTests
+//
+//  Created by Andrés Boedo on 5/12/20.
+//  Copyright © 2020 RevenueCat. All rights reserved.
+//
+
+import Quick
+import Nimble
+import PurchasesHybridCommon
+
+
+class PurchasesHybridAdditionsTests: QuickSpec {
+    override func spec() {
+        
+        context("configure with platform flavor and version") {
+            it("initialize without raising exceptions") {
+                expect {
+                    Purchases.configure(withAPIKey: "api key",
+                                        appUserID: nil,
+                                        observerMode: false,
+                                        userDefaults: nil,
+                                        platformFlavor: "hybrid-platform",
+                                        platformFlavorVersion: "1.2.3")
+                    
+                }.notTo(raiseException())
+            }
+        }
+    }
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridAdditionsTests.swift
@@ -23,7 +23,6 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         userDefaults: nil,
                                         platformFlavor: "hybrid-platform",
                                         platformFlavorVersion: "1.2.3")
-                    
                 }.notTo(raiseException())
             }
         }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests-Bridging-Header.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests-Bridging-Header.h
@@ -2,3 +2,4 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
+#import <PurchasesHybridCommon/RCPurchases+HybridAdditions.h>


### PR DESCRIPTION
This exposes the new configure method that includes `platformFlavor` and `platformFlavorVersion`, allowing hybrid SDKs to set them. 

This is final, but needs to wait for a final bump to the released version of purchases-ios

### Requirements: 
- [X] ~Released version of purchases-ios that includes the new headers~