### PR TITLE
version 1.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.0.14
+
+- New iOS headers for platformFlavor and platformFlavorVersion
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/23
+- CircleCI tests integration
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/20
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/21
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/22
+- Add xcproject and tests target
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/18
+
 ## 1.0.13
 
 - Small refactor on how periods are converted to map on Android https://github.com/RevenueCat/purchases-hybrid-common/pull/17

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 ### Releasing a version: 
 
 - Make a branch `bump/x.x.x`
-- Update purchases-android version in `build.gradle`
+- Update purchases-android version in `android/common/build.gradle`
 - Update CHANGELOG.md
 - Open a PR, merge and tag master.
 - Compile android aar: `cd android`, `./gradlew assembleRelease`. The .aar output will be in `common/build/outputs/aar/common-release.aar`


### PR DESCRIPTION
## 1.0.14

- New iOS headers for platformFlavor and platformFlavorVersion
    https://github.com/RevenueCat/purchases-hybrid-common/pull/23
- CircleCI tests integration
    https://github.com/RevenueCat/purchases-hybrid-common/pull/20
    https://github.com/RevenueCat/purchases-hybrid-common/pull/21
    https://github.com/RevenueCat/purchases-hybrid-common/pull/22
- Add xcproject and tests target
    https://github.com/RevenueCat/purchases-hybrid-common/pull/18