### PR TITLE
updating discountWithIdentifier method to use string equality check GH-34

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
@@ -412,7 +412,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
         discountToUse = productDiscounts.firstObject;
     } else {
         for (SKProductDiscount *discount in productDiscounts) {
-            if (identifier == discount.identifier) {
+            if ([identifier isEqualToString:discount.identifier]) {
                 discountToUse = discount;
             }
         }


### PR DESCRIPTION
Adds string equality check for discount.identifier.

We're getting 'Couldn't find discount.' even though the discount is present and available in the discounts array on the product object,