### PR TITLE
Prepares version update 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.1.1
+
+- Adds this library to Maven
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/31
+- Fixes discountWithIdentifier always returns null
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/35
+- Adds configure function to Android that lets pass a PlatformInfo
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/32
+
+
 ## 1.1.0
 
 -  Unified Android code into a single module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
     https://github.com/RevenueCat/purchases-hybrid-common/pull/35
 - Adds configure function to Android that lets pass a PlatformInfo
     https://github.com/RevenueCat/purchases-hybrid-common/pull/32
-
+- Adds method to pass in a suite name to revenuecat
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/33
 
 ## 1.1.0
 

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "1.1.0"
+  s.version          = "1.1.1"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,16 @@
 ### Releasing a version: 
 
 - Make a branch `bump/x.x.x`
-- Update purchases-android version in `android/common/build.gradle`
+- Increase version number in `android/build.gradle`, `android/gradle.properties` and `PurchasesHybridCommon.podspec`
+- Update purchases-android version in `android/build.gradle`
 - Update purchases-ios pod version in `PurchasesHybridCommon.podspec`, `ios/PurchasesHybridCommon/Podfile`, and `ios/PurchasesHybridCommon/PurchasdsHybridCommon.xcworkspace` (open this last one with Xcode)
 - Update `CHANGELOG.md`
 - Open a PR, merge and tag master.
-- Compile android aar: `cd android`, `./gradlew assembleRelease`. The .aar output will be in `common/build/outputs/aar/common-release.aar`
-- Create a github release, upload .aar to the release
+- Create a github release
+- Release Android:
+  1. Visit [Sonatype Nexus](https://oss.sonatype.org/)
+  1. Click on Staging Repositories on the left side
+  1. Scroll down to find the purchase repository
+  1. Select and click "Close" from the top menu. Why is it called close?
+  1. Once close is complete, repeat but this time selecting "Release"
 - run `pod trunk push PurchasesHybridCommon.podspec`

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 1
-        versionName "1.1.0"
+        versionName "1.1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 # Maven
 GROUP=com.revenuecat.purchases
-VERSION_NAME=1.1.0
+VERSION_NAME=1.1.1
 POM_ARTIFACT_ID=purchases-hybrid-common
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-hybrid-common


### PR DESCRIPTION
CHANGELOG:
- Adds this library to Maven
    https://github.com/RevenueCat/purchases-hybrid-common/pull/31
- Fixes discountWithIdentifier always returns null
    https://github.com/RevenueCat/purchases-hybrid-common/pull/35
- Adds configure function to Android that lets pass a PlatformInfo
    https://github.com/RevenueCat/purchases-hybrid-common/pull/32
- Adds method to pass in a suite name to revenuecat
    https://github.com/RevenueCat/purchases-hybrid-common/pull/33

Also updates RELEASING.md
