### PR TITLE
Adds project name; updates to android plugin 4.0.0; changes api with implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.android_tools = '3.6.3'
+    ext.android_tools = '4.0.0'
     ext.kotlin_version = '1.3.72'
     ext.android_junit5_version = '1.5.2.0'
     ext.junit5_runner = '0.2.2'
@@ -79,9 +79,9 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.2.0'
     implementation 'com.revenuecat.purchases:purchases:3.2.0'
 
+    implementation 'androidx.core:core-ktx:1.3.0'
     // assertion
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,9 +79,9 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.revenuecat.purchases:purchases:3.2.0'
-
     implementation 'androidx.core:core-ktx:1.3.0'
+    api 'com.revenuecat.purchases:purchases:3.2.0'
+    
     // assertion
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'purchases-hybrid-common'


### PR DESCRIPTION
- Upgrades Android plugin to 4.0.0
- Changes `implementation` with `api` so the hybrid SDKs don't have to also import the purchases SDK
- Adds a name to the project so when this project is added as a local module dependency, it can use the `includeBuild` Gradle feature. Otherwise, the name of the project will default to `android`. When using `includeBuild` Gradle looks for a matching name between a module and the artifact id of the external dependency. So when adding `includeBuild ('../../../../purchases-hybrid-common/android')` (pointing to a local copy of this repo) to a settings.gradle, gradle will use the local copy instead of the one downloaded from Maven.