### PR TITLE
Release: 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.2.0
+
+- Bumped iOS to 3.4.0 ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases))
+  Bumped Android to 3.2.0 ([Changelog here](https://github.com/RevenueCat/purchases-android/releases))
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/42
+- Added managementURL
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/41
+- Adds project name; updates to android plugin 4.0.0; changes api with implementation
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/44
+- Added setProxyURLString
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/43
+
 ## 1.1.2
 
 - Added originalPurchaseDate to RCPurchaserInfo dict

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "1.1.2"
+  s.version          = "1.2.0"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 ### Releasing a version: 
 
-- Make a branch `bump/x.x.x`
+- Make a release branch `release/x.x.x`
 - Increase version number in `android/build.gradle`, `android/gradle.properties` and `PurchasesHybridCommon.podspec`
 - Update purchases-android version in `android/build.gradle`
 - Update purchases-ios pod version in `PurchasesHybridCommon.podspec`, `ios/PurchasesHybridCommon/Podfile`, and `ios/PurchasesHybridCommon/PurchasdsHybridCommon.xcworkspace` (open this last one with Xcode)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 1
-        versionName "1.1.2"
+        versionName "1.2.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 # Maven
 GROUP=com.revenuecat.purchases
-VERSION_NAME=1.1.2
+VERSION_NAME=1.2.0
 POM_NAME=purchases-hybrid-common
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=purchases-hybrid-common


### PR DESCRIPTION
## 1.2.0

- Bumped iOS to 3.4.0 ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases))
  Bumped Android to 3.2.0 ([Changelog here](https://github.com/RevenueCat/purchases-android/releases))
    https://github.com/RevenueCat/purchases-hybrid-common/pull/42
- Added managementURL
    https://github.com/RevenueCat/purchases-hybrid-common/pull/41
- Adds project name; updates to android plugin 4.0.0; changes api with implementation
    https://github.com/RevenueCat/purchases-hybrid-common/pull/44
- Added setProxyURLString
    https://github.com/RevenueCat/purchases-hybrid-common/pull/43