### PR TITLE
Release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.3.1
 
 - Fix crash when Android periods come as "365"
-  https://github.com/RevenueCat/purchases-hybrid-common/pull/49
+   https://github.com/RevenueCat/purchases-hybrid-common/pull/49
+- Bumped iOS to 3.5.1 ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases))
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.1
+
+- Fix crash when Android periods come as "365"
+  https://github.com/RevenueCat/purchases-hybrid-common/pull/49
+
 ## 1.3.0
 
 - Bumped Android to 3.3.0 ([Changelog here](https://github.com/RevenueCat/purchases-android/releases))

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "1.3.0"
+  s.version          = "1.3.1"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.framework      = 'StoreKit'
 
-  s.dependency 'Purchases', '3.5.0'
+  s.dependency 'Purchases', '3.5.1'
 
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.12'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 1
-        versionName "1.3.0"
+        versionName "1.3.1"
 
         consumerProguardFiles 'consumer-rules.pro'
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 # Maven
 GROUP=com.revenuecat.purchases
-VERSION_NAME=1.3.0
+VERSION_NAME=1.3.1
 POM_NAME=purchases-hybrid-common
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=purchases-hybrid-common

--- a/ios/PurchasesHybridCommon/Info.plist
+++ b/ios/PurchasesHybridCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/ios/PurchasesHybridCommon/Podfile
+++ b/ios/PurchasesHybridCommon/Podfile
@@ -6,7 +6,7 @@ platform :ios, '9.0'
   use_frameworks!
 
   # Pods for PurchasesHybridCommon
-  pod 'Purchases', '3.5.0'
+  pod 'Purchases', '3.5.1'
 
   target 'PurchasesHybridCommonTests' do
     # Pods for testing

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
- Fix crash when Android periods come as "365" https://github.com/RevenueCat/purchases-hybrid-common/pull/49
- Bumped iOS to 3.5.1 ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases))