### PR TITLE
fix: setFBAnonymousID setting appsflyer instead

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/common/subscriberAttributes.kt
+++ b/android/src/main/java/com/revenuecat/purchases/common/subscriberAttributes.kt
@@ -44,7 +44,7 @@ fun setAppsflyerID(appsflyerID: String?) {
 }
 
 fun setFBAnonymousID(fbAnonymousID: String?) {
-    Purchases.sharedInstance.setAppsflyerID(fbAnonymousID)
+    Purchases.sharedInstance.setFBAnonymousID(fbAnonymousID)
 }
 
 fun setMparticleID(mparticleID: String?) {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.h
@@ -19,7 +19,7 @@ typedef void (^RCHybridResponseBlock)(NSDictionary * _Nullable, RCErrorContainer
 
 + (void)setAllowSharingStoreAccount:(BOOL)allowSharingStoreAccount;
 
-+ (void)addAttributionData:(NSDictionary *)data network:(NSInteger)network networkUserId:(NSString *)networkUserId;
++ (void)addAttributionData:(NSDictionary *)data network:(NSInteger)network networkUserId:(NSString *) networkUserId __attribute((deprecated("Use the set<NetworkId> functions instead.")));
 
 + (void)getProductInfo:(NSArray *)products completionBlock:(void(^)(NSArray<NSDictionary *> *))completion;
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
@@ -42,10 +42,13 @@ static NSMutableDictionary<NSString *, SKPaymentDiscount *> *_discounts = nil;
     RCPurchases.sharedPurchases.allowSharingAppStoreAccount = allowSharingStoreAccount;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 + (void)addAttributionData:(NSDictionary *)data network:(NSInteger)network networkUserId:(NSString *)networkUserId
 {
     [RCPurchases addAttributionData:data fromNetwork:(RCAttributionNetwork) network forNetworkUserId:networkUserId];
 }
+#pragma GCC diagnostic pop
 
 + (void)getProductInfo:(NSArray *)products
        completionBlock:(void (^)(NSArray<NSDictionary *> *))completion


### PR DESCRIPTION
There's a bug in release `1.4.0` where setting `fbAnonymousID` will set `appsflyerID` instead. 
This PR fixes the copy/paste issue and also cleans up a couple of deprecation warnings on iOS