### PR TITLE
Fix typo in transactions mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.4.2
+
+- Fixes a typo in the `Transaction` mapper in Android.
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/55
+
 ### 1.4.1
 
 - Fixes an issue where `setFBAnonymousID` would set the `appsflyerID` instead. 

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "1.4.1"
+  s.version          = "1.4.2"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 1
-        versionName "1.4.1"
+        versionName "1.4.2"
 
         consumerProguardFiles 'consumer-rules.pro'
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 # Maven
 GROUP=com.revenuecat.purchases
-VERSION_NAME=1.4.1
+VERSION_NAME=1.4.2
 POM_NAME=purchases-hybrid-common
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=purchases-hybrid-common

--- a/android/src/main/java/com/revenuecat/purchases/common/mappers/TransactionMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/common/mappers/TransactionMapper.kt
@@ -4,7 +4,7 @@ import com.revenuecat.purchases.models.Transaction
 
 fun Transaction.map(): Map<String, Any?> =
     mapOf(
-        "revenuecatId" to this.revenuecatId,
+        "revenueCatId" to this.revenuecatId,
         "productId" to this.productId,
         "purchaseDateMillis" to this.purchaseDate.toMillis(),
         "purchaseDate" to this.purchaseDate.toIso8601()

--- a/android/src/test/java/com/revenuecat/purchases/common/PurchaserInfoMappersTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/common/PurchaserInfoMappersTests.kt
@@ -68,7 +68,7 @@ object PurchaserInfoMappersTests : Spek({
                 assertThat(mappedNonSubscriptionTransactions).isNotEmpty
 
                 val transactionDictionary = mappedNonSubscriptionTransactions[0] as Map<*, *>
-                assertThat(transactionDictionary["revenuecatId"]).isEqualTo(transaction.revenuecatId)
+                assertThat(transactionDictionary["revenueCatId"]).isEqualTo(transaction.revenuecatId)
                 assertThat(transactionDictionary["productId"]).isEqualTo(transaction.productId)
                 assertThat(transactionDictionary["purchaseDateMillis"]).isEqualTo(transaction.purchaseDate.toMillis())
                 assertThat(transactionDictionary["purchaseDate"]).isEqualTo(transaction.purchaseDate.toIso8601())

--- a/ios/PurchasesHybridCommon/Info.plist
+++ b/ios/PurchasesHybridCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.4.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.4.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
updates `revenueCatId` mapping so that Android and iOS match
https://github.com/RevenueCat/purchases-flutter/pull/96#discussion_r492766257