### PR TITLE
fix build issues in hybrid sdks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.4.3
+
+- Fixes build issues in some hybrid SDKs by compiling pods statically
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/56
+
 ### 1.4.2
 
 - Fixes a typo in the `Transaction` mapper in Android.

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.framework      = 'StoreKit'
 
-  s.dependency 'Purchases', '3.7.1'
+  s.dependency 'Purchases', '3.7.2'
   s.swift_version = '5.0'
 
   s.ios.deployment_target = '9.0'

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "1.4.2"
+  s.version          = "1.4.3"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -16,11 +16,13 @@ Pod::Spec.new do |s|
   s.framework      = 'StoreKit'
 
   s.dependency 'Purchases', '3.7.1'
+  s.swift_version = '5.0'
 
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.12'
   s.watchos.deployment_target = '6.2'
   s.tvos.deployment_target = '9.0'
+  s.static_framework = true
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 1
-        versionName "1.4.2"
+        versionName "1.4.3"
 
         consumerProguardFiles 'consumer-rules.pro'
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 # Maven
 GROUP=com.revenuecat.purchases
-VERSION_NAME=1.4.2
+VERSION_NAME=1.4.3
 POM_NAME=purchases-hybrid-common
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=purchases-hybrid-common

--- a/ios/PurchasesHybridCommon/Info.plist
+++ b/ios/PurchasesHybridCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.2</string>
+	<string>1.4.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.2</string>
+	<string>1.4.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
Related to https://github.com/RevenueCat/purchases-ios/pull/353/

- Specifies swift version
- makes framework compile statically

Should address https://github.com/RevenueCat/purchases-flutter/issues/99

### Requirements: 

- [X] Build that includes https://github.com/RevenueCat/purchases-ios/pull/353/ released