### PR TITLE
fix build warnings

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/PurchasesHybridCommon.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/PurchasesHybridCommon.h
@@ -29,3 +29,4 @@ FOUNDATION_EXPORT const unsigned char PurchasesHybridCommonVersionString[];
 #import <PurchasesHybridCommon/SKProduct+HybridAdditions.h>
 #import <PurchasesHybridCommon/SKProductDiscount+HybridAdditions.h>
 #import <PurchasesHybridCommon/NSDate+HybridAdditions.h>
+#import <PurchasesHybridCommon/RCTransaction+HybridAdditions.h>

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCPurchases+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCPurchases+HybridAdditions.m
@@ -9,6 +9,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// some of the methods declared in the header are privately implemented in RCPurchases.h in the main SDK.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincomplete-implementation"
 
 @implementation RCPurchases (HybridAdditions)
 
@@ -31,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
                       platformFlavor:platformFlavor
                platformFlavorVersion:platformFlavorVersion];
 }
+#pragma clang diagnostic pop
 
 @end
 


### PR DESCRIPTION
We have a couple of build warnings: 

- One is because we were missing a header (`RCTransactions+HybridAdditions`) in the umbrella header

- The other one is trickier: it's because we have a few methods that we _want_ to have private in the main SDK, but that should be usable by the hybrid sdks. Their implementation relies on private stuff from the main SDK, but since hybridCommon uses it just as any app using the sdk would, it can't access the private files. 
The current solution is to have the implementation live in the main SDK, and just declare it in a header for our use. This triggers a build warning, however, so I'm supressing the build warning specifically for that file in this PR. 