### PR TITLE
Version 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 2.0.0
 
-- Bumps `purchases-ios` to 3.9.1, `purchases-android` to 4.0.1
+- Bumps `purchases-ios` to 3.9.2, `purchases-android` to 4.0.1
     https://github.com/RevenueCat/purchases-hybrid-common/pull/61
 - Fixes a bug where times in millis were actually returned in seconds
     https://github.com/RevenueCat/purchases-hybrid-common/pull/62

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-### 2.0.0
+### 1.5.0
 
 - Bumps `purchases-ios` to 3.9.2, `purchases-android` to 4.0.1
     https://github.com/RevenueCat/purchases-hybrid-common/pull/61
+- Adds `syncPurchases` for iOS
+- Adds `presentCodeRedemptionSheet` for iOS
 - Fixes a bug where times in millis were actually returned in seconds
     https://github.com/RevenueCat/purchases-hybrid-common/pull/62
 - Fixes build warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 2.0.0
 
-- Bumps iOS to 3.9.1
+- Bumps `purchases-ios` to 3.9.1, `purchases-android` to 4.0.1
     https://github.com/RevenueCat/purchases-hybrid-common/pull/61
 - Fixes a bug where times in millis were actually returned in seconds
     https://github.com/RevenueCat/purchases-hybrid-common/pull/62

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 2.0.0
+
+- Bumps iOS to 3.9.1
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/61
+- Fixes a bug where times in millis were actually returned in seconds
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/62
+- Fixes build warnings
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/60
+
 ### 1.4.5
 
 - Bumps iOS to 3.7.5, makes cocoapods compile statically, adds dummy Swift file

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.framework      = 'StoreKit'
 
-  s.dependency 'Purchases', '3.9.1'
+  s.dependency 'Purchases', '3.9.2'
   s.swift_version = '5.0'
 
   s.ios.deployment_target = '9.0'

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "2.0.0"
+  s.version          = "1.5.0"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "1.4.5"
+  s.version          = "1.5.0"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.framework      = 'StoreKit'
 
-  s.dependency 'Purchases', '3.7.5'
+  s.dependency 'Purchases', '3.9.1'
   s.swift_version = '5.0'
 
   s.ios.deployment_target = '9.0'

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "1.5.0"
+  s.version          = "2.0.0"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext.assertj_version = '3.13.2'
     ext.mockk_version = '1.10.0'
     ext.gradle_maven_publish = '0.11.1'
-    ext.purchases_version = '3.5.2'
+    ext.purchases_version = '4.0.1'
 
     repositories {
         google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 1
-        versionName "1.4.5"
+        versionName "1.5.0"
 
         consumerProguardFiles 'consumer-rules.pro'
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 # Maven
 GROUP=com.revenuecat.purchases
-VERSION_NAME=1.4.5
+VERSION_NAME=1.5.0
 POM_NAME=purchases-hybrid-common
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=purchases-hybrid-common

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 08 10:51:49 PDT 2020
+#Wed Dec 16 14:23:48 UYT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/android/src/main/java/com/revenuecat/purchases/common/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/common/common.kt
@@ -20,7 +20,6 @@ import com.revenuecat.purchases.purchasePackageWith
 import com.revenuecat.purchases.purchaseProductWith
 import com.revenuecat.purchases.resetWith
 import com.revenuecat.purchases.restorePurchasesWith
-import org.json.JSONObject
 import java.net.URL
 
 fun setAllowSharingAppStoreAccount(
@@ -70,16 +69,16 @@ fun purchaseProduct(
                     Purchases.sharedInstance.purchaseProductWith(
                         activity,
                         productToBuy,
-                        onError = getMakePurchaseErrorFunction(onResult),
-                        onSuccess = getMakePurchaseSuccessFunction(onResult)
+                        onError = getPurchaseErrorFunction(onResult),
+                        onSuccess = getPurchaseCompletedFunction(onResult)
                     )
                 } else {
                     Purchases.sharedInstance.purchaseProductWith(
                         activity,
                         productToBuy,
                         UpgradeInfo(oldSku, prorationMode),
-                        onError = getMakePurchaseErrorFunction(onResult),
-                        onSuccess = getMakePurchaseSuccessFunction(onResult)
+                        onError = getPurchaseErrorFunction(onResult),
+                        onSuccess = getPurchaseCompletedFunction(onResult)
                     )
                 }
             } else {
@@ -137,16 +136,16 @@ fun purchasePackage(
                         Purchases.sharedInstance.purchasePackageWith(
                             activity,
                             packageToBuy,
-                            onError = getMakePurchaseErrorFunction(onResult),
-                            onSuccess = getMakePurchaseSuccessFunction(onResult)
+                            onError = getPurchaseErrorFunction(onResult),
+                            onSuccess = getPurchaseCompletedFunction(onResult)
                         )
                     } else {
                         Purchases.sharedInstance.purchasePackageWith(
                             activity,
                             packageToBuy,
                             UpgradeInfo(oldSku, prorationMode),
-                            onError = getMakePurchaseErrorFunction(onResult),
-                            onSuccess = getMakePurchaseSuccessFunction(onResult)
+                            onError = getPurchaseErrorFunction(onResult),
+                            onSuccess = getPurchaseCompletedFunction(onResult)
                         )
                     }
                 } else {
@@ -276,15 +275,15 @@ fun configure(
 
 // region private functions
 
-private fun getMakePurchaseErrorFunction(onResult: OnResult): (PurchasesError, Boolean) -> Unit {
+private fun getPurchaseErrorFunction(onResult: OnResult): (PurchasesError, Boolean) -> Unit {
     return { error, userCancelled -> onResult.onError(error.map(mapOf("userCancelled" to userCancelled))) }
 }
 
-private fun getMakePurchaseSuccessFunction(onResult: OnResult): (Purchase, PurchaserInfo) -> Unit {
+private fun getPurchaseCompletedFunction(onResult: OnResult): (Purchase?, PurchaserInfo) -> Unit {
     return { purchase, purchaserInfo ->
         onResult.onReceived(
             mapOf(
-                "productIdentifier" to purchase.sku,
+                "productIdentifier" to purchase?.sku,
                 "purchaserInfo" to purchaserInfo.map()
             )
         )

--- a/android/src/main/java/com/revenuecat/purchases/common/subscriberAttributes.kt
+++ b/android/src/main/java/com/revenuecat/purchases/common/subscriberAttributes.kt
@@ -11,6 +11,7 @@ fun addAttributionData(
 ) {
     for (attributionNetwork in Purchases.AttributionNetwork.values()) {
         if (attributionNetwork.serverValue == network) {
+            @Suppress("DEPRECATION")
             Purchases.addAttributionData(data, attributionNetwork, networkUserId)
         }
     }
@@ -23,6 +24,7 @@ fun addAttributionData(
 ) {
     for (attributionNetwork in Purchases.AttributionNetwork.values()) {
         if (attributionNetwork.serverValue == network) {
+            @Suppress("DEPRECATION")
             Purchases.addAttributionData(data, attributionNetwork, networkUserId)
         }
     }

--- a/ios/PurchasesHybridCommon/Info.plist
+++ b/ios/PurchasesHybridCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.5</string>
+	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/ios/PurchasesHybridCommon/Podfile
+++ b/ios/PurchasesHybridCommon/Podfile
@@ -6,7 +6,7 @@ target 'PurchasesHybridCommon' do
   use_frameworks!
 
   # Pods for PurchasesHybridCommon
-  pod 'Purchases', '3.7.5'
+  pod 'Purchases', '3.9.1'
   
   target 'PurchasesHybridCommonTests' do
     # Pods for testing

--- a/ios/PurchasesHybridCommon/Podfile
+++ b/ios/PurchasesHybridCommon/Podfile
@@ -6,7 +6,7 @@ target 'PurchasesHybridCommon' do
   use_frameworks!
 
   # Pods for PurchasesHybridCommon
-  pod 'Purchases', '3.9.1'
+  pod 'Purchases', '3.9.2'
   
   target 'PurchasesHybridCommonTests' do
     # Pods for testing

--- a/ios/PurchasesHybridCommon/Podfile.lock
+++ b/ios/PurchasesHybridCommon/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - Nimble (9.0.0)
-  - Purchases (3.9.1):
-    - PurchasesCoreSwift (= 3.9.1)
-  - PurchasesCoreSwift (3.9.1)
+  - Purchases (3.9.2):
+    - PurchasesCoreSwift (= 3.9.2)
+  - PurchasesCoreSwift (3.9.2)
   - Quick (3.0.0)
 
 DEPENDENCIES:
   - Nimble
-  - Purchases (= 3.9.1)
+  - Purchases (= 3.9.2)
   - Quick
 
 SPEC REPOS:
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
-  Purchases: 30136cb5d20966a0a130edc5bfd5c6abb7ee8547
-  PurchasesCoreSwift: ffd54554fcbfdbb6791649da1fa4a34d3d1ae95e
+  Purchases: d8a798c9c7552fe66b550bf314a143e94ffa70c8
+  PurchasesCoreSwift: ea4eabae180416e580ac60366f41aa1fefec0693
   Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
 
-PODFILE CHECKSUM: 4186c3c3c1d3178d98bf81996c6f38f40babafa7
+PODFILE CHECKSUM: 709e5297804ebfa9ee78dce23a9555fd740ce4d5
 
 COCOAPODS: 1.10.0

--- a/ios/PurchasesHybridCommon/Podfile.lock
+++ b/ios/PurchasesHybridCommon/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - Nimble (9.0.0)
-  - Purchases (3.7.5):
-    - PurchasesCoreSwift (= 3.7.5)
-  - PurchasesCoreSwift (3.7.5)
+  - Purchases (3.9.1):
+    - PurchasesCoreSwift (= 3.9.1)
+  - PurchasesCoreSwift (3.9.1)
   - Quick (3.0.0)
 
 DEPENDENCIES:
   - Nimble
-  - Purchases (= 3.7.5)
+  - Purchases (= 3.9.1)
   - Quick
 
 SPEC REPOS:
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
-  Purchases: 7ebce9418bc16732c3c3bb4b6ff7e7e397de024e
-  PurchasesCoreSwift: 50636e307c1ab76c7a7894a87d042665f2fe0be9
+  Purchases: 30136cb5d20966a0a130edc5bfd5c6abb7ee8547
+  PurchasesCoreSwift: ffd54554fcbfdbb6791649da1fa4a34d3d1ae95e
   Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
 
-PODFILE CHECKSUM: aec0c83bee992980788bda1b4903f1442cb53806
+PODFILE CHECKSUM: 4186c3c3c1d3178d98bf81996c6f38f40babafa7
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.0

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
@@ -529,7 +529,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A7ED3A67A7FCB75F4706E21D /* Pods-PurchasesHybridCommon-PurchasesHybridCommonTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
@@ -553,7 +553,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3A8575F56F2F388A97BA04D3 /* Pods-PurchasesHybridCommon-PurchasesHybridCommonTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8SXR2327BM;

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.h
@@ -25,6 +25,8 @@ typedef void (^RCHybridResponseBlock)(NSDictionary * _Nullable, RCErrorContainer
 
 + (void)restoreTransactionsWithCompletionBlock:(RCHybridResponseBlock)completion;
 
++ (void)syncPurchasesWithCompletionBlock:(RCHybridResponseBlock)completion;
+
 + (NSString *)appUserID;
 
 + (void)createAlias:(nullable NSString *)newAppUserId completionBlock:(RCHybridResponseBlock)completion;
@@ -54,8 +56,6 @@ typedef void (^RCHybridResponseBlock)(NSDictionary * _Nullable, RCErrorContainer
 + (void)checkTrialOrIntroductoryPriceEligibility:(nonnull NSArray<NSString *> *)productIdentifiers completionBlock:(RCReceiveIntroEligibilityBlock)completion;
 
 + (void)paymentDiscountForProductIdentifier:(NSString *)productIdentifier discount:(nullable NSString *)discountIdentifier completionBlock:(RCHybridResponseBlock)completion;
-
-+ (void)syncPurchasesWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion;
 
 + (void)presentCodeRedemptionSheet API_AVAILABLE(ios(14.0)) API_UNAVAILABLE(tvos, macos, watchos);
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.h
@@ -55,6 +55,10 @@ typedef void (^RCHybridResponseBlock)(NSDictionary * _Nullable, RCErrorContainer
 
 + (void)paymentDiscountForProductIdentifier:(NSString *)productIdentifier discount:(nullable NSString *)discountIdentifier completionBlock:(RCHybridResponseBlock)completion;
 
++ (void)syncPurchasesWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion;
+
++ (void)presentCodeRedemptionSheet API_AVAILABLE(ios(14.0)) API_UNAVAILABLE(tvos, macos, watchos);
+
 + (void)invalidatePurchaserInfoCache;
 
 + (void)setAttributes:(NSDictionary<NSString *, NSString *> *)attributes;

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
@@ -313,6 +313,14 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
     [RCPurchases.sharedPurchases invalidatePurchaserInfoCache];
 }
 
++ (void)syncPurchasesWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
+    [RCPurchases.sharedPurchases syncPurchasesWithCompletionBlock:completion];
+}
+
++ (void)presentCodeRedemptionSheet API_AVAILABLE(ios(14.0)) API_UNAVAILABLE(tvos, macos, watchos) {
+    [RCPurchases.sharedPurchases presentCodeRedemptionSheet];
+}
+
 #pragma mark - Subcriber Attributes
 
 + (void)setAttributes:(NSDictionary<NSString *, NSString *> *)attributes {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
@@ -71,6 +71,11 @@ static NSMutableDictionary<NSString *, SKPaymentDiscount *> *_discounts = nil;
     [RCPurchases.sharedPurchases restoreTransactionsWithCompletionBlock:[self getPurchaserInfoCompletionBlock:completion]];
 }
 
++ (void)syncPurchasesWithCompletionBlock:(RCHybridResponseBlock)completion {
+    NSAssert(RCPurchases.sharedPurchases, @"You must call setup first.");
+    [RCPurchases.sharedPurchases syncPurchasesWithCompletionBlock:[self getPurchaserInfoCompletionBlock:completion]];
+}
+
 + (NSString *)appUserID
 {
     NSAssert(RCPurchases.sharedPurchases, @"You must call setup first.");
@@ -311,10 +316,6 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 + (void)invalidatePurchaserInfoCache { 
     NSAssert(RCPurchases.sharedPurchases, @"You must call setup first.");
     [RCPurchases.sharedPurchases invalidatePurchaserInfoCache];
-}
-
-+ (void)syncPurchasesWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
-    [RCPurchases.sharedPurchases syncPurchasesWithCompletionBlock:completion];
 }
 
 + (void)presentCodeRedemptionSheet API_AVAILABLE(ios(14.0)) API_UNAVAILABLE(tvos, macos, watchos) {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
@@ -319,6 +319,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 }
 
 + (void)presentCodeRedemptionSheet API_AVAILABLE(ios(14.0)) API_UNAVAILABLE(tvos, macos, watchos) {
+    NSAssert(RCPurchases.sharedPurchases, @"You must call setup first.");
     [RCPurchases.sharedPurchases presentCodeRedemptionSheet];
 }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.5</string>
+	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
### 1.5.0

- Bumps `purchases-ios` to 3.9.2, `purchases-android` to 4.0.1
    https://github.com/RevenueCat/purchases-hybrid-common/pull/61
- Adds `syncPurchases` for iOS
- Adds `presentCodeRedemptionSheet` for iOS
- Fixes a bug where times in millis were actually returned in seconds
    https://github.com/RevenueCat/purchases-hybrid-common/pull/62
- Fixes build warnings
    https://github.com/RevenueCat/purchases-hybrid-common/pull/60
