### PR TITLE
fix: dates in millis are actually in seconds in iOS

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/NSDate+HybridAdditions.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/NSDate+HybridAdditions.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NSDate (RCExtensions)
 
 - (NSString *)formattedAsISO8601;
+- (double)millisecondsSince1970;
 
 @end
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/NSDate+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/NSDate+HybridAdditions.m
@@ -29,6 +29,10 @@ static NSString *stringFromDate(NSDate *date) {
     return stringFromDate(self);
 }
 
+- (double)millisecondsSince1970 {
+    return [self timeIntervalSince1970] * 1000.0;
+}
+
 @end
 
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCEntitlementInfo+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCEntitlementInfo+HybridAdditions.m
@@ -29,11 +29,13 @@
     }
 
     jsonDict[@"latestPurchaseDate"] = self.latestPurchaseDate.formattedAsISO8601;
-    jsonDict[@"latestPurchaseDateMillis"] = @(self.latestPurchaseDate.timeIntervalSince1970);
+    jsonDict[@"latestPurchaseDateMillis"] = @(self.latestPurchaseDate.millisecondsSince1970);
     jsonDict[@"originalPurchaseDate"] = self.originalPurchaseDate.formattedAsISO8601;
-    jsonDict[@"originalPurchaseDateMillis"] = @(self.originalPurchaseDate.timeIntervalSince1970);
+    jsonDict[@"originalPurchaseDateMillis"] = @(self.originalPurchaseDate.millisecondsSince1970);
     jsonDict[@"expirationDate"] = self.expirationDate.formattedAsISO8601 ?: [NSNull null];
-    jsonDict[@"expirationDateMillis"] = self.expirationDate ? @(self.expirationDate.timeIntervalSince1970) : [NSNull null];
+    jsonDict[@"expirationDateMillis"] = self.expirationDate
+                                        ? @(self.expirationDate.millisecondsSince1970)
+                                        : [NSNull null];
 
     switch (self.store) {
         case RCAppStore:
@@ -59,9 +61,13 @@
     jsonDict[@"productIdentifier"] = self.productIdentifier;
     jsonDict[@"isSandbox"] = @(self.isSandbox);
     jsonDict[@"unsubscribeDetectedAt"] = self.unsubscribeDetectedAt.formattedAsISO8601 ?: [NSNull null];
-    jsonDict[@"unsubscribeDetectedAtMillis"] = self.unsubscribeDetectedAt ? @(self.unsubscribeDetectedAt.timeIntervalSince1970) : [NSNull null];
+    jsonDict[@"unsubscribeDetectedAtMillis"] = self.unsubscribeDetectedAt
+                                               ? @(self.unsubscribeDetectedAt.millisecondsSince1970)
+                                               : [NSNull null];
     jsonDict[@"billingIssueDetectedAt"] = self.billingIssueDetectedAt.formattedAsISO8601 ?: [NSNull null];
-    jsonDict[@"billingIssueDetectedAtMillis"] = self.billingIssueDetectedAt ? @(self.billingIssueDetectedAt.timeIntervalSince1970) : [NSNull null];
+    jsonDict[@"billingIssueDetectedAtMillis"] = self.billingIssueDetectedAt
+                                                ? @(self.billingIssueDetectedAt.millisecondsSince1970)
+                                                : [NSNull null];
     
     return [NSDictionary dictionaryWithDictionary:jsonDict];
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCPurchaserInfo+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCPurchaserInfo+HybridAdditions.m
@@ -19,7 +19,7 @@
     for (NSString *productIdentifier in sortedProductIdentifiers) {
         NSDate *date = [self expirationDateForProductIdentifier:productIdentifier];
         allExpirations[productIdentifier] = [self formattedAsISO8601OrNull:date];
-        allExpirationsMillis[productIdentifier] = [self timeIntervalSince1970OrNull:date];
+        allExpirationsMillis[productIdentifier] = [self millisecondsSince1970OrNull:date];
     }
 
     NSMutableDictionary *allPurchases = [NSMutableDictionary new];
@@ -27,7 +27,7 @@
     for (NSString *productIdentifier in sortedProductIdentifiers) {
         NSDate *date = [self purchaseDateForProductIdentifier:productIdentifier];
         allPurchases[productIdentifier] = [self formattedAsISO8601OrNull:date];
-        allPurchasesMillis[productIdentifier] = [self timeIntervalSince1970OrNull:date];
+        allPurchasesMillis[productIdentifier] = [self millisecondsSince1970OrNull:date];
     }
     NSObject *managementURLorNull = self.managementURL.absoluteString ?: NSNull.null;
     
@@ -41,27 +41,27 @@
         @"activeSubscriptions": self.activeSubscriptions.allObjects,
         @"allPurchasedProductIdentifiers": self.allPurchasedProductIdentifiers.allObjects,
         @"latestExpirationDate": [self formattedAsISO8601OrNull:self.latestExpirationDate],
-        @"latestExpirationDateMillis": [self timeIntervalSince1970OrNull:self.latestExpirationDate],
+        @"latestExpirationDateMillis": [self millisecondsSince1970OrNull:self.latestExpirationDate],
         @"firstSeen": self.firstSeen.formattedAsISO8601,
-        @"firstSeenMillis": @(self.firstSeen.timeIntervalSince1970),
+        @"firstSeenMillis": @(self.firstSeen.millisecondsSince1970),
         @"originalAppUserId": self.originalAppUserId,
         @"requestDate": self.requestDate.formattedAsISO8601,
-        @"requestDateMillis": @(self.requestDate.timeIntervalSince1970),
+        @"requestDateMillis": @(self.requestDate.millisecondsSince1970),
         @"allExpirationDates": allExpirations,
         @"allExpirationDatesMillis": allExpirationsMillis,
         @"allPurchaseDates": allPurchases,
         @"allPurchaseDatesMillis": allPurchasesMillis,
         @"originalApplicationVersion": self.originalApplicationVersion ?: NSNull.null,
         @"originalPurchaseDate": [self formattedAsISO8601OrNull:self.originalPurchaseDate],
-        @"originalPurchaseDateMillis": [self timeIntervalSince1970OrNull:self.originalPurchaseDate],
+        @"originalPurchaseDateMillis": [self millisecondsSince1970OrNull:self.originalPurchaseDate],
         @"managementURL": managementURLorNull,
         @"nonSubscriptionTransactions": nonSubscriptionTransactionsArray
     };
 }
 
-- (NSObject *)timeIntervalSince1970OrNull:(nullable NSDate *)date {
+- (NSObject *)millisecondsSince1970OrNull:(nullable NSDate *)date {
     if (date) {
-        return @(date.timeIntervalSince1970);
+        return @(date.millisecondsSince1970);
     } else {
         return NSNull.null;
     }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCTransaction+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCTransaction+HybridAdditions.m
@@ -16,7 +16,7 @@
     NSMutableDictionary *d = [NSMutableDictionary dictionaryWithDictionary:@{
         @"revenueCatId": self.revenueCatId,
         @"productId": self.productId,
-        @"purchaseDateMillis": @(self.purchaseDate.timeIntervalSince1970),
+        @"purchaseDateMillis": @(self.purchaseDate.millisecondsSince1970),
         @"purchaseDate": self.purchaseDate.formattedAsISO8601
     }];
     

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/NSDateHybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/NSDateHybridAdditionsTests.swift
@@ -41,7 +41,7 @@ class NSDateHybridAdditionsTests: QuickSpec {
                 expect(date.millisecondsSince1970()) == date.timeIntervalSince1970 * 1000.0
 
                 let now = NSDate()
-                expect(now.millisecondsSince1970) == now.timeIntervalSince1970 * 1000.0
+                expect(now.millisecondsSince1970()) == now.timeIntervalSince1970 * 1000.0
             }
         }
     }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/NSDateHybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/NSDateHybridAdditionsTests.swift
@@ -34,5 +34,15 @@ class NSDateHybridAdditionsTests: QuickSpec {
                 expect(dateformatter.string(from: date4 as Date)) == date4.formattedAsISO8601()
             }
         }
+
+        describe("millisecondsSince1970") {
+            it("correctly returns results in milliseconds") {
+                let date = NSDate(timeIntervalSince1970: 1588044611)
+                expect(date.millisecondsSince1970()) == date.timeIntervalSince1970 * 1000.0
+
+                let now = NSDate()
+                expect(now.millisecondsSince1970) == now.timeIntervalSince1970 * 1000.0
+            }
+        }
     }
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchaserInfoHybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchaserInfoHybridAdditionsTests.swift
@@ -47,7 +47,7 @@ class PurchaserInfoHybridAdditionsTests: QuickSpec {
                     let transactionDictionary = nonSubscriptionTransactions?[0] as? Dictionary<String, Any>
                     expect(transactionDictionary?["revenueCatId"] as? String) == transaction.revenueCatId
                     expect(transactionDictionary?["productId"] as? String) == transaction.productId
-                    expect(transactionDictionary?["purchaseDateMillis"] as? Double) == transactionDate.timeIntervalSince1970
+                    expect(transactionDictionary?["purchaseDateMillis"] as? Double) == (transactionDate as NSDate).millisecondsSince1970()
                     
                     let dateformatter = ISO8601DateFormatter()
                     expect(transactionDictionary?["purchaseDate"] as? String) == dateformatter.string(from: transactionDate as Date)


### PR DESCRIPTION
the dates in `millis` were actually in seconds, we were never doing a conversion to millis. 
This adds the conversion and uses it everywhere. 