### PR TITLE
Release: 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.6.1
+
+- Adds missing availability check for `simulatesAskToBuyInSandbox`
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/66
+
 ### 1.6.0
 
 - [iOS] Adds a new property `simulateAsksToBuyInSandbox`, that allows developers to test deferred purchases easily.

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "1.6.0"
+  s.version          = "1.6.1"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,6 +5,7 @@
 - Run `fastlane bump_and_update_changelog version:X.Y.Z` (where X.Y.Z is the new version) to update the version number in `android/build.gradle`, `android/gradle.properties` and `PurchasesHybridCommon.podspec`
 - Update purchases-android version in `android/build.gradle`
 - Update purchases-ios pod version in `PurchasesHybridCommon.podspec` and `ios/PurchasesHybridCommon/Podfile`.
+- run `pod lib lint` to ensure that no problems are found with the pod. 
 - Open a PR, merge and tag main.
 - run `./carthage.sh build --archive --platform iOS`
 - Upload to the new release PurchasesHybridCommon.framework.zip

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 1
-        versionName "1.6.0"
+        versionName "1.6.1"
 
         consumerProguardFiles 'consumer-rules.pro'
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 # Maven
 GROUP=com.revenuecat.purchases
-VERSION_NAME=1.6.0
+VERSION_NAME=1.6.1
 POM_NAME=purchases-hybrid-common
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=purchases-hybrid-common

--- a/ios/PurchasesHybridCommon/Info.plist
+++ b/ios/PurchasesHybridCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
@@ -119,7 +119,12 @@ static NSMutableDictionary<NSString *, SKPaymentDiscount *> *_discounts = nil;
 }
 
 + (BOOL)simulatesAskToBuyInSandbox {
-    return RCPurchases.simulatesAskToBuyInSandbox;
+    if (@available(iOS 8.0, macos 10.14, tvOS 9.0, watchos 6.2, macCatalyst 13.0, *)) {
+        return RCPurchases.simulatesAskToBuyInSandbox;
+    } else {
+        NSLog(@"called simulatesAskToBuyInSandbox, but it's not available on this platform / OS version");
+        return NO;
+    }
 }
 
 + (void)setSimulatesAskToBuyInSandbox:(BOOL)simulatesAskToBuyInSandbox {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
@@ -123,7 +123,11 @@ static NSMutableDictionary<NSString *, SKPaymentDiscount *> *_discounts = nil;
 }
 
 + (void)setSimulatesAskToBuyInSandbox:(BOOL)simulatesAskToBuyInSandbox {
-    RCPurchases.simulatesAskToBuyInSandbox = simulatesAskToBuyInSandbox;
+    if (@available(iOS 8.0, macos 10.14, tvOS 9.0, watchos 6.2, macCatalyst 13.0, *)) {
+        RCPurchases.simulatesAskToBuyInSandbox = simulatesAskToBuyInSandbox;
+    } else {
+        NSLog(@"called setSimulatesAskToBuyInSandbox, but it's not available on this platform / OS version");
+    }
 }
 
 + (void)getPurchaserInfoWithCompletionBlock:(RCHybridResponseBlock)completion

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
- Adds missing availability check for `simulatesAskToBuyInSandbox`
    https://github.com/RevenueCat/purchases-hybrid-common/pull/66