### PR TITLE
Fix: add prefix to foundation extensions

### DIFF
--- a/ios/PurchasesHybridCommon/Podfile.lock
+++ b/ios/PurchasesHybridCommon/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Nimble (9.0.0)
-  - Purchases (3.11.0-SNAPSHOT):
+  - Nimble (9.0.1)
+  - Purchases (3.12.0-SNAPSHOT):
     - PurchasesCoreSwift
-  - PurchasesCoreSwift (3.11.0-SNAPSHOT)
+  - PurchasesCoreSwift (3.12.0-SNAPSHOT)
   - Quick (3.1.2)
 
 DEPENDENCIES:
@@ -26,16 +26,16 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Purchases:
-    :commit: 15d2ff61b4c9e101a22b642662a09f7ee2b90fd7
+    :commit: e4db6f673142ac343eb58158124c1fe42c141608
     :git: https://github.com/RevenueCat/purchases-ios.git
   PurchasesCoreSwift:
-    :commit: 15d2ff61b4c9e101a22b642662a09f7ee2b90fd7
+    :commit: e4db6f673142ac343eb58158124c1fe42c141608
     :git: https://github.com/RevenueCat/purchases-ios.git
 
 SPEC CHECKSUMS:
-  Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
-  Purchases: 1a9088def9e5c06ea0e0984b62bc6bb2cdb28cd7
-  PurchasesCoreSwift: a13fb0bb162ec84b8eac9098f2d0c5fb6fce8be7
+  Nimble: 7bed62ffabd6dbfe05f5925cbc43722533248990
+  Purchases: 12e75facd6ec9f8d9c5ee49b27db307ff69e353b
+  PurchasesCoreSwift: ab847be1cfcc8c34c4a11d6fc0c90bdc86e7d812
   Quick: 60f0ea3b8e0cfc0df3259a5c06a238ad8b3c46e0
 
 PODFILE CHECKSUM: 193dedc24c771d6e62fcd0cd444db1f4ec9a2195

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/NSDate+HybridAdditions.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/NSDate+HybridAdditions.h
@@ -10,8 +10,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSDate (RCExtensions)
 
-- (NSString *)formattedAsISO8601;
-- (double)millisecondsSince1970;
+- (NSString *)rc_formattedAsISO8601;
+- (double)rc_millisecondsSince1970AsDouble;
 
 @end
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/NSDate+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/NSDate+HybridAdditions.m
@@ -25,11 +25,11 @@ static NSString *stringFromDate(NSDate *date) {
 
 @implementation NSDate (RCExtensions)
 
-- (NSString *)formattedAsISO8601 {
+- (NSString *)rc_formattedAsISO8601 {
     return stringFromDate(self);
 }
 
-- (double)millisecondsSince1970 {
+- (double)rc_millisecondsSince1970AsDouble {
     return [self timeIntervalSince1970] * 1000.0;
 }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
@@ -55,7 +55,7 @@ API_AVAILABLE(ios(12.2), macos(10.14.4), tvos(12.2)) {
                                          completionBlock:^(NSArray<SKProduct *> *_Nonnull products) {
                                              NSMutableArray *productObjects = [NSMutableArray new];
                                              for (SKProduct *p in products) {
-                                                 [productObjects addObject:p.dictionary];
+                                                 [productObjects addObject:p.rc_dictionary];
                                              }
                                              completion(productObjects);
                                          }];
@@ -342,7 +342,7 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
                                                                             if (paymentDiscount) {
                                                                                 self.discounts[[paymentDiscount.timestamp stringValue]] =
                                                                                     paymentDiscount;
-                                                                                completion(paymentDiscount.dictionary,
+                                                                                completion(paymentDiscount.rc_dictionary,
                                                                                            nil);
                                                                             } else {
                                                                                 completion(nil,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCEntitlementInfo+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCEntitlementInfo+HybridAdditions.m
@@ -28,13 +28,13 @@
             break;
     }
 
-    jsonDict[@"latestPurchaseDate"] = self.latestPurchaseDate.formattedAsISO8601;
-    jsonDict[@"latestPurchaseDateMillis"] = @(self.latestPurchaseDate.millisecondsSince1970);
-    jsonDict[@"originalPurchaseDate"] = self.originalPurchaseDate.formattedAsISO8601;
-    jsonDict[@"originalPurchaseDateMillis"] = @(self.originalPurchaseDate.millisecondsSince1970);
-    jsonDict[@"expirationDate"] = self.expirationDate.formattedAsISO8601 ?: [NSNull null];
+    jsonDict[@"latestPurchaseDate"] = self.latestPurchaseDate.rc_formattedAsISO8601;
+    jsonDict[@"latestPurchaseDateMillis"] = @(self.latestPurchaseDate.rc_millisecondsSince1970AsDouble);
+    jsonDict[@"originalPurchaseDate"] = self.originalPurchaseDate.rc_formattedAsISO8601;
+    jsonDict[@"originalPurchaseDateMillis"] = @(self.originalPurchaseDate.rc_millisecondsSince1970AsDouble);
+    jsonDict[@"expirationDate"] = self.expirationDate.rc_formattedAsISO8601 ?: [NSNull null];
     jsonDict[@"expirationDateMillis"] = self.expirationDate
-                                        ? @(self.expirationDate.millisecondsSince1970)
+                                        ? @(self.expirationDate.rc_millisecondsSince1970AsDouble)
                                         : [NSNull null];
 
     switch (self.store) {
@@ -60,13 +60,13 @@
     
     jsonDict[@"productIdentifier"] = self.productIdentifier;
     jsonDict[@"isSandbox"] = @(self.isSandbox);
-    jsonDict[@"unsubscribeDetectedAt"] = self.unsubscribeDetectedAt.formattedAsISO8601 ?: [NSNull null];
+    jsonDict[@"unsubscribeDetectedAt"] = self.unsubscribeDetectedAt.rc_formattedAsISO8601 ?: [NSNull null];
     jsonDict[@"unsubscribeDetectedAtMillis"] = self.unsubscribeDetectedAt
-                                               ? @(self.unsubscribeDetectedAt.millisecondsSince1970)
+                                               ? @(self.unsubscribeDetectedAt.rc_millisecondsSince1970AsDouble)
                                                : [NSNull null];
-    jsonDict[@"billingIssueDetectedAt"] = self.billingIssueDetectedAt.formattedAsISO8601 ?: [NSNull null];
+    jsonDict[@"billingIssueDetectedAt"] = self.billingIssueDetectedAt.rc_formattedAsISO8601 ?: [NSNull null];
     jsonDict[@"billingIssueDetectedAtMillis"] = self.billingIssueDetectedAt
-                                                ? @(self.billingIssueDetectedAt.millisecondsSince1970)
+                                                ? @(self.billingIssueDetectedAt.rc_millisecondsSince1970AsDouble)
                                                 : [NSNull null];
     
     return [NSDictionary dictionaryWithDictionary:jsonDict];

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCPackage+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCPackage+HybridAdditions.m
@@ -14,7 +14,7 @@
 
     jsonDict[@"identifier"] = self.identifier;
     jsonDict[@"packageType"] = [self nameForPackageType:self.packageType];
-    jsonDict[@"product"] = self.product.dictionary;
+    jsonDict[@"product"] = self.product.rc_dictionary;
     jsonDict[@"offeringIdentifier"] = offeringIdentifier;
 
     return [NSDictionary dictionaryWithDictionary:jsonDict];

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCPurchaserInfo+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCPurchaserInfo+HybridAdditions.m
@@ -42,11 +42,11 @@
         @"allPurchasedProductIdentifiers": self.allPurchasedProductIdentifiers.allObjects,
         @"latestExpirationDate": [self formattedAsISO8601OrNull:self.latestExpirationDate],
         @"latestExpirationDateMillis": [self millisecondsSince1970OrNull:self.latestExpirationDate],
-        @"firstSeen": self.firstSeen.formattedAsISO8601,
-        @"firstSeenMillis": @(self.firstSeen.millisecondsSince1970),
+        @"firstSeen": self.firstSeen.rc_formattedAsISO8601,
+        @"firstSeenMillis": @(self.firstSeen.rc_millisecondsSince1970AsDouble),
         @"originalAppUserId": self.originalAppUserId,
-        @"requestDate": self.requestDate.formattedAsISO8601,
-        @"requestDateMillis": @(self.requestDate.millisecondsSince1970),
+        @"requestDate": self.requestDate.rc_formattedAsISO8601,
+        @"requestDateMillis": @(self.requestDate.rc_millisecondsSince1970AsDouble),
         @"allExpirationDates": allExpirations,
         @"allExpirationDatesMillis": allExpirationsMillis,
         @"allPurchaseDates": allPurchases,
@@ -61,7 +61,7 @@
 
 - (NSObject *)millisecondsSince1970OrNull:(nullable NSDate *)date {
     if (date) {
-        return @(date.millisecondsSince1970);
+        return @(date.rc_millisecondsSince1970AsDouble);
     } else {
         return NSNull.null;
     }
@@ -69,7 +69,7 @@
 
 - (NSObject *)formattedAsISO8601OrNull:(nullable NSDate *)date {
     if (date) {
-        return date.formattedAsISO8601;
+        return date.rc_formattedAsISO8601;
     } else {
         return NSNull.null;
     }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCTransaction+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCTransaction+HybridAdditions.m
@@ -16,8 +16,8 @@
     NSMutableDictionary *d = [NSMutableDictionary dictionaryWithDictionary:@{
         @"revenueCatId": self.revenueCatId,
         @"productId": self.productId,
-        @"purchaseDateMillis": @(self.purchaseDate.millisecondsSince1970),
-        @"purchaseDate": self.purchaseDate.formattedAsISO8601
+        @"purchaseDateMillis": @(self.purchaseDate.rc_millisecondsSince1970AsDouble),
+        @"purchaseDate": self.purchaseDate.rc_formattedAsISO8601
     }];
     
     return d;

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKPaymentDiscount+HybridAdditions.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKPaymentDiscount+HybridAdditions.h
@@ -7,6 +7,6 @@
 
 @interface SKPaymentDiscount (HybridAdditions)
 
-- (NSDictionary *)dictionary;
+- (NSDictionary *)rc_dictionary;
 
 @end

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKPaymentDiscount+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKPaymentDiscount+HybridAdditions.m
@@ -7,7 +7,7 @@
 
 @implementation SKPaymentDiscount (RCPurchases)
 
-- (NSDictionary *)dictionary
+- (NSDictionary *)rc_dictionary
 {
     return @{
         @"identifier": self.identifier,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProduct+HybridAdditions.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProduct+HybridAdditions.h
@@ -7,8 +7,8 @@
 
 @interface SKProduct (HybridAdditions)
 
-- (NSDictionary *)dictionary;
-+ (NSString *)normalizedSubscriptionPeriod:(SKProductSubscriptionPeriod *)subscriptionPeriod API_AVAILABLE(ios(11.2), macos(10.13.2), tvos(11.2));
-+ (NSString *)normalizedSubscriptionPeriodUnit:(SKProductPeriodUnit)subscriptionPeriodUnit API_AVAILABLE(ios(11.2), macos(10.13.2), tvos(11.2));
+- (NSDictionary *)rc_dictionary;
++ (NSString *)rc_normalizedSubscriptionPeriod:(SKProductSubscriptionPeriod *)subscriptionPeriod API_AVAILABLE(ios(11.2), macos(10.13.2), tvos(11.2));
++ (NSString *)rc_normalizedSubscriptionPeriodUnit:(SKProductPeriodUnit)subscriptionPeriodUnit API_AVAILABLE(ios(11.2), macos(10.13.2), tvos(11.2));
 
 @end

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProduct+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProduct+HybridAdditions.m
@@ -16,7 +16,7 @@
     }
 }
 
-- (NSDictionary *)dictionary
+- (NSDictionary *)rc_dictionary
 {
     NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
     formatter.numberStyle = NSNumberFormatterCurrencyStyle;
@@ -42,11 +42,13 @@
         if (self.introductoryPrice) {
             d[@"intro_price"] = @(self.introductoryPrice.price.floatValue);
             d[@"intro_price_string"] = [formatter stringFromNumber:self.introductoryPrice.price];
-            d[@"intro_price_period"] = [SKProduct normalizedSubscriptionPeriod:self.introductoryPrice.subscriptionPeriod];
-            d[@"intro_price_period_unit"] = [SKProduct normalizedSubscriptionPeriodUnit:self.introductoryPrice.subscriptionPeriod.unit];
+            d[@"intro_price_period"] =
+                [SKProduct rc_normalizedSubscriptionPeriod:self.introductoryPrice.subscriptionPeriod];
+            d[@"intro_price_period_unit"] =
+                [SKProduct rc_normalizedSubscriptionPeriodUnit:self.introductoryPrice.subscriptionPeriod.unit];
             d[@"intro_price_period_number_of_units"] = @(self.introductoryPrice.subscriptionPeriod.numberOfUnits);
             d[@"intro_price_cycles"] = @(self.introductoryPrice.numberOfPeriods);
-            d[@"introPrice"] = self.introductoryPrice.dictionary;
+            d[@"introPrice"] = self.introductoryPrice.rc_dictionary;
         }
     }
     
@@ -55,14 +57,14 @@
     if (@available(iOS 12.2, tvOS 12.2, macos 10.14.4, *)) {
         d[@"discounts"] = [NSMutableArray new];
         for (SKProductDiscount* discount in self.discounts) {
-            [d[@"discounts"] addObject:discount.dictionary];
+            [d[@"discounts"] addObject:discount.rc_dictionary];
         }
     }
     
     return d;
 }
 
-+ (NSString *)normalizedSubscriptionPeriod:(SKProductSubscriptionPeriod *)subscriptionPeriod API_AVAILABLE(ios(11.2), macos(10.13.2), tvos(11.2)) {
++ (NSString *)rc_normalizedSubscriptionPeriod:(SKProductSubscriptionPeriod *)subscriptionPeriod API_AVAILABLE(ios(11.2), macos(10.13.2), tvos(11.2)) {
     NSString *unit;
     switch (subscriptionPeriod.unit) {
         case SKProductPeriodUnitDay:
@@ -81,7 +83,7 @@
     return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), unit];
 }
 
-+ (NSString *)normalizedSubscriptionPeriodUnit:(SKProductPeriodUnit)subscriptionPeriodUnit API_AVAILABLE(ios(11.2), macos(10.13.2), tvos(11.2)) {
++ (NSString *)rc_normalizedSubscriptionPeriodUnit:(SKProductPeriodUnit)subscriptionPeriodUnit API_AVAILABLE(ios(11.2), macos(10.13.2), tvos(11.2)) {
     switch (subscriptionPeriodUnit) {
         case SKProductPeriodUnitDay:
             return @"DAY";

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProductDiscount+HybridAdditions.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProductDiscount+HybridAdditions.h
@@ -8,6 +8,6 @@
 API_AVAILABLE(ios(11.2), macos(10.13.2))
 @interface SKProductDiscount (HybridAdditions)
 
-- (NSDictionary *)dictionary;
+- (NSDictionary *)rc_dictionary;
 
 @end

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProductDiscount+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProductDiscount+HybridAdditions.m
@@ -17,7 +17,7 @@ API_AVAILABLE(ios(11.2), macos(10.13.2))
     }
 }
 
-- (NSDictionary *)dictionary
+- (NSDictionary *)rc_dictionary
 {
     NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
     formatter.numberStyle = NSNumberFormatterCurrencyStyle;
@@ -26,8 +26,8 @@ API_AVAILABLE(ios(11.2), macos(10.13.2))
     NSMutableDictionary *d = [NSMutableDictionary dictionaryWithDictionary:@{
         @"price": @(self.price.floatValue),
         @"priceString": [formatter stringFromNumber:self.price],
-        @"period": [SKProduct normalizedSubscriptionPeriod:self.subscriptionPeriod],
-        @"periodUnit": [SKProduct normalizedSubscriptionPeriodUnit:self.subscriptionPeriod.unit],
+        @"period": [SKProduct rc_normalizedSubscriptionPeriod:self.subscriptionPeriod],
+        @"periodUnit": [SKProduct rc_normalizedSubscriptionPeriodUnit:self.subscriptionPeriod.unit],
         @"periodNumberOfUnits": @(self.subscriptionPeriod.numberOfUnits),
         @"cycles": @(self.numberOfPeriods)
     }];

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/NSDateHybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/NSDateHybridAdditionsTests.swift
@@ -18,30 +18,30 @@ class NSDateHybridAdditionsTests: QuickSpec {
                 let dateformatter = ISO8601DateFormatter()
 
                 let date1 = NSDate(timeIntervalSince1970: 1588028019)
-                expect(date1.formattedAsISO8601()) == "2020-04-27T22:53:39Z"
-                expect(dateformatter.string(from: date1 as Date)) == date1.formattedAsISO8601()
+                expect(date1.rc_formattedAsISO8601()) == "2020-04-27T22:53:39Z"
+                expect(dateformatter.string(from: date1 as Date)) == date1.rc_formattedAsISO8601()
 
                 let date2 = NSDate(timeIntervalSince1970: 1588027325)
-                expect(date2.formattedAsISO8601()) == "2020-04-27T22:42:05Z"
-                expect(dateformatter.string(from: date2 as Date)) == date2.formattedAsISO8601()
+                expect(date2.rc_formattedAsISO8601()) == "2020-04-27T22:42:05Z"
+                expect(dateformatter.string(from: date2 as Date)) == date2.rc_formattedAsISO8601()
 
                 let date3 = NSDate(timeIntervalSince1970: 1588327605)
-                expect(date3.formattedAsISO8601()) == "2020-05-01T10:06:45Z"
-                expect(dateformatter.string(from: date3 as Date)) == date3.formattedAsISO8601()
+                expect(date3.rc_formattedAsISO8601()) == "2020-05-01T10:06:45Z"
+                expect(dateformatter.string(from: date3 as Date)) == date3.rc_formattedAsISO8601()
 
                 let date4 = NSDate(timeIntervalSince1970: 1588044611)
-                expect(date4.formattedAsISO8601()) == "2020-04-28T03:30:11Z"
-                expect(dateformatter.string(from: date4 as Date)) == date4.formattedAsISO8601()
+                expect(date4.rc_formattedAsISO8601()) == "2020-04-28T03:30:11Z"
+                expect(dateformatter.string(from: date4 as Date)) == date4.rc_formattedAsISO8601()
             }
         }
 
-        describe("millisecondsSince1970") {
+        describe("rc_millisecondsSince1970AsDouble") {
             it("correctly returns results in milliseconds") {
                 let date = NSDate(timeIntervalSince1970: 1588044611)
-                expect(date.millisecondsSince1970()) == date.timeIntervalSince1970 * 1000.0
+                expect(date.rc_millisecondsSince1970AsDouble()) == 1588044611000.0
 
                 let now = NSDate()
-                expect(now.millisecondsSince1970()) == now.timeIntervalSince1970 * 1000.0
+                expect(now.rc_millisecondsSince1970AsDouble()) == now.timeIntervalSince1970 * 1000.0
             }
         }
     }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchaserInfoHybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchaserInfoHybridAdditionsTests.swift
@@ -13,7 +13,7 @@ import PurchasesHybridCommon
 class PurchaserInfoHybridAdditionsTests: QuickSpec {
 
     override func spec() {
-        describe("dictionary") {
+        describe("rc_dictionary") {
             context("managementURL") {
                 it("contains the management url when it exists") {
                     let purchaserInfo = PartialMockPurchaserInfo()
@@ -47,7 +47,7 @@ class PurchaserInfoHybridAdditionsTests: QuickSpec {
                     let transactionDictionary = nonSubscriptionTransactions?[0] as? Dictionary<String, Any>
                     expect(transactionDictionary?["revenueCatId"] as? String) == transaction.revenueCatId
                     expect(transactionDictionary?["productId"] as? String) == transaction.productId
-                    expect(transactionDictionary?["purchaseDateMillis"] as? Double) == (transactionDate as NSDate).millisecondsSince1970()
+                    expect(transactionDictionary?["purchaseDateMillis"] as? Double) == (transactionDate as NSDate).rc_millisecondsSince1970AsDouble()
                     
                     let dateformatter = ISO8601DateFormatter()
                     expect(transactionDictionary?["purchaseDate"] as? String) == dateformatter.string(from: transactionDate as Date)

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/SKProductDiscountHybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/SKProductDiscountHybridAdditionsTests.swift
@@ -14,7 +14,7 @@ import PurchasesHybridCommon
 
 class SkuProductDiscountHybridAdditionsTests: QuickSpec {
     override func spec() {
-        describe("dictionary") {
+        describe("rc_dictionary") {
             it("has the right format") {
                 let subscriptionPeriod = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .month)
                 let productDiscount = SKProductDiscount(price: 10.99,
@@ -24,8 +24,8 @@ class SkuProductDiscountHybridAdditionsTests: QuickSpec {
                                                         numberOfPeriods: 3,
                                                         paymentMode: SKProductDiscount.PaymentMode.payAsYouGo,
                                                         type: .introductory)
-                guard let receivedDictionary = productDiscount.dictionary() as? [String: NSObject] else {
-                    fatalError("received dictionary is not in the right format")
+                guard let receivedDictionary = productDiscount.rc_dictionary() as? [String: NSObject] else {
+                    fatalError("received rc_dictionary is not in the right format")
                 }
                 
                 expect(receivedDictionary["cycles"] as? NSNumber) == 3


### PR DESCRIPTION
purchases-hybrid-common equivalent of https://github.com/RevenueCat/purchases-ios/pull/500

adds `rc_` prefix to all foundation extensions to prevent naming collisions, renames `millisecondsSince1970` to prevent collisions in return type