### PR TITLE
fix crash when calling syncPurchases on iOS with no completion

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.h
@@ -31,7 +31,7 @@ __attribute((deprecated("Use the set<NetworkId> functions instead.")));
 
 + (void)restoreTransactionsWithCompletionBlock:(RCHybridResponseBlock)completion;
 
-+ (void)syncPurchasesWithCompletionBlock:(RCHybridResponseBlock)completion;
++ (void)syncPurchasesWithCompletionBlock:(nullable RCHybridResponseBlock)completion;
 
 + (NSString *)appUserID;
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
@@ -66,9 +66,12 @@ API_AVAILABLE(ios(12.2), macos(10.14.4), tvos(12.2)) {
     [RCPurchases.sharedPurchases restoreTransactionsWithCompletionBlock:[self getPurchaserInfoCompletionBlock:completion]];
 }
 
-+ (void)syncPurchasesWithCompletionBlock:(RCHybridResponseBlock)completion {
++ (void)syncPurchasesWithCompletionBlock:(nullable RCHybridResponseBlock)completion {
     NSAssert(RCPurchases.sharedPurchases, @"You must call setup first.");
-    [RCPurchases.sharedPurchases syncPurchasesWithCompletionBlock:[self getPurchaserInfoCompletionBlock:completion]];
+
+    void (^purchaserInfoCompletion)(RCPurchaserInfo *, NSError *) = completion ? [self getPurchaserInfoCompletionBlock:completion]
+                                                                               : nil;
+    [RCPurchases.sharedPurchases syncPurchasesWithCompletionBlock:purchaserInfoCompletion];
 }
 
 + (NSString *)appUserID {


### PR DESCRIPTION
Addresses https://github.com/RevenueCat/react-native-purchases/issues/248

We have a crash when calling `syncPurchases` on iOS. 
The underlying issue is a disparity for `syncPurchases` on iOS and Android: 
- iOS has a completion block
- Android does not. 
This is my bad, I for some reason assumed that `syncPurchases` on Android did have a completion 🤦 . 

Anyway, there are two possible fixes: 
1. Add an optional completion block in `purchases-android`, make it available to `purchases-hybrid-common`. 
2. Make the completion block in `purchases-hybrid-common` on iOS `nullable`, or remove it. 
I'm going with 2. because 1. is actually not as easy as it sounds - `syncPurchases` actually makes a separate backend call per transaction, so we'd need to make sure to call completion only when the last one of the responses arrives. 

While I think long-term we should do 2., doing 1. now fixes the current crash, is easy to test and safe (I checked that the react-native crash does indeed get fixed). 