### PR TITLE
release: 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Bumps `purchases-android` to `3.11.1` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.11.1))
     https://github.com/RevenueCat/purchases-hybrid-common/pull/79
 
+### 1.6.3
+
+- Bumps `purchases-ios` to `3.11.1` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.11.1))
+     https://github.com/RevenueCat/purchases-hybrid-common/pull/76
+
 ### 1.6.2
 
 - Bumps `purchases-ios` to `3.10.7` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.10.7))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fixes a crash when calling `syncPurchases` with no completion block on iOS
     https://github.com/RevenueCat/purchases-hybrid-common/pull/78
 - Bumps `purchases-android` to `3.11.1` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.11.1))
-    https://github.com/RevenueCat/purchases-hybrid-common/pull/69
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/79
 
 ### 1.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 1.7.0
+
+- Adds a new method, `canMakePayments`, that provides a way to check if the current user is allowed to make purchases on the device. 
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/77
+- Fixes a crash when calling `syncPurchases` with no completion block on iOS
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/78
+- Bumps `purchases-android` to `3.11.1` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.11.1))
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/69
+
 ### 1.6.2
 
 - Bumps `purchases-ios` to `3.10.7` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.10.7))

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "1.6.2"
+  s.version          = "1.7.0"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 - Start a git-flow release/x.y.z
 - Create a CHANGELOG.latest.md with the changes for the current version (to be used by Fastlane for the github release notes)
-- Run `fastlane bump_and_update_changelog version:X.Y.Z` (where X.Y.Z is the new version) to update the version number in `android/build.gradle`, `android/gradle.properties` and `PurchasesHybridCommon.podspec`
+- Run `bundle exec fastlane bump_and_update_changelog version:X.Y.Z` (where X.Y.Z is the new version) to update the version number in `android/build.gradle`, `android/gradle.properties` and `PurchasesHybridCommon.podspec`
 - Update purchases-android version in `android/build.gradle`
 - Update purchases-ios pod version in `PurchasesHybridCommon.podspec` and `ios/PurchasesHybridCommon/Podfile`.
 - run `pod lib lint` to ensure that no problems are found with the pod. 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 1
-        versionName "1.6.2"
+        versionName "1.7.0"
 
         consumerProguardFiles 'consumer-rules.pro'
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 # Maven
 GROUP=com.revenuecat.purchases
-VERSION_NAME=1.6.2
+VERSION_NAME=1.7.0
 POM_NAME=purchases-hybrid-common
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=purchases-hybrid-common

--- a/ios/PurchasesHybridCommon/Info.plist
+++ b/ios/PurchasesHybridCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.2</string>
+	<string>1.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/ios/PurchasesHybridCommon/Podfile
+++ b/ios/PurchasesHybridCommon/Podfile
@@ -6,7 +6,7 @@ target 'PurchasesHybridCommon' do
   use_frameworks!
 
   # Pods for PurchasesHybridCommon
-  pod 'Purchases', '3.11.0'
+  pod 'Purchases', '3.11.1'
   
   target 'PurchasesHybridCommonTests' do
     # Pods for testing

--- a/ios/PurchasesHybridCommon/Podfile.lock
+++ b/ios/PurchasesHybridCommon/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - Nimble (9.0.1)
-  - Purchases (3.11.0):
-    - PurchasesCoreSwift (= 3.11.0)
-  - PurchasesCoreSwift (3.11.0)
+  - Purchases (3.11.1):
+    - PurchasesCoreSwift (= 3.11.1)
+  - PurchasesCoreSwift (3.11.1)
   - Quick (3.1.2)
 
 DEPENDENCIES:
   - Nimble
-  - Purchases (= 3.11.0)
+  - Purchases (= 3.11.1)
   - Quick
 
 SPEC REPOS:
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Nimble: 7bed62ffabd6dbfe05f5925cbc43722533248990
-  Purchases: 4ea4c742e6c3d41de457dc482972dd6346ca5654
-  PurchasesCoreSwift: cae29de1aeda5d13caf68d69c847ddb01e224ab1
+  Purchases: 6351f9ff6bd514e5ec5aa0f989ea181effa94bf5
+  PurchasesCoreSwift: ee857e4c21e6254b09d7e303a756fcf2b9164408
   Quick: 60f0ea3b8e0cfc0df3259a5c06a238ad8b3c46e0
 
-PODFILE CHECKSUM: 6530ec24c415a41e6b4e2f57ddd9e7075fff857f
+PODFILE CHECKSUM: 570bc3c74d41dccf8632df281ba90dfa9da60b6e
 
 COCOAPODS: 1.10.1

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.2</string>
+	<string>1.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
### 1.7.0

- Adds a new method, `canMakePayments`, that provides a way to check if the current user is allowed to make purchases on the device. 
    https://github.com/RevenueCat/purchases-hybrid-common/pull/77
- Fixes a crash when calling `syncPurchases` with no completion block on iOS
    https://github.com/RevenueCat/purchases-hybrid-common/pull/78
- Bumps `purchases-android` to `3.11.1` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.11.1))
    https://github.com/RevenueCat/purchases-hybrid-common/pull/69