### PR TITLE
fix bad reference in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
     https://github.com/RevenueCat/purchases-hybrid-common/pull/77
 - Fixes a crash when calling `syncPurchases` with no completion block on iOS
     https://github.com/RevenueCat/purchases-hybrid-common/pull/78
-- Bumps `purchases-android` to `3.11.1` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.11.1))
-    https://github.com/RevenueCat/purchases-hybrid-common/pull/79
 
 ### 1.6.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     https://github.com/RevenueCat/purchases-hybrid-common/pull/77
 - Fixes a crash when calling `syncPurchases` with no completion block on iOS
     https://github.com/RevenueCat/purchases-hybrid-common/pull/78
+- Bumps `purchases-android` to `4.2.1` ([Changelog here](https://github.com/RevenueCat/purchases-android/releases/4.2.1))
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/77
 
 ### 1.6.3
 


### PR DESCRIPTION
- fixed a line in the changelog that says we updated purchases-ios to 3.11.1 in 1.7.0, but that was already a part of 1.6.3
- added the bump in `purchases-android` that happened as a part of the `canMakePayments` PR to the changelog