### PR TITLE
release: 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 1.7.1
 
 - Fixed dependency specificiation in Podspec to purchases-ios@3.11.1
-    https://github.com/RevenueCat/purchases-hybrid-common/pull/80
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/81
 
 ### 1.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.7.1
+
+- Fixed dependency specificiation in Podspec to purchases-ios@3.11.1
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/80
+
 ### 1.7.0
 
 - Adds a new method, `canMakePayments`, that provides a way to check if the current user is allowed to make purchases on the device. 

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "1.7.0"
+  s.version          = "1.7.1"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.framework      = 'StoreKit'
 
-  s.dependency 'Purchases', '3.11.0'
+  s.dependency 'Purchases', '3.11.1'
   s.swift_version = '5.0'
 
   s.ios.deployment_target = '9.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 1
-        versionName "1.7.0"
+        versionName "1.7.1"
 
         consumerProguardFiles 'consumer-rules.pro'
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 # Maven
 GROUP=com.revenuecat.purchases
-VERSION_NAME=1.7.0
+VERSION_NAME=1.7.1
 POM_NAME=purchases-hybrid-common
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=purchases-hybrid-common

--- a/ios/PurchasesHybridCommon/Info.plist
+++ b/ios/PurchasesHybridCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
### 1.7.1

- Fixed dependency specificiation in Podspec to purchases-ios@3.11.1
    https://github.com/RevenueCat/purchases-hybrid-common/pull/81