### PR TITLE
Adds readableErrorCode to UserInfo when creating ErrorContainer

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCErrorContainer.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCErrorContainer.m
@@ -30,8 +30,15 @@
     if (error.userInfo[RCReadableErrorCodeKey]) {
         NSString *readableErrorCode = error.userInfo[RCReadableErrorCodeKey];
         dict[@"readableErrorCode"] = readableErrorCode;
-        dict[@"readable_error_code"] = readableErrorCode;
-            
+        dict[RCReadableErrorCodeKey] = readableErrorCode;
+        
+        // Reason behind this is because React Native doens't let reject the promises passing more information
+        // besides passing the original error, but it passes the extra userInfo from that error to the JS layer.
+        // Since we want to pass both readable_error_code (deprecated) and readableErrorCode when building the
+        // error JS object, and the error coming from purchases-ios only has the snake case version, we need to
+        // add readableErrorCode to the userInfo of the error. In a future project, we will remove the
+        // deprecated version and also improve error handling so it's easier to detect which errors come
+        // from RevenueCat and which don't
         NSMutableDictionary *fixedUserInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
         fixedUserInfo[@"readableErrorCode"] = readableErrorCode;
                 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCErrorContainer.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCErrorContainer.m
@@ -28,8 +28,14 @@
     }
 
     if (error.userInfo[RCReadableErrorCodeKey]) {
-        dict[@"readableErrorCode"] = error.userInfo[RCReadableErrorCodeKey];
-        dict[@"readable_error_code"] = error.userInfo[RCReadableErrorCodeKey];
+        NSString *readableErrorCode = error.userInfo[RCReadableErrorCodeKey];
+        dict[@"readableErrorCode"] = readableErrorCode;
+        dict[@"readable_error_code"] = readableErrorCode;
+            
+        NSMutableDictionary *fixedUserInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
+        fixedUserInfo[@"readableErrorCode"] = readableErrorCode;
+                
+        error = [NSError errorWithDomain:error.domain code:error.code userInfo:fixedUserInfo];
     }
 
     if (self = [super init]) {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/ErrorContainerTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/ErrorContainerTests.swift
@@ -48,8 +48,14 @@ class ErrorContainerTests: QuickSpec {
             it("contains the error itself") {
                 let error = Purchases.ErrorUtils.missingAppUserIDError() as NSError
                 let errorContainer = RCErrorContainer(error: error, extraPayload: [:])
+                let containedError = errorContainer.error as NSError
 
-                expect(errorContainer.error as NSError) == error
+                expect(containedError.code) == error.code
+                expect(containedError.domain) == error.domain
+                expect(containedError.localizedDescription) == error.localizedDescription
+                for (key, value) in error.userInfo {
+                    expect(error.userInfo[key] as? String) == value as? String
+                }
             }
         }
 
@@ -85,6 +91,16 @@ class ErrorContainerTests: QuickSpec {
                 expect(readableErrorKey) != ""
                 expect(errorContainer.info["readableErrorCode"] as? String) == readableErrorKey
                 expect(errorContainer.info["readable_error_code"] as? String) == readableErrorKey
+            }
+            it("user info contains the readable error code in both keys") {
+                let error = Purchases.ErrorUtils.missingAppUserIDError() as NSError
+                let errorContainer = RCErrorContainer(error: error, extraPayload: [:])
+
+                let readableErrorKey = error.userInfo[Purchases.ReadableErrorCodeKey] as? String
+                expect(readableErrorKey).toNot(beNil())
+                expect(readableErrorKey) != ""
+                expect((errorContainer.error as NSError).userInfo["readableErrorCode"] as? String) == readableErrorKey
+                expect((errorContainer.error as NSError).userInfo["readable_error_code"] as? String) == readableErrorKey
             }
         }
     }


### PR DESCRIPTION
Should fix one of the issues related to https://github.com/RevenueCat/react-native-purchases/issues/266

We create a dictionary with extra info and we add `readableErrorCode` to it. The issue is that we don't pass that dictionary when rejecting the promise in Rn, and we pass the original error when rejecting (https://github.com/RevenueCat/react-native-purchases/blob/develop/ios/RNPurchases.m#L354) and the original error doesn't have `readableErrorCode`, it has `readable_error_code` instead. We don't want the snake case version because it doesn't match the casing of the other properties of the error.