### PR TITLE
Fix: error codes mismap android

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -355,10 +355,10 @@ internal fun PurchasesError.map(
     extra: Map<String, Any?> = mapOf()
 ): ErrorContainer =
     ErrorContainer(
-        code.ordinal,
+        code.code,
         message,
         mapOf(
-            "code" to code.ordinal,
+            "code" to code.code,
             "message" to message,
             "readableErrorCode" to code.name,
             "readable_error_code" to code.name,

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/MappersTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/MappersTests.kt
@@ -1,5 +1,7 @@
 package com.revenuecat.purchases.hybridcommon
 
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.hybridcommon.mappers.toMillis
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -21,6 +23,16 @@ internal class MappersHelpersTests {
 
         val date3: Date? = dateFormat.parse("31-07-1990")
         assertThat(date3?.toMillis()).isEqualTo(649382400000L)
+    }
+
+    @Test
+    fun `purchasesErrors are mapped correctly`() {
+        PurchasesErrorCode.values().forEach { errorCode ->
+            val error = PurchasesError(errorCode, "")
+            val errorContainer = error.map()
+
+            assertThat(errorContainer.code).isEqualTo(errorCode.code)
+        }
     }
 
 }


### PR DESCRIPTION
Addresses https://github.com/RevenueCat/purchases-flutter/issues/222

We have a bug in the code that maps `PurchasesErrorCode` -> `ErrorContainer` -> `Map`. 
We're using `ordinal` to find the value of the error code enum, however, since there's no value for code `13`, this maps the wrong error code for all errors after `13`. 

Fixed by replacing usage of `ordinal` with `.code`. 

