### PR TITLE
Makes getPaymentDiscount return an error in android

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -317,8 +317,6 @@ fun canMakePayments(context: Context,
     }
 }
 
-// region Subscriber Attributes
-
 fun configure(
     context: Context,
     apiKey: String,
@@ -332,6 +330,11 @@ fun configure(
     } else {
         Purchases.configure(context, apiKey, appUserID)
     }
+}
+
+fun getPaymentDiscount() : ErrorContainer {
+    return ErrorContainer(PurchasesErrorCode.UnsupportedError.code,
+        "Android platform doesn't support subscription offers", emptyMap())
 }
 
 // region private functions

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.BillingFeature
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchaserInfo
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.hybridcommon.mappers.map
 import com.revenuecat.purchases.interfaces.Callback
@@ -27,6 +28,8 @@ import java.net.URL
 import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 internal class CommonKtTests {
 
@@ -358,6 +361,14 @@ internal class CommonKtTests {
 
         val mockErrorMap = mockError.map()
         verify(exactly = 1) { onResult.onError(mockErrorMap) }
+    }
+
+    @Test
+    fun `getPaymentDiscount returns an error`() {
+        val error = getPaymentDiscount()
+        assertNotNull(error)
+        assertEquals(PurchasesErrorCode.UnsupportedError.code, error.code)
+        assertTrue(error.message.isNotEmpty())
     }
 
 }

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -366,7 +366,6 @@ internal class CommonKtTests {
     @Test
     fun `getPaymentDiscount returns an error`() {
         val error = getPaymentDiscount()
-        assertNotNull(error)
         assertEquals(PurchasesErrorCode.UnsupportedError.code, error.code)
         assertTrue(error.message.isNotEmpty())
     }


### PR DESCRIPTION
When adding susbcription offers support for Unity, I want to return an error if calling `getPaymentDiscount` from Android. I don't want to create the error in the Unity code, but I want to create it in this library so the behavior is the same in all platforms. I also noticed Flutter no-ops in Android which is not ideal.