### PR TITLE
Release/1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+### 1.10.0
+
+- Bump `purchases-ios` to `3.13.0` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.13.0))
+- Bump `purchases-android` to `4.4.0` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/4.4.0))
+- Added support for Airship integration via `setAirshipChannelID`
+     https://github.com/RevenueCat/purchases-hybrid-common/pull/96
+
 ### 1.9.3
 
-- Bump `purchases-ios` to 3.12.8
+- Bump `purchases-ios` to `3.12.8`
     [3.12.7 Changelog here](https://github.com/RevenueCat/purchases-ios/releases/tag/3.12.7)
     [3.12.8 Changelog here](https://github.com/RevenueCat/purchases-ios/releases/tag/3.12.8)
 
@@ -9,7 +16,7 @@
 - Bump `purchases-android` to `4.3.3`
     [4.3.3 Changelog here](https://github.com/RevenueCat/purchases-android/releases/tag/4.3.3)
     [4.3.2 Changelog here](https://github.com/RevenueCat/purchases-android/releases/tag/4.3.2)
-- Bump `purchases-ios` to 3.12.6
+- Bump `purchases-ios` to `3.12.6`
     [3.12.6 Changelog here](https://github.com/RevenueCat/purchases-ios/releases/tag/3.12.6)
     [3.12.5 Changelog here](https://github.com/RevenueCat/purchases-ios/releases/tag/3.12.5)
     [3.12.4 Changelog here](https://github.com/RevenueCat/purchases-ios/releases/tag/3.12.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 1.10.0
 
 - Bump `purchases-ios` to `3.13.0` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.13.0))
-- Bump `purchases-android` to `4.4.0` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/4.4.0))
+- Bump `purchases-android` to `4.4.0` ([Changelog here](https://github.com/RevenueCat/purchases-android/releases/4.4.0))
 - Added support for Airship integration via `setAirshipChannelID`
      https://github.com/RevenueCat/purchases-hybrid-common/pull/96
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,17 +8,17 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.520.1)
-    aws-sdk-core (3.121.4)
+    aws-partitions (1.525.0)
+    aws-sdk-core (3.122.0)
       aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.239.0)
+      aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.50.0)
-      aws-sdk-core (~> 3, >= 3.121.2)
+    aws-sdk-kms (1.51.0)
+      aws-sdk-core (~> 3, >= 3.122.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.104.0)
-      aws-sdk-core (~> 3, >= 3.121.2)
+    aws-sdk-s3 (1.105.1)
+      aws-sdk-core (~> 3, >= 3.122.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.4.0)
@@ -156,7 +156,7 @@ GEM
     nanaimo (0.3.0)
     naturally (2.2.1)
     optparse (0.1.1)
-    os (1.1.1)
+    os (1.1.4)
     plist (3.6.0)
     public_suffix (4.0.6)
     rake (13.0.6)
@@ -181,7 +181,7 @@ GEM
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    trailblazer-option (0.1.1)
+    trailblazer-option (0.1.2)
     tty-cursor (0.7.1)
     tty-screen (0.8.1)
     tty-spinner (0.9.3)
@@ -213,4 +213,4 @@ DEPENDENCIES
   fastlane-plugin-versioning_android
 
 BUNDLED WITH
-   2.2.24
+   2.2.26

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.framework      = 'StoreKit'
 
-  s.dependency 'Purchases', '3.12.8'
+  s.dependency 'Purchases', '3.13.0'
   s.swift_version = '5.0'
 
   s.ios.deployment_target = '9.0'

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "1.9.3"
+  s.version          = "1.10.0"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.assertj_version = '3.13.2'
     ext.mockk_version = '1.10.0'
     ext.gradle_maven_publish = '0.11.1'
-    ext.purchases_version = '4.3.3'
+    ext.purchases_version = '4.4.0'
 
     repositories {
         google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 1
-        versionName "1.9.3"
+        versionName "1.10.0"
 
         consumerProguardFiles 'consumer-rules.pro'
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 # Maven
 GROUP=com.revenuecat.purchases
-VERSION_NAME=1.9.3
+VERSION_NAME=1.10.0
 POM_NAME=purchases-hybrid-common
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=purchases-hybrid-common

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/subscriberAttributes.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/subscriberAttributes.kt
@@ -57,6 +57,10 @@ fun setOnesignalID(onesignalID: String?) {
     Purchases.sharedInstance.setOnesignalID(onesignalID)
 }
 
+fun setAirshipChannelID(airshipChannelID: String?) {
+    Purchases.sharedInstance.setAirshipChannelID(airshipChannelID)
+}
+
 // endregion
 // region Campaign parameters
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,15 +13,20 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
-desc "Increment build number and update changelog"
-lane :bump_and_update_changelog do |options|
-  new_version_number = options[:version]
-  sh "fastlane ios bump version:#{new_version_number}"
-  sh "fastlane android bump version:#{new_version_number}"
-  attach_changelog_to_master
-end
-
 platform :ios do
+  before_all do
+    setup_circle_ci
+    update_fastlane
+  end
+
+  desc "Increment build number and update changelog"
+  lane :bump_and_update_changelog do |options|
+    new_version_number = options[:version]
+    sh "fastlane ios bump version:#{new_version_number}"
+    sh "fastlane android bump version:#{new_version_number}"
+    attach_changelog_to_master
+  end
+
   desc "Increment build number"
   lane :bump do |options|
     new_version_number = options[:version]

--- a/ios/PurchasesHybridCommon/Info.plist
+++ b/ios/PurchasesHybridCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.3</string>
+	<string>1.10.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/ios/PurchasesHybridCommon/Podfile
+++ b/ios/PurchasesHybridCommon/Podfile
@@ -6,7 +6,7 @@ target 'PurchasesHybridCommon' do
   use_frameworks!
 
   # Pods for PurchasesHybridCommon
-  pod 'Purchases', '3.12.8'
+  pod 'Purchases', '3.13.0'
   
   target 'PurchasesHybridCommonTests' do
     # Pods for testing

--- a/ios/PurchasesHybridCommon/Podfile.lock
+++ b/ios/PurchasesHybridCommon/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - Nimble (9.0.1)
-  - Purchases (3.12.8):
-    - PurchasesCoreSwift (= 3.12.8)
-  - PurchasesCoreSwift (3.12.8)
-  - Quick (3.1.2)
+  - Nimble (9.2.1)
+  - Purchases (3.13.0):
+    - PurchasesCoreSwift (= 3.13.0)
+  - PurchasesCoreSwift (3.13.0)
+  - Quick (4.0.0)
 
 DEPENDENCIES:
   - Nimble
-  - Purchases (= 3.12.8)
+  - Purchases (= 3.13.0)
   - Quick
 
 SPEC REPOS:
@@ -18,11 +18,11 @@ SPEC REPOS:
     - Quick
 
 SPEC CHECKSUMS:
-  Nimble: 7bed62ffabd6dbfe05f5925cbc43722533248990
-  Purchases: 4e410d75f18b544aba8aa41ddc4bffbf8e787246
-  PurchasesCoreSwift: 93fa64c1a70e7f493f54aba64e01ff42d1ed9109
-  Quick: 60f0ea3b8e0cfc0df3259a5c06a238ad8b3c46e0
+  Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
+  Purchases: a545d402454bc9395495cceaf0e893360670e0ad
+  PurchasesCoreSwift: e7f7267a6dc526da226baad19c61e8977fa664b4
+  Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
 
-PODFILE CHECKSUM: 5e64f207a9bfc80ebe3c577aa83877c120159464
+PODFILE CHECKSUM: 9a1bb731e56ce87bb5abd2c38cc2bc719eb76d9e
 
 COCOAPODS: 1.11.2

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.h
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.h
@@ -107,6 +107,8 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
 
 + (void)setOnesignalID:(nullable NSString *)onesignalID;
 
++ (void)setAirshipChannelID:(nullable NSString *)airshipChannelID;
+
 + (void)setMediaSource:(nullable NSString *)mediaSource;
 
 + (void)setCampaign:(nullable NSString *)campaign;

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCCommonFunctionality.m
@@ -479,6 +479,12 @@ signedDiscountTimestamp:(nullable NSString *)discountTimestamp
     [RCPurchases.sharedPurchases setOnesignalID:nonNSNullAttribute];
 }
 
++ (void)setAirshipChannelID:(nullable NSString *)airshipChannelID {
+    NSAssert(RCPurchases.sharedPurchases, @"You must call setup first.");
+    NSString *nonNSNullAttribute = [self nonNSNullAttribute:airshipChannelID];
+    [RCPurchases.sharedPurchases setAirshipChannelID:nonNSNullAttribute];
+}
+
 #pragma mark Campaign parameters
 
 + (void)setMediaSource:(nullable NSString *)mediaSource {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.3</string>
+	<string>1.10.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
### 1.10.0

- Bump `purchases-ios` to `3.13.0` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/3.13.0))
- Bump `purchases-android` to `4.4.0` ([Changelog here](https://github.com/RevenueCat/purchases-ios/releases/4.4.0))
- Added support for Airship integration via `setAirshipChannelID`
     https://github.com/RevenueCat/purchases-hybrid-common/pull/96
