### PR TITLE
Fix bump_and_update_changelog

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.4)
+    CFPropertyList (3.0.5)
       rexml
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.525.0)
-    aws-sdk-core (3.122.0)
+    aws-partitions (1.533.0)
+    aws-sdk-core (3.122.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
@@ -17,7 +17,7 @@ GEM
     aws-sdk-kms (1.51.0)
       aws-sdk-core (~> 3, >= 3.122.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.105.1)
+    aws-sdk-s3 (1.106.0)
       aws-sdk-core (~> 3, >= 3.122.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
@@ -62,7 +62,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.2.5)
-    fastlane (2.197.0)
+    fastlane (2.198.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,23 +10,20 @@
 #     https://docs.fastlane.tools/plugins/available-plugins
 #
 
-# Uncomment the line if you want fastlane to automatically update itself
-# update_fastlane
+before_all do
+  setup_circle_ci
+  update_fastlane
+end
+
+desc "Increment build number and update changelog"
+lane :bump_and_update_changelog do |options|
+  new_version_number = options[:version]
+  sh "fastlane ios bump version:#{new_version_number}"
+  sh "fastlane android bump version:#{new_version_number}"
+  attach_changelog_to_master
+end
 
 platform :ios do
-  before_all do
-    setup_circle_ci
-    update_fastlane
-  end
-
-  desc "Increment build number and update changelog"
-  lane :bump_and_update_changelog do |options|
-    new_version_number = options[:version]
-    sh "fastlane ios bump version:#{new_version_number}"
-    sh "fastlane android bump version:#{new_version_number}"
-    attach_changelog_to_master
-  end
-
   desc "Increment build number"
   lane :bump do |options|
     new_version_number = options[:version]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,7 +20,7 @@ lane :bump_and_update_changelog do |options|
   new_version_number = options[:version]
   sh "fastlane ios bump version:#{new_version_number}"
   sh "fastlane android bump version:#{new_version_number}"
-  attach_changelog_to_master
+  attach_changelog_to_main(options)
 end
 
 platform :ios do
@@ -46,20 +46,21 @@ platform :android do
   end
 end
 
-def attach_changelog_to_master
+def attach_changelog_to_main(options)
+  version_number = options[:version]
   current_changelog = File.open("../CHANGELOG.latest.md", 'r')
   master_changelog = File.open("../CHANGELOG.md", 'r')
 
   current_changelog_data = current_changelog.read
   master_changelog_data = master_changelog.read
 
-  current_changelog.close  
+  current_changelog.close
   master_changelog.close
 
   File.open("../CHANGELOG.md", 'w') { |master_changelog_write_mode|
-    whole_file_data = "#{current_changelog_data}\n#{master_changelog_data}"
+    version_header = "## #{version_number}"
+    whole_file_data = "#{version_header}\n\n#{current_changelog_data}\n#{master_changelog_data}"
     puts "going to save. Contents - #{whole_file_data}"
-    
     master_changelog_write_mode.write(whole_file_data)
   }
 end


### PR DESCRIPTION
`bump_and_update_changelog` was inside the ios platform, but it performs actions on both platforms. I also updated fastlane and fixed the attaching to changelog so it adds the version number 