### PR TITLE
Get the ownershipType from the android sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-- Get the ownershipType from the purchases-android SDK via the API
-
 ## 1.11.0
 
 Add ownershipType to EntitlementInfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Get the ownershipType from the purchases-android SDK via the API
+
 ## 1.11.0
 
 Add ownershipType to EntitlementInfo

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.assertj_version = '3.13.2'
     ext.mockk_version = '1.10.0'
     ext.gradle_maven_publish = '0.15.1'
-    ext.purchases_version = '4.5.0'
+    ext.purchases_version = '4.6.0'
 
     repositories {
         google()

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/EntitlementInfoMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/EntitlementInfoMapper.kt
@@ -21,5 +21,5 @@ fun EntitlementInfo.map(): Map<String, Any?> =
         "unsubscribeDetectedAtMillis" to this.unsubscribeDetectedAt?.toMillis(),
         "billingIssueDetectedAt" to this.billingIssueDetectedAt?.toIso8601(),
         "billingIssueDetectedAtMillis" to this.billingIssueDetectedAt?.toMillis(),
-        "ownershipType" to "UNKNOWN"
+        "ownershipType" to this.ownershipType.name
     )


### PR DESCRIPTION
Description:

This PR exposes `ownershipType` from `purchases-android` via the Hybrid Common Purchases SDK

I know that the play store does not provide this information, but it is possible that a user id exists in multiple platforms and as such may have their entitlement purchased by themselves, or shared to them, for example on iOS, and then be using it on Android.

This information is stored in the revenucat API and as such, the entitlement could be returned to Android with this data and a store type of e.g. `APP_STORE`

I'm making use of this in the purchases-flutter SDK, so a further PR will be forthcoming to update `purchases-flutter`

`purchases-android` PR: https://github.com/RevenueCat/purchases-android/pull/382

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

Related to Zendesk ticket: 12668

  - [ ] If applicable, unit tests.
