### PR TITLE
Release: 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.11.1
+
+- Adds compatibility for `ownershipType` for Android
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/103
+- Bump purchases-android to 4.6.0. [Changelog here](https://github.com/RevenueCat/purchases-android/releases/tag/4.6.0)
+
+
 ## 1.11.0
 
 Add ownershipType to EntitlementInfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - Bump purchases-android to 4.6.0. [Changelog here](https://github.com/RevenueCat/purchases-android/releases/tag/4.6.0)
 - Bump purchases-ios to 3.13.1. [Changelog here](https://github.com/RevenueCat/purchases-ios/releases/tag/3.13.1)
 
-
 ## 1.11.0
 
 Add ownershipType to EntitlementInfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Adds compatibility for `ownershipType` for Android
     https://github.com/RevenueCat/purchases-hybrid-common/pull/103
 - Bump purchases-android to 4.6.0. [Changelog here](https://github.com/RevenueCat/purchases-android/releases/tag/4.6.0)
+- Bump purchases-ios to 3.13.1. [Changelog here](https://github.com/RevenueCat/purchases-ios/releases/tag/3.13.1)
 
 
 ## 1.11.0

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.framework      = 'StoreKit'
 
-  s.dependency 'Purchases', '3.13.0'
+  s.dependency 'Purchases', '3.13.1'
   s.swift_version = '5.0'
 
   s.ios.deployment_target = '9.0'

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "1.11.0"
+  s.version          = "1.11.1"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 1
-        versionName "1.11.0"
+        versionName "1.11.1"
 
         consumerProguardFiles 'consumer-rules.pro'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.junit5 = '5.3.2'
     ext.assertj_version = '3.13.2'
     ext.mockk_version = '1.10.0'
-    ext.gradle_maven_publish = '0.15.1'
+    ext.gradle_maven_publish = '0.18.0'
     ext.purchases_version = '4.6.0'
 
     repositories {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 # Maven
 GROUP=com.revenuecat.purchases
-VERSION_NAME=1.11.0
+VERSION_NAME=1.11.1
 POM_NAME=purchases-hybrid-common
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=purchases-hybrid-common

--- a/ios/PurchasesHybridCommon/Info.plist
+++ b/ios/PurchasesHybridCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.11.0</string>
+	<string>1.11.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/ios/PurchasesHybridCommon/Podfile
+++ b/ios/PurchasesHybridCommon/Podfile
@@ -6,7 +6,7 @@ target 'PurchasesHybridCommon' do
   use_frameworks!
 
   # Pods for PurchasesHybridCommon
-  pod 'Purchases', '3.13.0'
+  pod 'Purchases', '3.13.1'
   
   target 'PurchasesHybridCommonTests' do
     # Pods for testing

--- a/ios/PurchasesHybridCommon/Podfile.lock
+++ b/ios/PurchasesHybridCommon/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - Nimble (9.2.1)
-  - Purchases (3.13.0):
-    - PurchasesCoreSwift (= 3.13.0)
-  - PurchasesCoreSwift (3.13.0)
+  - Purchases (3.13.1):
+    - PurchasesCoreSwift (= 3.13.1)
+  - PurchasesCoreSwift (3.13.1)
   - Quick (4.0.0)
 
 DEPENDENCIES:
   - Nimble
-  - Purchases (= 3.13.0)
+  - Purchases (= 3.13.1)
   - Quick
 
 SPEC REPOS:
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
-  Purchases: a545d402454bc9395495cceaf0e893360670e0ad
-  PurchasesCoreSwift: e7f7267a6dc526da226baad19c61e8977fa664b4
+  Purchases: 2693d6444609de044ab25fcda9561bef038f24da
+  PurchasesCoreSwift: ca55f9ef671f89abed133775dd9e53f55007828d
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
 
-PODFILE CHECKSUM: 9a1bb731e56ce87bb5abd2c38cc2bc719eb76d9e
+PODFILE CHECKSUM: 7f318bbc5e86c15be78e1fc0d8a01ac849ce3d9f
 
 COCOAPODS: 1.11.2

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.11.0</string>
+	<string>1.11.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
### 1.11.1
- Adds compatibility for `ownershipType` for Android
    https://github.com/RevenueCat/purchases-hybrid-common/pull/103
- Bump purchases-android to 4.6.0. [Changelog here](https://github.com/RevenueCat/purchases-android/releases/tag/4.6.0)
- Bump purchases-ios to 3.13.1. [Changelog here](https://github.com/RevenueCat/purchases-ios/releases/tag/3.13.1)
