### PR TITLE
fix inconsistency in `introPrice` mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.11.2
+
+- Fixes an inconsistency between `null` `introPrice` mapping in iOS and Android
+    https://github.com/RevenueCat/purchases-hybrid-common/pull/106
+
 ## 1.11.1
 
 - Adds compatibility for `ownershipType` for Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Fixes an inconsistency between `null` `introPrice` mapping in iOS and Android
     https://github.com/RevenueCat/purchases-hybrid-common/pull/106
+- Bump `purchases-android` to `4.6.1` ([Changelog here](https://github.com/RevenueCat/purchases-android/releases/4.6.1))
+- Bump purchases-ios to 3.13.2. [Changelog here](https://github.com/RevenueCat/purchases-ios/releases/tag/3.13.2)
 
 ## 1.11.1
 

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesHybridCommon"
-  s.version          = "1.11.1"
+  s.version          = "1.11.2"
   s.summary          = "Common files for hybrid SDKs for RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.framework      = 'StoreKit'
 
-  s.dependency 'Purchases', '3.13.1'
+  s.dependency 'Purchases', '3.13.2'
   s.swift_version = '5.0'
 
   s.ios.deployment_target = '9.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.assertj_version = '3.13.2'
     ext.mockk_version = '1.10.0'
     ext.gradle_maven_publish = '0.18.0'
-    ext.purchases_version = '4.6.0'
+    ext.purchases_version = '4.6.1'
 
     repositories {
         google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 1
-        versionName "1.11.1"
+        versionName "1.11.2"
 
         consumerProguardFiles 'consumer-rules.pro'
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 # Maven
 GROUP=com.revenuecat.purchases
-VERSION_NAME=1.11.1
+VERSION_NAME=1.11.2
 POM_NAME=purchases-hybrid-common
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=purchases-hybrid-common

--- a/android/src/main/java/com/revenuecat/purchases/common/mappers/SkuDetailsMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/common/mappers/SkuDetailsMapper.kt
@@ -52,7 +52,7 @@ private fun SkuDetails.formatUsingDeviceLocale(number: Long): String {
     }.format(number)
 }
 
-internal fun SkuDetails.mapIntroPrice(): Map<String, Any?> {
+internal fun SkuDetails.mapIntroPrice(): Map<String, Any?>? {
     // isNullOrBlank() gives issues with older Kotlin stdlib versions
     return if (freeTrialPeriod.isNotBlank()) {
         // Check freeTrialPeriod first to give priority to trials
@@ -65,7 +65,7 @@ internal fun SkuDetails.mapIntroPrice(): Map<String, Any?> {
                 "period" to freeTrialPeriod,
                 "cycles" to 1
             ) + periodFields
-        } ?: mapNullPeriod()
+        } ?: null
     } else if (introductoryPrice.isNotBlank()) {
         introductoryPricePeriod.mapPeriod()?.let { periodFields ->
             mapOf(
@@ -74,9 +74,9 @@ internal fun SkuDetails.mapIntroPrice(): Map<String, Any?> {
                 "period" to introductoryPricePeriod,
                 "cycles" to introductoryPriceCycles
             ) + periodFields
-        } ?: mapNullPeriod()
+        } ?: null
     } else {
-        mapNullPeriod()
+        null
     }
 }
 
@@ -88,17 +88,6 @@ private fun mapNullDeprecatedPeriod(): Map<String, Nothing?> {
         "intro_price_cycles" to null,
         "intro_price_period_unit" to null,
         "intro_price_period_number_of_units" to null
-    )
-}
-
-private fun mapNullPeriod(): Map<String, Nothing?> {
-    return mapOf(
-        "price" to null,
-        "priceString" to null,
-        "period" to null,
-        "cycles" to null,
-        "periodUnit" to null,
-        "periodNumberOfUnits" to null
     )
 }
 

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/SkuDetailsMappersTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/SkuDetailsMappersTests.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 
 internal class SkuDetailsMapperTests {
 
-    var received: Map<String, Any?> = emptyMap()
+    var received: Map<String, Any?>? = emptyMap()
     val mockSkuDetails = mockk<SkuDetails>(relaxed = true)
 
     @BeforeEach

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/SkuDetailsMappersTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/SkuDetailsMappersTests.kt
@@ -77,15 +77,7 @@ internal class SkuDetailsMapperTests {
             mockLogError()
             every { mockSkuDetails.freeTrialPeriod } returns "365"
             received = mockSkuDetails.mapIntroPrice()
-            val expected = mapOf(
-                "price" to null,
-                "priceString" to null,
-                "period" to null,
-                "cycles" to null,
-                "periodUnit" to null,
-                "periodNumberOfUnits" to null
-            )
-            assertThat(expected).isEqualTo(received)
+            assertThat(received).isEqualTo(null)
         }
     }
 
@@ -150,33 +142,15 @@ internal class SkuDetailsMapperTests {
             mockLogError()
             every { mockSkuDetails.introductoryPricePeriod } returns "365"
             received = mockSkuDetails.mapIntroPrice()
-
-            val expected = mapOf(
-                "price" to null,
-                "priceString" to null,
-                "period" to null,
-                "cycles" to null,
-                "periodUnit" to null,
-                "periodNumberOfUnits" to null
-            )
-            assertThat(expected).isEqualTo(received)
+            assertThat(received).isEqualTo(null)
         }
     }
 
     @Test
-    fun `when mapping a SkuDetails with no free trial nor introductory price, the map has null intro price values`() {
+    fun `when mapping a SkuDetails with no free trial nor introductory price, intro price is null`() {
         every { mockSkuDetails.freeTrialPeriod } returns ""
         every { mockSkuDetails.introductoryPrice } returns ""
         received = mockSkuDetails.mapIntroPrice()
-
-        val expected = mapOf(
-            "price" to null,
-            "priceString" to null,
-            "period" to null,
-            "cycles" to null,
-            "periodUnit" to null,
-            "periodNumberOfUnits" to null
-        )
-        assertThat(expected).isEqualTo(received)
+        assertThat(received).isEqualTo(null)
     }
 }

--- a/ios/PurchasesHybridCommon/Info.plist
+++ b/ios/PurchasesHybridCommon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.11.1</string>
+	<string>1.11.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/ios/PurchasesHybridCommon/Podfile
+++ b/ios/PurchasesHybridCommon/Podfile
@@ -6,7 +6,7 @@ target 'PurchasesHybridCommon' do
   use_frameworks!
 
   # Pods for PurchasesHybridCommon
-  pod 'Purchases', '3.13.1'
+  pod 'Purchases', '3.13.2'
   
   target 'PurchasesHybridCommonTests' do
     # Pods for testing

--- a/ios/PurchasesHybridCommon/Podfile.lock
+++ b/ios/PurchasesHybridCommon/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - Nimble (9.2.1)
-  - Purchases (3.13.1):
-    - PurchasesCoreSwift (= 3.13.1)
-  - PurchasesCoreSwift (3.13.1)
+  - Purchases (3.13.2):
+    - PurchasesCoreSwift (= 3.13.2)
+  - PurchasesCoreSwift (3.13.2)
   - Quick (4.0.0)
 
 DEPENDENCIES:
   - Nimble
-  - Purchases (= 3.13.1)
+  - Purchases (= 3.13.2)
   - Quick
 
 SPEC REPOS:
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
-  Purchases: 2693d6444609de044ab25fcda9561bef038f24da
-  PurchasesCoreSwift: ca55f9ef671f89abed133775dd9e53f55007828d
+  Purchases: 03200de9288724e77de435000d1828601e6b8e00
+  PurchasesCoreSwift: 2ea4b33e5cece5c8a0751594ef7c6cbfcbd747a9
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
 
-PODFILE CHECKSUM: 7f318bbc5e86c15be78e1fc0d8a01ac849ce3d9f
+PODFILE CHECKSUM: 3263c26ccea00d38380cc4b1c0b99f3234d4f273
 
 COCOAPODS: 1.11.2

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.11.1</string>
+	<string>1.11.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
mapping of null `introPrice` is inconsistent between iOS and Android: 

### iOS:
```json
"introPrice": null
```

[Code here](https://github.com/RevenueCat/purchases-hybrid-common/blob/main/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProduct+HybridAdditions.m#L39)

### Android:
```json
"introPrice": { 
    "price": null,
    "priceString": null,
    "period": null,
    "cycles": null,
    "periodUnit": null,
    "periodNumberOfUnits": null
}
```

[Code here](https://github.com/RevenueCat/purchases-hybrid-common/blob/main/android/src/main/java/com/revenuecat/purchases/common/mappers/SkuDetailsMapper.kt#L94)

This is the root cause of this [flutter issue](https://github.com/RevenueCat/purchases-flutter/issues/293)