### PR TITLE
Release fixing Amazon observer mode for release with BillingClient 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.0.0-amazon.alpha.5.billing3.iap2
+
+- Adds DangerousSettings option
+- Adds `syncObserverAmazonPurchase`
+- Disables connecting to Amazon PurchasingService in observer mode
+
 ### 1.7.1
 
 - Fixed dependency specificiation in Podspec to purchases-ios@3.11.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,4 +201,4 @@ DEPENDENCIES
   fastlane-plugin-versioning_android
 
 BUNDLED WITH
-   1.17.3
+   2.2.33

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.assertj_version = '3.13.2'
     ext.mockk_version = '1.10.0'
     ext.gradle_maven_publish = '0.11.1'
-    ext.purchases_version = '5.0.0-amazon.alpha.3.billing3.iap2'
+    ext.purchases_version = '5.0.0-amazon.alpha.5.billing3.iap2'
 
     repositories {
         google()
@@ -36,7 +36,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 29
         versionCode 1
-        versionName "2.0.0-amazon.alpha.4.billing3.iap2"
+        versionName "2.0.0-amazon.alpha.5.billing3.iap2"
 
         consumerProguardFiles 'consumer-rules.pro'
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 
 # Maven
 GROUP=com.revenuecat.purchases
-VERSION_NAME=2.0.0-amazon.alpha.4.billing3.iap2
+VERSION_NAME=2.0.0-amazon.alpha.5.billing3.iap2
 POM_NAME=purchases-hybrid-common
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=purchases-hybrid-common

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -287,7 +287,8 @@ fun configure(
     appUserID: String?,
     observerMode: Boolean?,
     platformInfo: PlatformInfo,
-    store: Store = Store.PLAY_STORE
+    store: Store = Store.PLAY_STORE,
+    dangerousSettings: DangerousSettings? = null
 ) {
     Purchases.platformInfo = platformInfo
     val builder =
@@ -296,6 +297,9 @@ fun configure(
             .store(store)
     if (observerMode != null) {
         builder.observerMode(observerMode)
+    }
+    if (dangerousSettings != null) {
+        builder.dangerousSettings(dangerousSettings)
     }
 
     Purchases.configure(builder.build())

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.UpgradeInfo
 import com.revenuecat.purchases.BillingFeature
+import com.revenuecat.purchases.DangerousSettings
 import com.revenuecat.purchases.hybridcommon.mappers.map
 import com.revenuecat.purchases.createAliasWith
 import com.revenuecat.purchases.getNonSubscriptionSkusWith


### PR DESCRIPTION
- Adds DangerousSettings option
- Adds `syncObserverAmazonPurchase`
- Disables connecting to Amazon PurchasingService in observer mode