### PR TITLE
remove @testable imports

### DIFF
--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -15,9 +15,7 @@ Pod::Spec.new do |s|
 
   s.framework      = 'StoreKit'
 
-  # todo: re-add specfic version once a version that exposes PromotionalOffer.SignedData is released
-  # s.dependency 'RevenueCat', '4.2.1'
-  s.dependency 'RevenueCat'
+  s.dependency 'RevenueCat', '4.3.0'
   s.swift_version = '5.0'
 
   s.ios.deployment_target = '11.0'

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -15,7 +15,9 @@ Pod::Spec.new do |s|
 
   s.framework      = 'StoreKit'
 
-  s.dependency 'RevenueCat', '4.2.1'
+  # todo: re-add specfic version once a version that exposes PromotionalOffer.SignedData is released
+  # s.dependency 'RevenueCat', '4.2.1'
+  s.dependency 'RevenueCat'
   s.swift_version = '5.0'
 
   s.ios.deployment_target = '11.0'

--- a/ios/PurchasesHybridCommon/Podfile
+++ b/ios/PurchasesHybridCommon/Podfile
@@ -6,8 +6,7 @@ target 'PurchasesHybridCommon' do
   use_frameworks!
 
   # Pods for PurchasesHybridCommon
-  # todo: remove the branch once the feature has been released
-  pod 'RevenueCat', :git => 'https://github.com/RevenueCat/purchases-ios.git', :branch => 'feature/expose_signed_data_in_promo_offers'
+  pod 'RevenueCat', '4.3.0'
   
   target 'PurchasesHybridCommonTests' do
     # Pods for testing

--- a/ios/PurchasesHybridCommon/Podfile
+++ b/ios/PurchasesHybridCommon/Podfile
@@ -6,7 +6,8 @@ target 'PurchasesHybridCommon' do
   use_frameworks!
 
   # Pods for PurchasesHybridCommon
-  pod 'RevenueCat', '4.2.1'
+  # todo: remove the branch once the feature has been released
+  pod 'RevenueCat', :git => 'https://github.com/RevenueCat/purchases-ios.git', :branch => 'feature/expose_signed_data_in_promo_offers'
   
   target 'PurchasesHybridCommonTests' do
     # Pods for testing

--- a/ios/PurchasesHybridCommon/Podfile.lock
+++ b/ios/PurchasesHybridCommon/Podfile.lock
@@ -1,32 +1,39 @@
 PODS:
   - Nimble (9.2.1)
   - PurchasesHybridCommon (2.0.1):
-    - RevenueCat (= 4.2.1)
+    - RevenueCat
   - Quick (5.0.1)
-  - RevenueCat (4.2.1)
+  - RevenueCat (4.3.0-SNAPSHOT)
 
 DEPENDENCIES:
   - Nimble
   - PurchasesHybridCommon (from `../../`)
   - Quick
-  - RevenueCat (= 4.2.1)
+  - RevenueCat (from `https://github.com/RevenueCat/purchases-ios.git`, branch `feature/expose_signed_data_in_promo_offers`)
 
 SPEC REPOS:
   trunk:
     - Nimble
     - Quick
-    - RevenueCat
 
 EXTERNAL SOURCES:
   PurchasesHybridCommon:
     :path: "../../"
+  RevenueCat:
+    :branch: feature/expose_signed_data_in_promo_offers
+    :git: https://github.com/RevenueCat/purchases-ios.git
+
+CHECKOUT OPTIONS:
+  RevenueCat:
+    :commit: 295a4945e388a4741ce5fda2720dc80085376e49
+    :git: https://github.com/RevenueCat/purchases-ios.git
 
 SPEC CHECKSUMS:
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
-  PurchasesHybridCommon: cc398a5b4e1c5309323aba2bdb767a440e0a257d
+  PurchasesHybridCommon: b8cfb95accea41ceeb038c20cf32e52ac1f3500d
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
-  RevenueCat: 6b08a19976f599a0ced21e2c98cf64e2318ac53e
+  RevenueCat: 08216e75afa83e3600476cc0665a765e3c511b74
 
-PODFILE CHECKSUM: a22742e12afef7c0ec7072af469dda80e069dc1c
+PODFILE CHECKSUM: 4bf14f3e06810d6d8a4a6e77432ee6060c39cdce
 
 COCOAPODS: 1.11.2

--- a/ios/PurchasesHybridCommon/Podfile.lock
+++ b/ios/PurchasesHybridCommon/Podfile.lock
@@ -1,39 +1,32 @@
 PODS:
   - Nimble (9.2.1)
   - PurchasesHybridCommon (2.0.1):
-    - RevenueCat
+    - RevenueCat (= 4.3.0)
   - Quick (5.0.1)
-  - RevenueCat (4.3.0-SNAPSHOT)
+  - RevenueCat (4.3.0)
 
 DEPENDENCIES:
   - Nimble
   - PurchasesHybridCommon (from `../../`)
   - Quick
-  - RevenueCat (from `https://github.com/RevenueCat/purchases-ios.git`, branch `feature/expose_signed_data_in_promo_offers`)
+  - RevenueCat (= 4.3.0)
 
 SPEC REPOS:
   trunk:
     - Nimble
     - Quick
+    - RevenueCat
 
 EXTERNAL SOURCES:
   PurchasesHybridCommon:
     :path: "../../"
-  RevenueCat:
-    :branch: feature/expose_signed_data_in_promo_offers
-    :git: https://github.com/RevenueCat/purchases-ios.git
-
-CHECKOUT OPTIONS:
-  RevenueCat:
-    :commit: 295a4945e388a4741ce5fda2720dc80085376e49
-    :git: https://github.com/RevenueCat/purchases-ios.git
 
 SPEC CHECKSUMS:
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
-  PurchasesHybridCommon: b8cfb95accea41ceeb038c20cf32e52ac1f3500d
+  PurchasesHybridCommon: 2326871bfa7b6e15520dbfd55acd62faf0c49a6e
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
-  RevenueCat: 08216e75afa83e3600476cc0665a765e3c511b74
+  RevenueCat: bcbf0d68e546f947e00b7ea68d4f2d1c913e7767
 
-PODFILE CHECKSUM: 4bf14f3e06810d6d8a4a6e77432ee6060c39cdce
+PODFILE CHECKSUM: 8aad6e693de2c8c32106bc84b2381e4c1e74321a
 
 COCOAPODS: 1.11.2

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -77,6 +77,7 @@ import RevenueCat
         Purchases.shared.invalidateCustomerInfoCache()
     }
 
+#if os(iOS)
     @available(iOS 14.0, *)
     @available(tvOS, unavailable)
     @available(macOS, unavailable)
@@ -84,6 +85,7 @@ import RevenueCat
     @objc public static func presentCodeRedemptionSheet() {
         Purchases.shared.presentCodeRedemptionSheet()
     }
+#endif
 
     @objc public static func canMakePaymentsWithFeatures(_ features: [Int]) -> Bool {
         return Purchases.canMakePayments()
@@ -396,10 +398,7 @@ import RevenueCat
     }
 
     @objc static func setPushToken(_ pushToken: String?) {
-        // todo
-        // this method has been temporarily removed and will be re-added
-        // when this code is adapted for v4
-        // Purchases.shared.setPushToken(pushToken)
+         Purchases.shared.setPushTokenString(pushToken)
     }
 
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -8,8 +8,7 @@
 
 import Foundation
 import StoreKit
-// todo: remove testable once signedData is exposed on PromotionalOffer in purchases-ios
-@testable import RevenueCat
+import RevenueCat
 
 
 @objc(RCCommonFunctionality) public class CommonFunctionality: NSObject {
@@ -214,7 +213,7 @@ import StoreKit
     }
 
     @objc(makeDeferredPurchase:completionBlock:)
-    static func makeDeferredPurchase(_ startPurchase: DeferredPromotionalPurchaseBlock,
+    static func makeDeferredPurchase(_ startPurchase: StartPurchaseBlock,
                                      completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
         startPurchase { transaction, purchaserInfo, error, userCancelled in
             if let error = error {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/ErrorContainer.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/ErrorContainer.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-@testable import RevenueCat
+import RevenueCat
 
 @objc(RCErrorContainer) public class ErrorContainer: NSObject {
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/PromotionalOffer+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/PromotionalOffer+HybridAdditions.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 // todo: expose signedData in promotionalOffer in purchases-ios
-@testable import RevenueCat
+import RevenueCat
 
 @objc public extension PromotionalOffer {
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/PromotionalOffer+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/PromotionalOffer+HybridAdditions.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-// todo: expose signedData in promotionalOffer in purchases-ios
 import RevenueCat
 
 @objc public extension PromotionalOffer {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
@@ -47,7 +47,7 @@ class MockPurchases: Purchases {
 
         let attributionPoster: AttributionPoster = AttributionPoster(
             deviceCache: deviceCache,
-            identityManager: identityManager,
+            currentUserProvider: identityManager,
             backend: backend,
             attributionFetcher: attributionFetcher,
             subscriberAttributesManager: subscriberAttributesManager)
@@ -63,13 +63,13 @@ class MockPurchases: Purchases {
 
         let introEligibilityCalculator: IntroEligibilityCalculator = IntroEligibilityCalculator(productsManager: productsManager, receiptParser: ReceiptParser())
 
-        let manageSubscriptionsHelper = ManageSubscriptionsHelper(systemInfo: systemInfo, customerInfoManager: customerInfoManager, identityManager: identityManager)
+        let manageSubscriptionsHelper = ManageSubscriptionsHelper(systemInfo: systemInfo, customerInfoManager: customerInfoManager, currentUserProvider: identityManager)
 
-        let beginRefundRequestHelper = BeginRefundRequestHelper(systemInfo: systemInfo, customerInfoManager: customerInfoManager, identityManager: identityManager)
+        let beginRefundRequestHelper = BeginRefundRequestHelper(systemInfo: systemInfo, customerInfoManager: customerInfoManager, currentUserProvider: identityManager)
 
-        let purchasesOrchestrator: PurchasesOrchestrator = PurchasesOrchestrator(productsManager: productsManager, storeKitWrapper: storeKitWrapper, systemInfo: systemInfo, subscriberAttributesManager: subscriberAttributesManager, operationDispatcher: operationDispatcher, receiptFetcher: receiptFetcher, customerInfoManager: customerInfoManager, backend: backend, identityManager: identityManager, transactionsManager: TransactionsManager(receiptParser: ReceiptParser()), deviceCache: deviceCache, manageSubscriptionsHelper: manageSubscriptionsHelper, beginRefundRequestHelper: beginRefundRequestHelper)
+        let purchasesOrchestrator: PurchasesOrchestrator = PurchasesOrchestrator(productsManager: productsManager, storeKitWrapper: storeKitWrapper, systemInfo: systemInfo, subscriberAttributesManager: subscriberAttributesManager, operationDispatcher: operationDispatcher, receiptFetcher: receiptFetcher, customerInfoManager: customerInfoManager, backend: backend, currentUserProvider: identityManager, transactionsManager: TransactionsManager(storeKit2Setting: .enabledOnlyForOptimizations, receiptParser: ReceiptParser()), deviceCache: deviceCache, manageSubscriptionsHelper: manageSubscriptionsHelper, beginRefundRequestHelper: beginRefundRequestHelper)
 
-        let trialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityChecker = TrialOrIntroPriceEligibilityChecker(receiptFetcher: receiptFetcher, introEligibilityCalculator: introEligibilityCalculator, backend: backend, identityManager: identityManager, operationDispatcher: operationDispatcher, productsManager: productsManager)
+        let trialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityChecker = TrialOrIntroPriceEligibilityChecker(systemInfo: systemInfo, receiptFetcher: receiptFetcher, introEligibilityCalculator: introEligibilityCalculator, backend: backend, currentUserProvider: identityManager, operationDispatcher: operationDispatcher, productsManager: productsManager)
 
         super.init(appUserID: nil,
                    requestFetcher: requestFetcher,


### PR DESCRIPTION
This updates the codebase so that we no longer need `@testable` imports. 
Before shipping this we will need to make a purchases-ios release [including the changes from this PR](https://github.com/RevenueCat/purchases-ios/pull/1523). 

Note that `pod lib lint` will continue to fail on this PR, sadly, because we can't point a `Podspec` to a specific branch, only a `Podfile`. And `pod lib lint` uses a `Podspec`. 