### PR TITLE
Update apis to v4

### DIFF
--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -49,8 +49,8 @@ NS_ASSUME_NONNULL_BEGIN
     }];
 
     [RCCommonFunctionality setDebugLogsEnabled:NO];
-    [RCCommonFunctionality getPurchaserInfoWithCompletionBlock:^(NSDictionary * _Nullable customerInfo,
-                                                                 RCErrorContainer * _Nullable error) {
+    [RCCommonFunctionality getCustomerInfoWithCompletionBlock:^(NSDictionary * _Nullable customerInfo,
+                                                                RCErrorContainer * _Nullable error) {
     }];
 
     [RCCommonFunctionality setAutomaticAppleSearchAdsAttributionCollection:YES];
@@ -98,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (@available(iOS 14.0, *)) {
         [RCCommonFunctionality presentCodeRedemptionSheet];
     }
-    [RCCommonFunctionality invalidatePurchaserInfoCache];
+    [RCCommonFunctionality invalidateCustomerInfoCache];
     BOOL canMakePayments __unused = [RCCommonFunctionality canMakePaymentsWithFeatures:@[]];
 }
 

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -30,8 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
                           completionBlock:^(NSArray<NSDictionary *> * _Nonnull products) {
     }];
 
-    [RCCommonFunctionality restoreTransactionsWithCompletionBlock:^(NSDictionary * _Nullable customerInfo,
-                                                                    RCErrorContainer * _Nullable error) {
+    [RCCommonFunctionality restorePurchasesWithCompletionBlock:^(NSDictionary * _Nullable customerInfo,
+                                                                 RCErrorContainer * _Nullable error) {
     }];
 
     [RCCommonFunctionality syncPurchasesWithCompletionBlock:^(NSDictionary * _Nullable customerInfo,

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -20,7 +20,6 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *proxyURL __unused = [RCCommonFunctionality proxyURLString];
     BOOL simulatesAskToBuyInSandbox __unused = [RCCommonFunctionality simulatesAskToBuyInSandbox];
 
-    [RCCommonFunctionality configure];
     // should issue deprecated warning
     [RCCommonFunctionality setAllowSharingStoreAccount:NO];
 

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -48,23 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
                                                        RCErrorContainer * _Nullable error) {
     }];
 
-    // should issue deprecated warning
-    [RCCommonFunctionality createAlias:@""
-                       completionBlock:^(NSDictionary * _Nullable customerInfo,
-                                         RCErrorContainer * _Nullable error) {
-    }];
-
-    // should issue deprecated warning
-    [RCCommonFunctionality identify:@""
-                    completionBlock:^(NSDictionary * _Nullable customerInfo,
-                                      RCErrorContainer * _Nullable error) {
-    }];
-
-    // should issue deprecated warning
-    [RCCommonFunctionality resetWithCompletionBlock:^(NSDictionary * _Nullable customerInfo,
-                                                      RCErrorContainer * _Nullable error) {
-    }];
-
     [RCCommonFunctionality setDebugLogsEnabled:NO];
     [RCCommonFunctionality getPurchaserInfoWithCompletionBlock:^(NSDictionary * _Nullable customerInfo,
                                                                  RCErrorContainer * _Nullable error) {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -263,27 +263,6 @@ import RevenueCat
         Purchases.shared.logOut(completion: purchaserInfoCompletionBlock(from: completion))
     }
 
-    @objc(createAlias:completionBlock:)
-    static func createAlias(newAppUserID: String, completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        let hybridCompletion = purchaserInfoCompletionBlock(from: completion)
-        Purchases.shared.logIn(newAppUserID) { customerInfo, created, error in
-            hybridCompletion(customerInfo, error)
-        }
-    }
-
-    @objc(identify:completionBlock:)
-    static func identify(appUserID: String, completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        let hybridCompletion = purchaserInfoCompletionBlock(from: completion)
-        Purchases.shared.logIn(appUserID) { customerInfo, created, error in
-            hybridCompletion(customerInfo, error)
-        }
-    }
-
-    @objc(resetWithCompletionBlock:)
-    static func reset(completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        Purchases.shared.logOut(completion: purchaserInfoCompletionBlock(from: completion))
-    }
-
     @objc(getPurchaserInfoWithCompletionBlock:)
     static func purchaserInfo(completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
         Purchases.shared.getCustomerInfo(completion: purchaserInfoCompletionBlock(from: completion))

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -51,7 +51,7 @@ import RevenueCat
         }
     }
 
-    private static var discountsByProductIdentifier: [String: PromotionalOffer] = [:]
+    private static var promoOffersByTimestamp: [String: PromotionalOffer] = [:]
 
     @available(*, deprecated, message: "Use the set<NetworkId> functions instead")
     @objc public static func setAllowSharingStoreAccount(_ allowSharingStoreAccount: Bool) {
@@ -143,12 +143,12 @@ import RevenueCat
             if let signedDiscountTimestamp = signedDiscountTimestamp {
                 let storeProduct = StoreProduct(sk1Product: product)
                 if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) {
-                    guard let discount = self.discountsByProductIdentifier[signedDiscountTimestamp] else {
+                    guard let promotionalOffer = self.promoOffersByTimestamp[signedDiscountTimestamp] else {
                         completion(nil, productNotFoundError(description: "Couldn't find discount.", userCancelled: false))
                         return
                     }
                     Purchases.shared.purchase(product: storeProduct,
-                                              promotionalOffer: discount,
+                                              promotionalOffer: promotionalOffer,
                                               completion: hybridCompletion)
                     return
                 }
@@ -194,12 +194,12 @@ import RevenueCat
 
             if let signedDiscountTimestamp = signedDiscountTimestamp {
                 if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) {
-                    guard let discount = self.discountsByProductIdentifier[signedDiscountTimestamp] else {
+                    guard let promotionalOffer = self.promoOffersByTimestamp[signedDiscountTimestamp] else {
                         completion(nil, productNotFoundError(description: "Couldn't find discount.", userCancelled: false))
                         return
                     }
                     Purchases.shared.purchase(package: package,
-                                              promotionalOffer: discount,
+                                              promotionalOffer: promotionalOffer,
                                               completion: hybridCompletion)
                     return
                 }
@@ -342,7 +342,7 @@ import RevenueCat
                     }
                     return
                 }
-                discountsByProductIdentifier["\(promotionalOffer.signedData.timestamp)"] = promotionalOffer
+                promoOffersByTimestamp["\(promotionalOffer.signedData.timestamp)"] = promotionalOffer
                 completion(promotionalOffer.rc_dictionary, nil)
             }
             let storeProduct = StoreProduct(sk1Product: product)

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -70,7 +70,7 @@ import RevenueCat
         Purchases.shared.finishTransactions = finishTransactions
     }
 
-    @objc public static func invalidatePurchaserInfoCache() {
+    @objc public static func invalidateCustomerInfoCache() {
         Purchases.shared.invalidateCustomerInfoCache()
     }
 
@@ -95,15 +95,15 @@ import RevenueCat
 
     @objc(restorePurchasesWithCompletionBlock:)
     static func restorePurchases(completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        let purchaserInfoCompletion = purchaserInfoCompletionBlock(from: completion)
-        Purchases.shared.restorePurchases(completion: purchaserInfoCompletion)
+        let customerInfoCompletion = customerInfoCompletionBlock(from: completion)
+        Purchases.shared.restorePurchases(completion: customerInfoCompletion)
     }
 
     @objc(syncPurchasesWithCompletionBlock:)
     static func syncPurchases(completion: (([String: Any]?, ErrorContainer?) -> Void)?) {
         if let completion = completion {
-            let purchaserInfoCompletion = purchaserInfoCompletionBlock(from: completion)
-            Purchases.shared.syncPurchases(completion: purchaserInfoCompletion)
+            let customerInfoCompletion = customerInfoCompletionBlock(from: completion)
+            Purchases.shared.syncPurchases(completion: customerInfoCompletion)
         } else {
             Purchases.shared.syncPurchases(completion: nil)
         }
@@ -116,13 +116,13 @@ import RevenueCat
         let hybridCompletion: (StoreTransaction?,
                                CustomerInfo?,
                                Error?,
-                               Bool) -> Void = { transaction, purchaserInfo, error, userCancelled in
+                               Bool) -> Void = { transaction, customerInfo, error, userCancelled in
             if let error = error {
                 completion(nil, ErrorContainer(error: error, extraPayload: ["userCancelled": userCancelled]))
-            } else if let purchaserInfo = purchaserInfo,
+            } else if let customerInfo = customerInfo,
                       let transaction = transaction {
                 completion([
-                    "purchaserInfo": purchaserInfo.dictionary,
+                    "customerInfo": customerInfo.dictionary,
                     "productIdentifier": transaction.sk1Transaction!.payment.productIdentifier
                 ], nil)
             } else {
@@ -167,13 +167,13 @@ import RevenueCat
         let hybridCompletion: (StoreTransaction?,
                                CustomerInfo?,
                                Error?,
-                               Bool) -> Void = { transaction, purchaserInfo, error, userCancelled in
+                               Bool) -> Void = { transaction, customerInfo, error, userCancelled in
             if let error = error {
                 completion(nil, ErrorContainer(error: error, extraPayload: ["userCancelled": userCancelled]))
-            } else if let purchaserInfo = purchaserInfo,
+            } else if let customerInfo = customerInfo,
                       let transaction = transaction {
                 completion([
-                    "purchaserInfo": purchaserInfo.dictionary,
+                    "customerInfo": customerInfo.dictionary,
                     "productIdentifier": transaction.sk1Transaction!.payment.productIdentifier
                 ], nil)
             } else {
@@ -214,13 +214,13 @@ import RevenueCat
     @objc(makeDeferredPurchase:completionBlock:)
     static func makeDeferredPurchase(_ startPurchase: StartPurchaseBlock,
                                      completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        startPurchase { transaction, purchaserInfo, error, userCancelled in
+        startPurchase { transaction, customerInfo, error, userCancelled in
             if let error = error {
                 completion(nil, ErrorContainer(error: error, extraPayload: ["userCancelled": userCancelled]))
-            } else if let purchaserInfo = purchaserInfo,
+            } else if let customerInfo = customerInfo,
                       let transaction = transaction {
                 completion([
-                    "purchaserInfo": purchaserInfo.dictionary,
+                    "customerInfo": customerInfo.dictionary,
                     "productIdentifier": transaction.sk1Transaction!.payment.productIdentifier
                 ], nil)
             } else {
@@ -240,12 +240,12 @@ import RevenueCat
 
     @objc(logInWithAppUserID:completionBlock:)
     static func logIn(appUserID: String, completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        Purchases.shared.logIn(appUserID) { purchaserInfo, created, error in
+        Purchases.shared.logIn(appUserID) { customerInfo, created, error in
             if let error = error {
                 completion(nil, ErrorContainer(error: error, extraPayload: [:]))
-            } else if let purchaserInfo = purchaserInfo {
+            } else if let customerInfo = customerInfo {
                 completion([
-                    "customerInfo": purchaserInfo.dictionary,
+                    "customerInfo": customerInfo.dictionary,
                     "created": created
                 ], nil)
             } else {
@@ -260,12 +260,12 @@ import RevenueCat
 
     @objc(logOutWithCompletionBlock:)
     static func logOut(completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        Purchases.shared.logOut(completion: purchaserInfoCompletionBlock(from: completion))
+        Purchases.shared.logOut(completion: customerInfoCompletionBlock(from: completion))
     }
 
-    @objc(getPurchaserInfoWithCompletionBlock:)
-    static func purchaserInfo(completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        Purchases.shared.getCustomerInfo(completion: purchaserInfoCompletionBlock(from: completion))
+    @objc(getCustomerInfoWithCompletionBlock:)
+    static func customerInfo(completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
+        Purchases.shared.getCustomerInfo(completion: customerInfoCompletionBlock(from: completion))
     }
 
 }
@@ -441,14 +441,14 @@ import RevenueCat
 
 private extension CommonFunctionality {
 
-    static func purchaserInfoCompletionBlock(from block: @escaping ([String: Any]?, ErrorContainer?) -> Void)
+    static func customerInfoCompletionBlock(from block: @escaping ([String: Any]?, ErrorContainer?) -> Void)
     -> ((CustomerInfo?, Error?) -> Void) {
-        return { purchaserInfo, error in
+        return { customerInfo, error in
             if let error = error {
                 let errorContainer = ErrorContainer(error: error, extraPayload: [:])
                 block(nil, errorContainer)
-            } else if let purchaserInfo = purchaserInfo {
-                block(purchaserInfo.dictionary, nil)
+            } else if let customerInfo = customerInfo {
+                block(customerInfo.dictionary, nil)
             } else {
                 let error = NSError(domain: RCPurchasesErrorCodeDomain,
                                     code: ErrorCode.unknownError.rawValue,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -93,8 +93,8 @@ import RevenueCat
 // MARK: purchasing and restoring
 @objc public extension CommonFunctionality {
 
-    @objc(restoreTransactionsWithCompletionBlock:)
-    static func restoreTransactions(completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
+    @objc(restorePurchasesWithCompletionBlock:)
+    static func restorePurchases(completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
         let purchaserInfoCompletion = purchaserInfoCompletionBlock(from: completion)
         Purchases.shared.restorePurchases(completion: purchaserInfoCompletion)
     }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -53,10 +53,7 @@ import RevenueCat
 
     private static var discountsByProductIdentifier: [String: PromotionalOffer] = [:]
 
-    @objc public static func configure() {
-        // todo: it seems like this call isn't needed anymore?
-    }
-
+    @available(*, deprecated, message: "Use the set<NetworkId> functions instead")
     @objc public static func setAllowSharingStoreAccount(_ allowSharingStoreAccount: Bool) {
         Purchases.shared.allowSharingAppStoreAccount = allowSharingStoreAccount;
     }
@@ -429,6 +426,7 @@ import RevenueCat
         Purchases.shared.setAirshipChannelID(airshipChannelID)
     }
 
+    @available(*, deprecated, message: "Use the set<NetworkId> functions instead")
     @objc static func addAttributionData(_ data: [String: Any], network: Int, networkUserId: String) {
         // todo: clean up force cast after migration to v4
         Purchases.addAttributionData(data,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -245,7 +245,7 @@ import RevenueCat
                 completion(nil, ErrorContainer(error: error, extraPayload: [:]))
             } else if let purchaserInfo = purchaserInfo {
                 completion([
-                    "purchaserInfo": purchaserInfo.dictionary,
+                    "customerInfo": purchaserInfo.dictionary,
                     "created": created
                 ], nil)
             } else {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
@@ -146,19 +146,19 @@ class MockPurchases: Purchases {
     var invokedCreateAliasCount = 0
     var invokedCreateAliasParameters: (alias: String, completion: ((CustomerInfo?, Error?) -> ())?)?
     var invokedCreateAliasParametersList = [(alias: String,
-        completion: ((CustomerInfo?, Error?) -> ())?)]()
+                                             completion: ((CustomerInfo?, Error?) -> ())?)]()
 
-    var invokedPurchaserInfo = false
-    var invokedPurchaserInfoCount = 0
-    var invokedPurchaserInfoParameters: (completion: ((CustomerInfo?, Error?) -> ()), Void)?
-    var invokedPurchaserInfoParametersList = [(completion: ((CustomerInfo?, Error?) -> ()),
-        Void)]()
+    var invokedCustomerInfo = false
+    var invokedCustomerInfoCount = 0
+    var invokedCustomerInfoParameters: (completion: ((CustomerInfo?, Error?) -> ()), Void)?
+    var invokedCustomerInfoParametersList = [(completion: ((CustomerInfo?, Error?) -> ()),
+                                              Void)]()
 
     override func getCustomerInfo(completion: @escaping ((CustomerInfo?, Error?) -> ())) {
-        invokedPurchaserInfo = true
-        invokedPurchaserInfoCount += 1
-        invokedPurchaserInfoParameters = (completion, ())
-        invokedPurchaserInfoParametersList.append((completion, ()))
+        invokedCustomerInfo = true
+        invokedCustomerInfoCount += 1
+        invokedCustomerInfoParameters = (completion, ())
+        invokedCustomerInfoParametersList.append((completion, ()))
     }
 
     var invokedOfferings = false
@@ -190,7 +190,7 @@ class MockPurchases: Purchases {
     var invokedPurchaseProductCount = 0
     var invokedPurchaseProductParameters: (product: StoreProduct, completion: PurchaseCompletedBlock)?
     var invokedPurchaseProductParametersList = [(product: StoreProduct,
-        completion: PurchaseCompletedBlock)]()
+                                                 completion: PurchaseCompletedBlock)]()
 
     override func purchase(product: StoreProduct, completion: @escaping PurchaseCompletedBlock) {
         invokedPurchaseProduct = true
@@ -203,7 +203,7 @@ class MockPurchases: Purchases {
     var invokedPurchasePackageCount = 0
     var invokedPurchasePackageParameters: (package: Package, completion: PurchaseCompletedBlock)?
     var invokedPurchasePackageParametersList = [(package: Package,
-        completion: PurchaseCompletedBlock)]()
+                                                 completion: PurchaseCompletedBlock)]()
 
     override func purchase(package: Package,
                            completion: @escaping PurchaseCompletedBlock) {
@@ -217,7 +217,7 @@ class MockPurchases: Purchases {
     var invokedRestoreTransactionsCount = 0
     var invokedRestoreTransactionsParameters: (completion: ((CustomerInfo?, Error?) -> ())?, Void)?
     var invokedRestoreTransactionsParametersList = [(completion: ((CustomerInfo?, Error?) -> ())?,
-        Void)]()
+                                                     Void)]()
 
     override func restorePurchases(completion: ((CustomerInfo?, Error?) -> ())?) {
         invokedRestoreTransactions = true
@@ -230,7 +230,7 @@ class MockPurchases: Purchases {
     var invokedSyncPurchasesCount = 0
     var invokedSyncPurchasesParameters: (completion: ((CustomerInfo?, Error?) -> ())?, Void)?
     var invokedSyncPurchasesParametersList = [(completion: ((CustomerInfo?, Error?) -> ())?,
-        Void)]()
+                                               Void)]()
 
     override func syncPurchases(completion: ((CustomerInfo?, Error?) -> ())?) {
         invokedSyncPurchases = true
@@ -302,27 +302,27 @@ class MockPurchases: Purchases {
     var invokedPurchasePackageWithPromotionalOffer = false
     var invokedPurchasePackageWithPromotionalOfferCount = 0
     var invokedPurchasePackageWithPromotionalOfferParameters: (package: Package,
-                                                       promotionalOffer: PromotionalOffer,
-                                                       completion: PurchaseCompletedBlock)?
+                                                               promotionalOffer: PromotionalOffer,
+                                                               completion: PurchaseCompletedBlock)?
     var invokedPurchasePackageWithPromotionalOfferParametersList = [(package: Package,
-        promotionalOffer: PromotionalOffer,
-        completion: PurchaseCompletedBlock)]()
+                                                                     promotionalOffer: PromotionalOffer,
+                                                                     completion: PurchaseCompletedBlock)]()
 
     override func purchase(package: Package,
-                                  promotionalOffer: PromotionalOffer,
-                                  completion: @escaping PurchaseCompletedBlock) {
+                           promotionalOffer: PromotionalOffer,
+                           completion: @escaping PurchaseCompletedBlock) {
         invokedPurchasePackageWithPromotionalOffer = true
         invokedPurchasePackageWithPromotionalOfferCount += 1
         invokedPurchasePackageWithPromotionalOfferParameters = (package, promotionalOffer, completion)
         invokedPurchasePackageWithPromotionalOfferParametersList.append((package, promotionalOffer, completion))
     }
 
-    var invokedInvalidatePurchaserInfoCache = false
-    var invokedInvalidatePurchaserInfoCacheCount = 0
+    var invokedInvalidateCustomerInfoCache = false
+    var invokedInvalidateCustomerInfoCacheCount = 0
 
     override func invalidateCustomerInfoCache() {
-        invokedInvalidatePurchaserInfoCache = true
-        invokedInvalidatePurchaserInfoCacheCount += 1
+        invokedInvalidateCustomerInfoCache = true
+        invokedInvalidateCustomerInfoCacheCount += 1
     }
 
     var invokedPresentCodeRedemptionSheet = false

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchaserInfoHybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchaserInfoHybridAdditionsTests.swift
@@ -1,5 +1,5 @@
 //
-//  PurchaserInfoHybridAdditionsTests.swift
+//  CustomerInfoHybridAdditionsTests.swift
 //  PurchasesHybridCommonTests
 //
 //  Created by Andrés Boedo on 6/10/20.

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
@@ -80,7 +80,7 @@ class PurchasesHybridCommonTests: QuickSpec {
 
                 // todo: update this once APIs get updated to v4
                 let expectedResult: NSDictionary = [
-                    "purchaserInfo": self.mockCustomerInfo.dictionary,
+                    "customerInfo": self.mockCustomerInfo.dictionary,
                     "created": mockCreated
                 ]
 


### PR DESCRIPTION
Updates a few APIs to use v4 naming. 
- Removes `configure`
- Renames `restoreTransactions` -> `restorePurchases`
- Renames `purchaserInfo` -> `customerInfo`