### PR TITLE
rename `paymentDiscountForProductIdentifier` -> `promotionalOffer(for:)`

### DIFF
--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -89,10 +89,10 @@ NS_ASSUME_NONNULL_BEGIN
                                                     completionBlock:^(NSDictionary<NSString *, NSObject *>
                                                                       * _Nonnull eligibilities) {
     }];
-    [RCCommonFunctionality paymentDiscountForProductIdentifier:@""
-                                                      discount:@""
-                                               completionBlock:^(NSDictionary * _Nullable discount,
-                                                                 RCErrorContainer * _Nullable error) {
+    [RCCommonFunctionality promotionalOfferForProductIdentifier:@""
+                                                       discount:@""
+                                                completionBlock:^(NSDictionary * _Nullable discount,
+                                                                  RCErrorContainer * _Nullable error) {
     }];
 
     if (@available(iOS 14.0, *)) {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -308,10 +308,10 @@ import RevenueCat
         }
     }
 
-    @objc(paymentDiscountForProductIdentifier:discount:completionBlock:)
-    static func paymentDiscount(for productIdentifier: String,
-                                discountIdentifier: String?,
-                                completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
+    @objc(promotionalOfferForProductIdentifier:discount:completionBlock:)
+    static func promotionalOffer(for productIdentifier: String,
+                                 discountIdentifier: String?,
+                                 completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
         guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) else {
             completion(nil, nil)
             return

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -328,7 +328,7 @@ import RevenueCat
                 return
             }
 
-            let paymentDiscountCompletion: (PromotionalOffer?, Error?) -> Void = { promotionalOffer, error in
+            let promotionalOfferCompletion: (PromotionalOffer?, Error?) -> Void = { promotionalOffer, error in
                 guard let promotionalOffer = promotionalOffer else {
                     if let error = error {
                         completion(nil, ErrorContainer(error: error, extraPayload: [:]))
@@ -347,7 +347,7 @@ import RevenueCat
             let storeProduct = StoreProduct(sk1Product: product)
             Purchases.shared.getPromotionalOffer(forProductDiscount: discountToUse,
                                                  product: storeProduct,
-                                                 completion: paymentDiscountCompletion)
+                                                 completion: promotionalOfferCompletion)
         }
     }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/CustomerInfo+HybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/CustomerInfo+HybridAdditionsTests.swift
@@ -50,6 +50,8 @@ class CustomerInfoHybridAdditionsTests: QuickSpec {
                 it("contains all the non subscription transactions") {
                     let transactionDateString = "1990-08-30T02:40:36Z"
 
+                    let expectedTransactionID = "expectedTransactionID"
+                    let expectedProductID = "expectedProductID"
                     let mockCustomerInfo = try CustomerInfo(data: [
                         "request_date": "2019-08-16T10:30:42Z",
                         "subscriber": [
@@ -57,9 +59,9 @@ class CustomerInfoHybridAdditionsTests: QuickSpec {
                             "first_seen": "2019-06-17T16:05:33Z",
                             "subscriptions": [:],
                             "non_subscriptions": [
-                                "productid": [
+                                expectedProductID: [
                                     [
-                                        "id": "transactionid",
+                                        "id": expectedTransactionID,
                                         "is_sandbox": true,
                                         "original_purchase_date": "1990-08-30T02:40:36Z",
                                         "purchase_date": transactionDateString,
@@ -73,16 +75,16 @@ class CustomerInfoHybridAdditionsTests: QuickSpec {
                     let transactionDate = dateformatter.date(from: transactionDateString)!
 
                     let dictionary = mockCustomerInfo.dictionary
-                    let nonSubscriptionTransactions = dictionary["nonSubscriptionTransactions"] as? Array<Any>
-                    expect(nonSubscriptionTransactions?.count) == 1
+                    let nonSubscriptionTransactions = try XCTUnwrap(dictionary["nonSubscriptionTransactions"] as? [Any])
+                    expect(nonSubscriptionTransactions.count) == 1
 
-                    let transactionDictionary = nonSubscriptionTransactions?[0] as? Dictionary<String, Any>
-                    expect(transactionDictionary?["revenueCatId"] as? String) == "transactionid"
-                    expect(transactionDictionary?["productId"] as? String) == "productid"
-                    expect(transactionDictionary?["purchaseDateMillis"] as? Double) == transactionDate.rc_millisecondsSince1970AsDouble()
+                    let transactionDictionary = try XCTUnwrap(nonSubscriptionTransactions[0] as? [String: Any])
+                    expect(transactionDictionary["revenueCatId"] as? String) == expectedTransactionID
+                    expect(transactionDictionary["productId"] as? String) == expectedProductID
+                    expect(transactionDictionary["purchaseDateMillis"] as? Double) == transactionDate.rc_millisecondsSince1970AsDouble()
 
 
-                    expect(transactionDictionary?["purchaseDate"] as? String) == dateformatter.string(from: transactionDate as Date)
+                    expect(transactionDictionary["purchaseDate"] as? String) == dateformatter.string(from: transactionDate as Date)
                 }
                 it ("is empty when there are no non subscription transactions") {
                     let mockCustomerInfo = try CustomerInfo(data: [

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/StoreProductDiscount+HybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/StoreProductDiscount+HybridAdditionsTests.swift
@@ -23,7 +23,7 @@ class StoreProductDiscountHybridAdditionsTests: QuickSpec {
                                                         numberOfPeriods: 3,
                                                         paymentMode: SKProductDiscount.PaymentMode.payAsYouGo,
                                                         type: .introductory)
-                let storeProductDiscount = StoreProductDiscount(sk1Discount: productDiscount)!
+                let storeProductDiscount = try XCTUnwrap(StoreProductDiscount(sk1Discount: productDiscount))
                 guard let receivedDictionary = storeProductDiscount.rc_dictionary as? [String: NSObject] else {
                     fatalError("received rc_dictionary is not in the right format")
                 }


### PR DESCRIPTION
renames `paymentDiscountForProductIdentifier` -> `promotionalOffer(for:)` to match iOS v4 APIs. 

I had this branch around for days and totally forgot to make a PR 😅 