### PR TITLE
add `Amazon` to iOS hybrid `Store`

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCEntitlementInfo+HybridAdditions.m
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RCEntitlementInfo+HybridAdditions.m
@@ -53,6 +53,8 @@
         case RCPromotional:
             jsonDict[@"store"] = @"PROMOTIONAL";
             break;
+        case RCAmazon:
+            jsonDict[@"store"] = @"AMAZON";
         case RCUnknownStore:
             jsonDict[@"store"] = @"UNKNOWN_STORE";
             break;


### PR DESCRIPTION
This PR adds `Amazon` to the `Store` dictionaries in both the iOS common hybrid SDKs.

### Motivation
Resolves [CF-653](https://revenuecats.atlassian.net/browse/CF-653).

### Description
#### iOS
- Added the `RCAmazon` value to the `RCEntitlementInfo.jsonDict`'s `store` value.

#### Android
No changes required since:
1. The [EntitlementInfoMapper automatically consumes](https://github.com/RevenueCat/purchases-hybrid-common/blob/ed689b6ad230a2e2c94faf87f5bf9eb7194c1f1e/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/EntitlementInfoMapper.kt#L17) changes to the Android SDK's `Store` enum.
2. The Android SDK [already has](https://github.com/RevenueCat/purchases-android/blob/e40aac4487aaf385ec26eeb843b0bc73a6b61140/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt#L150) the `Amazon` `Store` case.

### Testing
I wasn't able to find any tests around this behavior for either platform, am I missing them somewhere?