### PR TITLE
added missing method for auto-release

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -175,4 +175,9 @@ def carthage_archive
     # https://github.com/Carthage/Carthage/releases/0.38.0
     sh("./carthage.sh", "build", "--archive", "--platform", "iOS")
   end
+
+  def is_snapshot_version?(version_name)
+    version_name.end_with?("-SNAPSHOT")
+  end
+
 end


### PR DESCRIPTION
automatic release of 3.0.0 failed because it was missing the `is_snapshot_version?` method. Added now