### PR TITLE
Remove old intro_price_* fields and rename introPrice to intro_price

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -11,7 +11,7 @@ fun StoreProduct.map(): Map<String, Any?> =
         "price" to priceAmountMicros / 1_000_000.0,
         "price_string" to price,
         "currency_code" to priceCurrencyCode,
-        "introPrice" to mapIntroPrice(),
+        "intro_price" to mapIntroPrice(),
         "discounts" to null,
         "product_category" to mapProductCategory(),
         "product_type" to mapProductType()

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProduct+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProduct+HybridAdditions.swift
@@ -18,12 +18,6 @@ import StoreKit
             "description": self.localizedDescription,
             "discounts": NSNull(),
             "identifier": self.productIdentifier,
-            "intro_price": NSNull(),
-            "intro_price_cycles": NSNull(),
-            "intro_price_period": NSNull(),
-            "intro_price_period_number_of_units": NSNull(),
-            "intro_price_period_unit": NSNull(),
-            "intro_price_string": NSNull(),
             "introPrice": NSNull(),
             "price": self.price,
             "price_string": self.localizedPriceString,
@@ -34,12 +28,6 @@ import StoreKit
 
         if #available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *),
            let introductoryDiscount = self.introductoryDiscount {
-            dictionary["intro_price"] = introductoryDiscount.price
-            dictionary["intro_price_string"] = introductoryDiscount.localizedPriceString
-            dictionary["intro_price_period"] = StoreProduct.rc_normalized(subscriptionPeriod: introductoryDiscount.subscriptionPeriod)
-            dictionary["intro_price_period_unit"] = StoreProduct.rc_normalized(subscriptionPeriodUnit: introductoryDiscount.subscriptionPeriod.unit)
-            dictionary["intro_price_period_number_of_units"] = introductoryDiscount.subscriptionPeriod.value
-            dictionary["intro_price_cycles"] = introductoryDiscount.numberOfPeriods
             dictionary["introPrice"] = introductoryDiscount.rc_dictionary
         }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProduct+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProduct+HybridAdditions.swift
@@ -18,7 +18,7 @@ import StoreKit
             "description": self.localizedDescription,
             "discounts": NSNull(),
             "identifier": self.productIdentifier,
-            "introPrice": NSNull(),
+            "intro_price": NSNull(),
             "price": self.price,
             "price_string": self.localizedPriceString,
             "product_category": self.productCategoryString,
@@ -28,7 +28,7 @@ import StoreKit
 
         if #available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *),
            let introductoryDiscount = self.introductoryDiscount {
-            dictionary["introPrice"] = introductoryDiscount.rc_dictionary
+            dictionary["intro_price"] = introductoryDiscount.rc_dictionary
         }
 
         if #available(iOS 12.2, tvOS 12.2, macOS 10.14.4, *) {


### PR DESCRIPTION
We still had the introductory price information in the JSON root apart from having an `introPrice` object. I removed the old `intro_price_*` and migrated the `introPrice` to `intro_price` so old fields are snake case.

I also created https://revenuecats.atlassian.net/browse/CSDK-170 and https://revenuecats.atlassian.net/browse/CSDK-171 so we make the change in Flutter and Unity too