### PR TITLE
Added Integration Tests

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		57FFDE3B286A760E0089A57B /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFDE38286A75970089A57B /* Constants.swift */; };
 		57FFDE3F286A777D0089A57B /* StoreKitIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFDE3E286A777D0089A57B /* StoreKitIntegrationTests.swift */; };
 		57FFDE41286A77E30089A57B /* CommonFunctionality+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFDE40286A77E30089A57B /* CommonFunctionality+async.swift */; };
+		57FFDE46286B606A0089A57B /* XCTestCase+Expectations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD3D1842810A81F00A19EC6 /* XCTestCase+Expectations.swift */; };
 		B1C9A7EEA6961CC6DE22BCAD /* Pods_PurchasesHybridCommon_PurchasesHybridCommonTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E05FA8EACFF88F020CF8B9BB /* Pods_PurchasesHybridCommon_PurchasesHybridCommonTests.framework */; };
 		C5335FED2A63D9B5B628774F /* Pods_PurchasesHybridCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A3E4FAC475FE1D7EA890501 /* Pods_PurchasesHybridCommon.framework */; };
 		E54FA36E3E12B4802B29BC74 /* Pods_PurchasesHybridCommon_PurchasesHybridCommonIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73AF1F3DF376D2EA6B061FDB /* Pods_PurchasesHybridCommon_PurchasesHybridCommonIntegrationTests.framework */; };
@@ -130,6 +131,7 @@
 		4FAA49047A2AE8963CF73C94 /* Pods_ObjCAPITester.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ObjCAPITester.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		57AD0D7928733B0C000932FF /* NonSubscriptionTransaction+HybridAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NonSubscriptionTransaction+HybridAdditions.swift"; sourceTree = "<group>"; };
 		517430C4E8FC91A379B7BFE0 /* Pods-PurchasesHybridCommon-PurchasesHybridCommonIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommon-PurchasesHybridCommonIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommon-PurchasesHybridCommonIntegrationTests/Pods-PurchasesHybridCommon-PurchasesHybridCommonIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
+		57920F7A286B9B78000461A9 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		57FFDE16286A566D0089A57B /* PurchasesHybridCommonIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PurchasesHybridCommonIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		57FFDE18286A566D0089A57B /* BaseIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseIntegrationTests.swift; sourceTree = "<group>"; };
 		57FFDE28286A57580089A57B /* PurchasesHybridCommonIntegrationTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PurchasesHybridCommonIntegrationTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -310,6 +312,7 @@
 		57FFDE17286A566D0089A57B /* PurchasesHybridCommonIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
+				57920F7A286B9B78000461A9 /* __Snapshots__ */,
 				57FFDE18286A566D0089A57B /* BaseIntegrationTests.swift */,
 				57FFDE3E286A777D0089A57B /* StoreKitIntegrationTests.swift */,
 				57FFDE40286A77E30089A57B /* CommonFunctionality+async.swift */,
@@ -744,6 +747,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				57FFDE3F286A777D0089A57B /* StoreKitIntegrationTests.swift in Sources */,
+				57FFDE46286B606A0089A57B /* XCTestCase+Expectations.swift in Sources */,
 				57FFDE41286A77E30089A57B /* CommonFunctionality+async.swift in Sources */,
 				57FFDE19286A566D0089A57B /* BaseIntegrationTests.swift in Sources */,
 				57FFDE3B286A760E0089A57B /* Constants.swift in Sources */,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -267,7 +267,15 @@ import RevenueCat
 
     @objc(getCustomerInfoWithCompletionBlock:)
     static func customerInfo(completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        Purchases.shared.getCustomerInfo(completion: customerInfoCompletionBlock(from: completion))
+        Self.customerInfo(fetchPolicy: .default, completion: completion)
+    }
+
+    internal static func customerInfo(
+        fetchPolicy: CacheFetchPolicy,
+        completion: @escaping ([String: Any]?, ErrorContainer?) -> Void
+    ) {
+        Purchases.shared.getCustomerInfo(fetchPolicy: fetchPolicy,
+                                         completion: customerInfoCompletionBlock(from: completion))
     }
 
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CustomerInfo+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CustomerInfo+HybridAdditions.swift
@@ -31,7 +31,7 @@ import RevenueCat
             allPurchasesMillis[identifier] = purchaseDate?.rc_millisecondsSince1970AsDouble() ?? NSNull()
         }
 
-        let aDictionary: [String: Any] = [
+        return [
             "entitlements": entitlements.dictionary,
             "activeSubscriptions": Array(activeSubscriptions),
             "allPurchasedProductIdentifiers": Array(allPurchasedProductIdentifiers),
@@ -52,7 +52,6 @@ import RevenueCat
             "managementURL": managementURL?.absoluteString ?? NSNull(),
             "nonSubscriptionTransactions": nonSubscriptions.map { $0.dictionary },
         ]
-        return aDictionary
     }
 
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
@@ -7,6 +7,7 @@
 //
 
 @testable import RevenueCat
+import SnapshotTesting
 import XCTest
 
 class BaseIntegrationTests: XCTestCase {
@@ -25,7 +26,9 @@ class BaseIntegrationTests: XCTestCase {
         try await super.setUp()
 
         // Avoid continuing with potentially bad data after a failed assertion
-        self.continueAfterFailure = false
+        // Unless snapshots are being recorded, since we need to record the entire test
+        // instead of stopping after the first snapshot is created (which makes the test fail)
+        self.continueAfterFailure = isRecording
 
         guard Constants.apiKey != "REVENUECAT_API_KEY", Constants.proxyURL != "REVENUECAT_PROXY_URL" else {
             XCTFail("Must set configuration in `Constants.swift`")

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/CommonFunctionality+async.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/CommonFunctionality+async.swift
@@ -6,8 +6,7 @@
 //  Copyright © 2022 RevenueCat. All rights reserved.
 //
 
-import PurchasesHybridCommon
-
+@testable import PurchasesHybridCommon
 @testable import RevenueCat
 
 extension CommonFunctionality {
@@ -15,6 +14,51 @@ extension CommonFunctionality {
     static func offerings() async throws -> [String: Any] {
         return try await withCheckedThrowingContinuation { continuation in
             Self.getOfferings { dictionary, error in
+                continuation.resume(with: Result(dictionary, error?.error))
+            }
+        }
+    }
+
+    static func purchase(product productIdentifier: String,
+                         signedDiscountTimestamp: String?) async throws -> [String: Any] {
+        return try await withCheckedThrowingContinuation { continuation in
+            Self.purchase(product: productIdentifier, signedDiscountTimestamp: signedDiscountTimestamp) { dictionary, error in
+                continuation.resume(with: Result(dictionary, error?.error))
+            }
+        }
+    }
+
+    static func purchase(package packageIdentifier: String,
+                         offeringIdentifier: String,
+                         signedDiscountTimestamp: String?) async throws -> [String: Any] {
+        return try await withCheckedThrowingContinuation { continuation in
+            Self.purchase(package: packageIdentifier,
+                          offeringIdentifier: offeringIdentifier,
+                          signedDiscountTimestamp: signedDiscountTimestamp) { dictionary, error in
+                continuation.resume(with: Result(dictionary, error?.error))
+            }
+        }
+    }
+
+    static func customerInfo(fetchPolicy: CacheFetchPolicy = .default) async throws -> [String: Any] {
+        return try await withCheckedThrowingContinuation { continuation in
+            Self.customerInfo(fetchPolicy: fetchPolicy) { dictionary, error in
+                continuation.resume(with: Result(dictionary, error?.error))
+            }
+        }
+    }
+
+    static func logIn(appUserID: String) async throws -> [String: Any] {
+        return try await withCheckedThrowingContinuation { continuation in
+            Self.logIn(appUserID: appUserID) { dictionary, error in
+                continuation.resume(with: Result(dictionary, error?.error))
+            }
+        }
+    }
+
+    static func logOut() async throws -> [String: Any] {
+        return try await withCheckedThrowingContinuation { continuation in
+            Self.logOut { dictionary, error in
                 continuation.resume(with: Result(dictionary, error?.error))
             }
         }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/CommonFunctionality+async.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/CommonFunctionality+async.swift
@@ -64,4 +64,12 @@ extension CommonFunctionality {
         }
     }
 
+    static func restorePurchases() async throws -> [String: Any] {
+        return try await withCheckedThrowingContinuation { continuation in
+            Self.restorePurchases { dictionary, error in
+                continuation.resume(with: Result(dictionary, error?.error))
+            }
+        }
+    }
+
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
@@ -25,6 +25,11 @@ class StoreKit1IntegrationTests: BaseIntegrationTests {
 
     private var testSession: SKTestSession!
 
+    override class func setUp() {
+        // Uncomment this to re-record snapshots if necessary:
+        // isRecording = true
+    }
+
     override func setUp() async throws {
         try await super.setUp()
 
@@ -49,10 +54,48 @@ class StoreKit1IntegrationTests: BaseIntegrationTests {
         return .disabled
     }
 
+    func testCanGetOfferings() async throws {
+        let offerings = try await CommonFunctionality.offerings()
+
+        await self.assertSnapshot(offerings)
+    }
+
+    func testCanMakePurchase() async throws {
+        var data = try await self.purchaseMonthlyOffering()
+        removeDates(&data)
+
+        await self.assertSnapshot(data)
+    }
+
+    func testPurchaseFailuresAreReportedCorrectly() async throws {
+        self.testSession.failTransactionsEnabled = true
+        self.testSession.failureError = .invalidSignature
+
+        do {
+            try await self.purchaseMonthlyOffering()
+            fail("Expected error")
+        } catch {
+            expect(error).to(matchError(ErrorCode.invalidPromotionalOfferError))
+        }
+    }
+
+    func testLogInAndLogOut() async throws {
+        var customerInfo = try await CommonFunctionality.logIn(appUserID: UUID().uuidString)
+        removeDates(&customerInfo)
+        await self.assertSnapshot(customerInfo)
+
+        try await self.purchaseMonthlyOffering()
+
+        var loggedOutCustomerInfo = try await CommonFunctionality.logOut()
+        removeDates(&loggedOutCustomerInfo)
+        await self.assertSnapshot(loggedOutCustomerInfo)
+    }
+
 }
 
 private extension StoreKit1IntegrationTests {
 
+    @MainActor
     func assertSnapshot(
         _ value: Any,
         testName: String = #function,
@@ -69,6 +112,39 @@ private extension StoreKit1IntegrationTests {
 
 }
 
+private extension StoreKit1IntegrationTests {
+
+    static let entitlementIdentifier = "premium"
+
+    private var currentOffering: Offering {
+        get async throws {
+            return try await XCTAsyncUnwrap(try await Purchases.shared.offerings().current)
+        }
+    }
+
+    var monthlyPackage: Package {
+        get async throws {
+            return try await XCTAsyncUnwrap(try await self.currentOffering.monthly)
+        }
+    }
+
+
+    @discardableResult
+    func purchaseMonthlyOffering(
+        file: FileString = #file,
+        line: UInt = #line
+    ) async throws -> [String: Any] {
+        let package = try await self.monthlyPackage
+
+        return try await CommonFunctionality.purchase(
+            package: package.identifier,
+            offeringIdentifier: package.offeringIdentifier,
+            signedDiscountTimestamp: nil
+        )
+    }
+
+}
+
 private extension StoreKit2Setting {
 
     var testSuffix: String {
@@ -78,4 +154,38 @@ private extension StoreKit2Setting {
         }
     }
 
+}
+
+/// Remove dates from the given dictionary so they can be ignored from snapshot tests.
+private func removeDates(_ data: inout [String: Any]) {
+    func removeDatesFromAny(_ data: inout Any) {
+        guard var dictionary = data as? [String: Any] else {
+            return
+        }
+
+        removeDates(&dictionary)
+        data = dictionary
+    }
+
+    func shouldRemove(key: String, withValue value: Any?) -> Bool {
+        let keysToRemove: Set<String> = [
+            "millis",
+            "date",
+            "firstSeen",
+            "originalAppUserId"
+        ]
+
+        return (!keysToRemove.allSatisfy { !key.localizedCaseInsensitiveContains($0) } &&
+                value != nil &&
+                !(value is NSNull))
+    }
+
+    for var entry in data {
+        if shouldRemove(key: entry.key, withValue: entry.value) {
+            data.removeValue(forKey: entry.key)
+        } else {
+            removeDatesFromAny(&entry.value)
+            data[entry.key] = entry.value
+        }
+    }
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
@@ -80,6 +80,9 @@ class StoreKit1IntegrationTests: BaseIntegrationTests {
     }
 
     func testLogInAndLogOut() async throws {
+        // Fetch receipt to make sure there aren't race conditions
+        _ = try await CommonFunctionality.restorePurchases()
+
         var customerInfo = try await CommonFunctionality.logIn(appUserID: UUID().uuidString)
         removeDates(&customerInfo)
         await self.assertSnapshot(customerInfo)

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
@@ -80,7 +80,8 @@ class StoreKit1IntegrationTests: BaseIntegrationTests {
     }
 
     func testLogInAndLogOut() async throws {
-        // Fetch receipt to make sure there aren't race conditions
+        // Since the receipt might not be available on device on the first run,
+        // Fetch receipt to make sure there aren't race conditions dependent on the order of test runs.
         _ = try await CommonFunctionality.restorePurchases()
 
         var customerInfo = try await CommonFunctionality.logIn(appUserID: UUID().uuidString)

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanGetOfferings.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanGetOfferings.1.json
@@ -1,0 +1,224 @@
+{
+  "all" : {
+    "default" : {
+      "annual" : {
+        "identifier" : "$rc_annual",
+        "offeringIdentifier" : "default",
+        "packageType" : "ANNUAL",
+        "product" : {
+          "currency_code" : "USD",
+          "description" : "Annual Subscription with 1 week trial",
+          "discounts" : [
+
+          ],
+          "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
+          "intro_price" : {
+            "cycles" : 1,
+            "period" : "P1W",
+            "periodNumberOfUnits" : 1,
+            "periodUnit" : "WEEK",
+            "price" : 0,
+            "priceString" : "$0.00"
+          },
+          "price" : 39.99,
+          "price_string" : "$39.99",
+          "product_category" : "SUBSCRIPTION",
+          "product_type" : "NON_CONSUMABLE",
+          "title" : "Annual Subscription"
+        }
+      },
+      "availablePackages" : [
+        {
+          "identifier" : "$rc_annual",
+          "offeringIdentifier" : "default",
+          "packageType" : "ANNUAL",
+          "product" : {
+            "currency_code" : "USD",
+            "description" : "Annual Subscription with 1 week trial",
+            "discounts" : [
+
+            ],
+            "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
+            "intro_price" : {
+              "cycles" : 1,
+              "period" : "P1W",
+              "periodNumberOfUnits" : 1,
+              "periodUnit" : "WEEK",
+              "price" : 0,
+              "priceString" : "$0.00"
+            },
+            "price" : 39.99,
+            "price_string" : "$39.99",
+            "product_category" : "SUBSCRIPTION",
+            "product_type" : "NON_CONSUMABLE",
+            "title" : "Annual Subscription"
+          }
+        },
+        {
+          "identifier" : "$rc_monthly",
+          "offeringIdentifier" : "default",
+          "packageType" : "MONTHLY",
+          "product" : {
+            "currency_code" : "USD",
+            "description" : "Monthly Subscription with 1 week trial",
+            "discounts" : [
+
+            ],
+            "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+            "intro_price" : {
+              "cycles" : 1,
+              "period" : "P1W",
+              "periodNumberOfUnits" : 1,
+              "periodUnit" : "WEEK",
+              "price" : 0,
+              "priceString" : "$0.00"
+            },
+            "price" : 19.99,
+            "price_string" : "$19.99",
+            "product_category" : "SUBSCRIPTION",
+            "product_type" : "NON_CONSUMABLE",
+            "title" : "Monthly Subscription"
+          }
+        }
+      ],
+      "identifier" : "default",
+      "monthly" : {
+        "identifier" : "$rc_monthly",
+        "offeringIdentifier" : "default",
+        "packageType" : "MONTHLY",
+        "product" : {
+          "currency_code" : "USD",
+          "description" : "Monthly Subscription with 1 week trial",
+          "discounts" : [
+
+          ],
+          "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+          "intro_price" : {
+            "cycles" : 1,
+            "period" : "P1W",
+            "periodNumberOfUnits" : 1,
+            "periodUnit" : "WEEK",
+            "price" : 0,
+            "priceString" : "$0.00"
+          },
+          "price" : 19.99,
+          "price_string" : "$19.99",
+          "product_category" : "SUBSCRIPTION",
+          "product_type" : "NON_CONSUMABLE",
+          "title" : "Monthly Subscription"
+        }
+      },
+      "serverDescription" : "standard set of packages"
+    }
+  },
+  "current" : {
+    "annual" : {
+      "identifier" : "$rc_annual",
+      "offeringIdentifier" : "default",
+      "packageType" : "ANNUAL",
+      "product" : {
+        "currency_code" : "USD",
+        "description" : "Annual Subscription with 1 week trial",
+        "discounts" : [
+
+        ],
+        "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
+        "intro_price" : {
+          "cycles" : 1,
+          "period" : "P1W",
+          "periodNumberOfUnits" : 1,
+          "periodUnit" : "WEEK",
+          "price" : 0,
+          "priceString" : "$0.00"
+        },
+        "price" : 39.99,
+        "price_string" : "$39.99",
+        "product_category" : "SUBSCRIPTION",
+        "product_type" : "NON_CONSUMABLE",
+        "title" : "Annual Subscription"
+      }
+    },
+    "availablePackages" : [
+      {
+        "identifier" : "$rc_annual",
+        "offeringIdentifier" : "default",
+        "packageType" : "ANNUAL",
+        "product" : {
+          "currency_code" : "USD",
+          "description" : "Annual Subscription with 1 week trial",
+          "discounts" : [
+
+          ],
+          "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
+          "intro_price" : {
+            "cycles" : 1,
+            "period" : "P1W",
+            "periodNumberOfUnits" : 1,
+            "periodUnit" : "WEEK",
+            "price" : 0,
+            "priceString" : "$0.00"
+          },
+          "price" : 39.99,
+          "price_string" : "$39.99",
+          "product_category" : "SUBSCRIPTION",
+          "product_type" : "NON_CONSUMABLE",
+          "title" : "Annual Subscription"
+        }
+      },
+      {
+        "identifier" : "$rc_monthly",
+        "offeringIdentifier" : "default",
+        "packageType" : "MONTHLY",
+        "product" : {
+          "currency_code" : "USD",
+          "description" : "Monthly Subscription with 1 week trial",
+          "discounts" : [
+
+          ],
+          "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+          "intro_price" : {
+            "cycles" : 1,
+            "period" : "P1W",
+            "periodNumberOfUnits" : 1,
+            "periodUnit" : "WEEK",
+            "price" : 0,
+            "priceString" : "$0.00"
+          },
+          "price" : 19.99,
+          "price_string" : "$19.99",
+          "product_category" : "SUBSCRIPTION",
+          "product_type" : "NON_CONSUMABLE",
+          "title" : "Monthly Subscription"
+        }
+      }
+    ],
+    "identifier" : "default",
+    "monthly" : {
+      "identifier" : "$rc_monthly",
+      "offeringIdentifier" : "default",
+      "packageType" : "MONTHLY",
+      "product" : {
+        "currency_code" : "USD",
+        "description" : "Monthly Subscription with 1 week trial",
+        "discounts" : [
+
+        ],
+        "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+        "intro_price" : {
+          "cycles" : 1,
+          "period" : "P1W",
+          "periodNumberOfUnits" : 1,
+          "periodUnit" : "WEEK",
+          "price" : 0,
+          "priceString" : "$0.00"
+        },
+        "price" : 19.99,
+        "price_string" : "$19.99",
+        "product_category" : "SUBSCRIPTION",
+        "product_type" : "NON_CONSUMABLE",
+        "title" : "Monthly Subscription"
+      }
+    },
+    "serverDescription" : "standard set of packages"
+  }
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanMakePurchase.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanMakePurchase.1.json
@@ -1,0 +1,50 @@
+{
+  "customerInfo" : {
+    "activeSubscriptions" : [
+      "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro"
+    ],
+    "allPurchasedProductIdentifiers" : [
+      "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro"
+    ],
+    "entitlements" : {
+      "active" : {
+        "premium" : {
+          "billingIssueDetectedAt" : null,
+          "billingIssueDetectedAtMillis" : null,
+          "identifier" : "premium",
+          "isActive" : true,
+          "isSandbox" : true,
+          "ownershipType" : "PURCHASED",
+          "periodType" : "INTRO",
+          "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+          "store" : "APP_STORE",
+          "unsubscribedDetectedAt" : null,
+          "unsubscribedDetectedAtMillis" : null,
+          "willRenew" : true
+        }
+      },
+      "all" : {
+        "premium" : {
+          "billingIssueDetectedAt" : null,
+          "billingIssueDetectedAtMillis" : null,
+          "identifier" : "premium",
+          "isActive" : true,
+          "isSandbox" : true,
+          "ownershipType" : "PURCHASED",
+          "periodType" : "INTRO",
+          "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+          "store" : "APP_STORE",
+          "unsubscribedDetectedAt" : null,
+          "unsubscribedDetectedAtMillis" : null,
+          "willRenew" : true
+        }
+      }
+    },
+    "managementURL" : "https:\/\/apps.apple.com\/account\/subscriptions",
+    "nonSubscriptionTransactions" : [
+
+    ],
+    "originalApplicationVersion" : "1.0"
+  },
+  "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro"
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testLogInAndLogOut.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testLogInAndLogOut.1.json
@@ -1,0 +1,26 @@
+{
+  "created" : true,
+  "customerInfo" : {
+    "activeSubscriptions" : [
+
+    ],
+    "allPurchasedProductIdentifiers" : [
+
+    ],
+    "entitlements" : {
+      "active" : {
+
+      },
+      "all" : {
+
+      }
+    },
+    "latestExpirationDate" : null,
+    "latestExpirationDateMillis" : null,
+    "managementURL" : null,
+    "nonSubscriptionTransactions" : [
+
+    ],
+    "originalApplicationVersion" : "1.0"
+  }
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testLogInAndLogOut.2.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testLogInAndLogOut.2.json
@@ -1,0 +1,25 @@
+{
+  "activeSubscriptions" : [
+
+  ],
+  "allPurchasedProductIdentifiers" : [
+
+  ],
+  "entitlements" : {
+    "active" : {
+
+    },
+    "all" : {
+
+    }
+  },
+  "latestExpirationDate" : null,
+  "latestExpirationDateMillis" : null,
+  "managementURL" : null,
+  "nonSubscriptionTransactions" : [
+
+  ],
+  "originalApplicationVersion" : null,
+  "originalPurchaseDate" : null,
+  "originalPurchaseDateMillis" : null
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanGetOfferings.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanGetOfferings.1.json
@@ -1,0 +1,224 @@
+{
+  "all" : {
+    "default" : {
+      "annual" : {
+        "identifier" : "$rc_annual",
+        "offeringIdentifier" : "default",
+        "packageType" : "ANNUAL",
+        "product" : {
+          "currency_code" : "USD",
+          "description" : "Annual Subscription with 1 week trial",
+          "discounts" : [
+
+          ],
+          "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
+          "intro_price" : {
+            "cycles" : 1,
+            "period" : "P1W",
+            "periodNumberOfUnits" : 1,
+            "periodUnit" : "WEEK",
+            "price" : 0,
+            "priceString" : "$0.00"
+          },
+          "price" : 39.99,
+          "price_string" : "$39.99",
+          "product_category" : "SUBSCRIPTION",
+          "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+          "title" : "Annual Subscription"
+        }
+      },
+      "availablePackages" : [
+        {
+          "identifier" : "$rc_annual",
+          "offeringIdentifier" : "default",
+          "packageType" : "ANNUAL",
+          "product" : {
+            "currency_code" : "USD",
+            "description" : "Annual Subscription with 1 week trial",
+            "discounts" : [
+
+            ],
+            "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
+            "intro_price" : {
+              "cycles" : 1,
+              "period" : "P1W",
+              "periodNumberOfUnits" : 1,
+              "periodUnit" : "WEEK",
+              "price" : 0,
+              "priceString" : "$0.00"
+            },
+            "price" : 39.99,
+            "price_string" : "$39.99",
+            "product_category" : "SUBSCRIPTION",
+            "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+            "title" : "Annual Subscription"
+          }
+        },
+        {
+          "identifier" : "$rc_monthly",
+          "offeringIdentifier" : "default",
+          "packageType" : "MONTHLY",
+          "product" : {
+            "currency_code" : "USD",
+            "description" : "Monthly Subscription with 1 week trial",
+            "discounts" : [
+
+            ],
+            "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+            "intro_price" : {
+              "cycles" : 1,
+              "period" : "P1W",
+              "periodNumberOfUnits" : 1,
+              "periodUnit" : "WEEK",
+              "price" : 0,
+              "priceString" : "$0.00"
+            },
+            "price" : 19.99,
+            "price_string" : "$19.99",
+            "product_category" : "SUBSCRIPTION",
+            "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+            "title" : "Monthly Subscription"
+          }
+        }
+      ],
+      "identifier" : "default",
+      "monthly" : {
+        "identifier" : "$rc_monthly",
+        "offeringIdentifier" : "default",
+        "packageType" : "MONTHLY",
+        "product" : {
+          "currency_code" : "USD",
+          "description" : "Monthly Subscription with 1 week trial",
+          "discounts" : [
+
+          ],
+          "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+          "intro_price" : {
+            "cycles" : 1,
+            "period" : "P1W",
+            "periodNumberOfUnits" : 1,
+            "periodUnit" : "WEEK",
+            "price" : 0,
+            "priceString" : "$0.00"
+          },
+          "price" : 19.99,
+          "price_string" : "$19.99",
+          "product_category" : "SUBSCRIPTION",
+          "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+          "title" : "Monthly Subscription"
+        }
+      },
+      "serverDescription" : "standard set of packages"
+    }
+  },
+  "current" : {
+    "annual" : {
+      "identifier" : "$rc_annual",
+      "offeringIdentifier" : "default",
+      "packageType" : "ANNUAL",
+      "product" : {
+        "currency_code" : "USD",
+        "description" : "Annual Subscription with 1 week trial",
+        "discounts" : [
+
+        ],
+        "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
+        "intro_price" : {
+          "cycles" : 1,
+          "period" : "P1W",
+          "periodNumberOfUnits" : 1,
+          "periodUnit" : "WEEK",
+          "price" : 0,
+          "priceString" : "$0.00"
+        },
+        "price" : 39.99,
+        "price_string" : "$39.99",
+        "product_category" : "SUBSCRIPTION",
+        "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+        "title" : "Annual Subscription"
+      }
+    },
+    "availablePackages" : [
+      {
+        "identifier" : "$rc_annual",
+        "offeringIdentifier" : "default",
+        "packageType" : "ANNUAL",
+        "product" : {
+          "currency_code" : "USD",
+          "description" : "Annual Subscription with 1 week trial",
+          "discounts" : [
+
+          ],
+          "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
+          "intro_price" : {
+            "cycles" : 1,
+            "period" : "P1W",
+            "periodNumberOfUnits" : 1,
+            "periodUnit" : "WEEK",
+            "price" : 0,
+            "priceString" : "$0.00"
+          },
+          "price" : 39.99,
+          "price_string" : "$39.99",
+          "product_category" : "SUBSCRIPTION",
+          "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+          "title" : "Annual Subscription"
+        }
+      },
+      {
+        "identifier" : "$rc_monthly",
+        "offeringIdentifier" : "default",
+        "packageType" : "MONTHLY",
+        "product" : {
+          "currency_code" : "USD",
+          "description" : "Monthly Subscription with 1 week trial",
+          "discounts" : [
+
+          ],
+          "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+          "intro_price" : {
+            "cycles" : 1,
+            "period" : "P1W",
+            "periodNumberOfUnits" : 1,
+            "periodUnit" : "WEEK",
+            "price" : 0,
+            "priceString" : "$0.00"
+          },
+          "price" : 19.99,
+          "price_string" : "$19.99",
+          "product_category" : "SUBSCRIPTION",
+          "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+          "title" : "Monthly Subscription"
+        }
+      }
+    ],
+    "identifier" : "default",
+    "monthly" : {
+      "identifier" : "$rc_monthly",
+      "offeringIdentifier" : "default",
+      "packageType" : "MONTHLY",
+      "product" : {
+        "currency_code" : "USD",
+        "description" : "Monthly Subscription with 1 week trial",
+        "discounts" : [
+
+        ],
+        "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+        "intro_price" : {
+          "cycles" : 1,
+          "period" : "P1W",
+          "periodNumberOfUnits" : 1,
+          "periodUnit" : "WEEK",
+          "price" : 0,
+          "priceString" : "$0.00"
+        },
+        "price" : 19.99,
+        "price_string" : "$19.99",
+        "product_category" : "SUBSCRIPTION",
+        "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+        "title" : "Monthly Subscription"
+      }
+    },
+    "serverDescription" : "standard set of packages"
+  }
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanMakePurchase.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanMakePurchase.1.json
@@ -1,0 +1,50 @@
+{
+  "customerInfo" : {
+    "activeSubscriptions" : [
+      "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro"
+    ],
+    "allPurchasedProductIdentifiers" : [
+      "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro"
+    ],
+    "entitlements" : {
+      "active" : {
+        "premium" : {
+          "billingIssueDetectedAt" : null,
+          "billingIssueDetectedAtMillis" : null,
+          "identifier" : "premium",
+          "isActive" : true,
+          "isSandbox" : true,
+          "ownershipType" : "PURCHASED",
+          "periodType" : "INTRO",
+          "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+          "store" : "APP_STORE",
+          "unsubscribedDetectedAt" : null,
+          "unsubscribedDetectedAtMillis" : null,
+          "willRenew" : true
+        }
+      },
+      "all" : {
+        "premium" : {
+          "billingIssueDetectedAt" : null,
+          "billingIssueDetectedAtMillis" : null,
+          "identifier" : "premium",
+          "isActive" : true,
+          "isSandbox" : true,
+          "ownershipType" : "PURCHASED",
+          "periodType" : "INTRO",
+          "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+          "store" : "APP_STORE",
+          "unsubscribedDetectedAt" : null,
+          "unsubscribedDetectedAtMillis" : null,
+          "willRenew" : true
+        }
+      }
+    },
+    "managementURL" : "https:\/\/apps.apple.com\/account\/subscriptions",
+    "nonSubscriptionTransactions" : [
+
+    ],
+    "originalApplicationVersion" : "1.0"
+  },
+  "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro"
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testLogInAndLogOut.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testLogInAndLogOut.1.json
@@ -21,8 +21,6 @@
     "nonSubscriptionTransactions" : [
 
     ],
-    "originalApplicationVersion" : null,
-    "originalPurchaseDate" : null,
-    "originalPurchaseDateMillis" : null
+    "originalApplicationVersion" : "1.0"
   }
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testLogInAndLogOut.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testLogInAndLogOut.1.json
@@ -1,0 +1,28 @@
+{
+  "created" : true,
+  "customerInfo" : {
+    "activeSubscriptions" : [
+
+    ],
+    "allPurchasedProductIdentifiers" : [
+
+    ],
+    "entitlements" : {
+      "active" : {
+
+      },
+      "all" : {
+
+      }
+    },
+    "latestExpirationDate" : null,
+    "latestExpirationDateMillis" : null,
+    "managementURL" : null,
+    "nonSubscriptionTransactions" : [
+
+    ],
+    "originalApplicationVersion" : null,
+    "originalPurchaseDate" : null,
+    "originalPurchaseDateMillis" : null
+  }
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testLogInAndLogOut.2.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testLogInAndLogOut.2.json
@@ -1,0 +1,25 @@
+{
+  "activeSubscriptions" : [
+
+  ],
+  "allPurchasedProductIdentifiers" : [
+
+  ],
+  "entitlements" : {
+    "active" : {
+
+    },
+    "all" : {
+
+    }
+  },
+  "latestExpirationDate" : null,
+  "latestExpirationDateMillis" : null,
+  "managementURL" : null,
+  "nonSubscriptionTransactions" : [
+
+  ],
+  "originalApplicationVersion" : null,
+  "originalPurchaseDate" : null,
+  "originalPurchaseDateMillis" : null
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/XCTestCase+Expectations.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/XCTestCase+Expectations.swift
@@ -65,6 +65,24 @@ extension XCTestCase {
 
 }
 
+/// Similar to `XCTUnrap` but it allows an `async` closure.
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+func XCTAsyncUnwrap<T>(
+    _ expression: @autoclosure () async throws -> T?,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async throws -> T {
+    let value = try await expression()
+
+    return try XCTUnwrap(
+        value,
+        message(),
+        file: file,
+        line: line
+    )
+}
+
 private extension XCTestCase {
 
     func unreachable() -> Never {


### PR DESCRIPTION
Follow up to #157.
Fixes [CSDK-146].

### TODO:

- [x] Look into flaky login/logout test
- [x] Figure out incorrect SK1/SK2 `product_type`:
```diff
26c26
<           "product_type" : "NON_CONSUMABLE",
---
>           "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
53c53
```
_This is the reason: https://github.com/RevenueCat/purchases-ios/blob/main/Sources/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift#L36-L38_
- [x] Handle changing dates

[CSDK-146]: https://revenuecats.atlassian.net/browse/CSDK-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ