### PR TITLE
Fix checkTrialOrIntroDiscountEligibility map value

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -292,7 +292,7 @@ import RevenueCat
         completion: @escaping([String: Any]) -> Void) {
             Purchases.shared.checkTrialOrIntroDiscountEligibility(productIdentifiers: products) { eligibilityByProductId in
                 completion(eligibilityByProductId.mapValues { [
-                    "status": $0.status,
+                    "status": $0.status.rawValue,
                     "description": $0.description
                 ]
                 })


### PR DESCRIPTION
mapping `$0.status` was yielding the name of the enum instead of the value.
e.g.:
```
        - key : "status"
        - value : RevenueCat.IntroEligibilityStatus
```

instead of
```
        - key : "status"
        - value : 0
```
