### PR TITLE
add comment to clarify `canMakePayments` behavior on iOS

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -85,6 +85,8 @@ import RevenueCat
 #endif
 
     @objc public static func canMakePaymentsWithFeatures(_ features: [Int]) -> Bool {
+        // Features are for Google Play only, so we ignore them for iOS.
+        // See https://sdk.revenuecat.com/android/5.1.1/purchases/com.revenuecat.purchases/-purchases/-companion/can-make-payments.html
         return Purchases.canMakePayments()
     }
 


### PR DESCRIPTION
Added comment to clarify behavior of `canMakePayments` on iOS. 

On iOS, we ignore the `features` value passed in, because those are for Google Play only. 
But there's no reason a maintainer should know that when reading the code, so this adds a comment to explain what's going on. 