### PR TITLE
Add api tests for android code

### DIFF
--- a/android/src/test/java/apitests/java/CommonApiTests.java
+++ b/android/src/test/java/apitests/java/CommonApiTests.java
@@ -1,0 +1,149 @@
+package apitests.java;
+
+import android.app.Activity;
+import android.content.Context;
+
+import com.revenuecat.purchases.DangerousSettings;
+import com.revenuecat.purchases.LogHandler;
+import com.revenuecat.purchases.Store;
+import com.revenuecat.purchases.common.PlatformInfo;
+import com.revenuecat.purchases.hybridcommon.CommonKt;
+import com.revenuecat.purchases.hybridcommon.ErrorContainer;
+import com.revenuecat.purchases.hybridcommon.OnResult;
+import com.revenuecat.purchases.hybridcommon.OnResultAny;
+import com.revenuecat.purchases.hybridcommon.OnResultList;
+
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings({"unused", "deprecation"})
+class CommonApiTests {
+    private void checkCheckSetAllowSharingAppStoreAccount(Boolean enabled) {
+        CommonKt.setAllowSharingAppStoreAccount(enabled);
+    }
+
+    private void checkGetOfferings(OnResult onResult) {
+        CommonKt.getOfferings(onResult);
+    }
+
+    private void checkGetProductInfo(List<String> productIDs,
+                             String type,
+                             OnResultList onResult) {
+        CommonKt.getProductInfo(productIDs, type, onResult);
+    }
+
+    private void checkPurchaseProduct(Activity activity,
+                              String productIdentifier,
+                              String oldSku,
+                              Integer prorationMode,
+                              String type,
+                              OnResult onResult) {
+        CommonKt.purchaseProduct(
+                activity,
+                productIdentifier,
+                oldSku,
+                prorationMode,
+                type,
+                onResult
+        );
+    }
+
+    private void checkPurchasePackage(Activity activity,
+                              String packageIdentifier,
+                              String offeringIdentifier,
+                              String oldSku,
+                              Integer prorationMode,
+                              OnResult onResult) {
+        CommonKt.purchasePackage(
+                activity,
+                packageIdentifier,
+                offeringIdentifier,
+                oldSku,
+                prorationMode,
+                onResult
+        );
+    }
+
+    private void checkGetAppUserId() {
+        String appUserId = CommonKt.getAppUserID();
+    }
+
+    private void checkRestorePurchases(OnResult onResult) {
+        CommonKt.restorePurchases(onResult);
+    }
+
+    private void checkLogIn(String appUserId, OnResult onResult) {
+        CommonKt.logIn(appUserId, onResult);
+    }
+
+    private void checkLogOut(OnResult onResult) {
+        CommonKt.logOut(onResult);
+    }
+
+    private void checkSetDebugLogsEnabled(Boolean enabled) {
+        CommonKt.setDebugLogsEnabled(enabled);
+    }
+
+    private void checkSetLogHandler(LogHandler logHandler) {
+        CommonKt.setLogHandler(logHandler);
+    }
+
+    private void checkSetProxyURLString(String proxyUrlString) {
+        CommonKt.setProxyURLString(proxyUrlString);
+    }
+
+    private void checkGetProxyURLString() {
+        String proxyUrlString = CommonKt.getProxyURLString();
+    }
+
+    private void checkGetCustomerInfo(OnResult onResult) {
+        CommonKt.getCustomerInfo(onResult);
+    }
+
+    private void checkSyncPurchases() {
+        CommonKt.syncPurchases();
+    }
+
+    private void checkIsAnonymous() {
+        Boolean isAnonymous = CommonKt.isAnonymous();
+    }
+
+    private void checkSetFinishTransactions(Boolean enabled) {
+        CommonKt.setFinishTransactions(enabled);
+    }
+
+    private void checkCheckTrialOrIntroductoryPriceEligibility(List<String> productIdentifiers) {
+        Map<String, Map<String, Object>> result = CommonKt.checkTrialOrIntroductoryPriceEligibility(productIdentifiers);
+    }
+
+    private void checkInvalidateCustomerInfoCache() {
+        CommonKt.invalidateCustomerInfoCache();
+    }
+
+    private void checkCanMakePayments(Context context, List<Integer> features, OnResultAny<Boolean> onResult) {
+        CommonKt.canMakePayments(context, features, onResult);
+    }
+
+    private void checkConfigure(Context context,
+                                String apiKey,
+                                String appUserId,
+                                Boolean observerMode,
+                                PlatformInfo platformInfo,
+                                Store store,
+                                DangerousSettings dangerousSettings) {
+        CommonKt.configure(context, apiKey, appUserId, observerMode, platformInfo);
+        CommonKt.configure(context, apiKey, appUserId, observerMode, platformInfo, store);
+        CommonKt.configure(context, apiKey, appUserId, observerMode, platformInfo, store, dangerousSettings);
+    }
+
+    private void checkGetPromotionalOffer() {
+        ErrorContainer errorContainer = CommonKt.getPromotionalOffer();
+    }
+
+    private void checkErrorContainer(Integer code, String message, Map<String, Object> info) {
+        ErrorContainer errorContainer = new ErrorContainer(code, message, info);
+        Integer storedCode = errorContainer.getCode();
+        String storedMessage = errorContainer.getMessage();
+        Map<String, Object> storedAny = errorContainer.getInfo();
+    }
+}

--- a/android/src/test/java/apitests/java/CommonApiTests.java
+++ b/android/src/test/java/apitests/java/CommonApiTests.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 @SuppressWarnings({"unused", "deprecation"})
 class CommonApiTests {
-    private void checkCheckSetAllowSharingAppStoreAccount(Boolean enabled) {
+    private void checkCheckSetAllowSharingAppStoreAccount(boolean enabled) {
         CommonKt.setAllowSharingAppStoreAccount(enabled);
     }
 
@@ -80,7 +80,7 @@ class CommonApiTests {
         CommonKt.logOut(onResult);
     }
 
-    private void checkSetDebugLogsEnabled(Boolean enabled) {
+    private void checkSetDebugLogsEnabled(boolean enabled) {
         CommonKt.setDebugLogsEnabled(enabled);
     }
 
@@ -105,10 +105,10 @@ class CommonApiTests {
     }
 
     private void checkIsAnonymous() {
-        Boolean isAnonymous = CommonKt.isAnonymous();
+        boolean isAnonymous = CommonKt.isAnonymous();
     }
 
-    private void checkSetFinishTransactions(Boolean enabled) {
+    private void checkSetFinishTransactions(boolean enabled) {
         CommonKt.setFinishTransactions(enabled);
     }
 

--- a/android/src/test/java/apitests/java/OnResultAnyApiTests.java
+++ b/android/src/test/java/apitests/java/OnResultAnyApiTests.java
@@ -1,0 +1,17 @@
+package apitests.java;
+
+import com.revenuecat.purchases.hybridcommon.ErrorContainer;
+import com.revenuecat.purchases.hybridcommon.OnResultAny;
+
+@SuppressWarnings("unused")
+class OnResultAnyApiTests<T> {
+    private void checkOnSuccess(OnResultAny<T> onResult,
+                                T result) {
+        onResult.onReceived(result);
+    }
+
+    private void checkOnError(OnResultAny<T> onResult,
+                              ErrorContainer errorContainer) {
+        onResult.onError(errorContainer);
+    }
+}

--- a/android/src/test/java/apitests/java/OnResultApiTests.java
+++ b/android/src/test/java/apitests/java/OnResultApiTests.java
@@ -1,0 +1,19 @@
+package apitests.java;
+
+import com.revenuecat.purchases.hybridcommon.ErrorContainer;
+import com.revenuecat.purchases.hybridcommon.OnResult;
+
+import java.util.Map;
+
+@SuppressWarnings("unused")
+class OnResultApiTests {
+    private void checkOnSuccess(OnResult onResult,
+                                Map<String, Object> result) {
+        onResult.onReceived(result);
+    }
+
+    private void checkOnError(OnResult onResult,
+                              ErrorContainer errorContainer) {
+        onResult.onError(errorContainer);
+    }
+}

--- a/android/src/test/java/apitests/java/OnResultListApiTests.java
+++ b/android/src/test/java/apitests/java/OnResultListApiTests.java
@@ -1,0 +1,20 @@
+package apitests.java;
+
+import com.revenuecat.purchases.hybridcommon.ErrorContainer;
+import com.revenuecat.purchases.hybridcommon.OnResultList;
+
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("unused")
+class OnResultListApiTests {
+    private void checkOnSuccess(OnResultList onResult,
+                                List<Map<String, ?>> result) {
+        onResult.onReceived(result);
+    }
+
+    private void checkOnError(OnResultList onResult,
+                              ErrorContainer errorContainer) {
+        onResult.onError(errorContainer);
+    }
+}

--- a/android/src/test/java/apitests/java/SubscriberAttributesApiTests.java
+++ b/android/src/test/java/apitests/java/SubscriberAttributesApiTests.java
@@ -1,0 +1,90 @@
+package apitests.java;
+
+import com.revenuecat.purchases.hybridcommon.SubscriberAttributesKt;
+
+import java.util.Map;
+
+@SuppressWarnings("unused")
+class SubscriberAttributesApiTests {
+    // region Attribution IDs
+
+    private void checkCollectDeviceIdentifiers() {
+        SubscriberAttributesKt.collectDeviceIdentifiers();
+    }
+
+    private void checkSetAdjustID(String id) {
+        SubscriberAttributesKt.setAdjustID(id);
+    }
+
+    private void checkSetAppsflyerId(String id) {
+        SubscriberAttributesKt.setAppsflyerID(id);
+    }
+
+    private void checkSetFBAnonymousID(String id) {
+        SubscriberAttributesKt.setFBAnonymousID(id);
+    }
+
+    private void checkSetMparticleID(String id) {
+        SubscriberAttributesKt.setMparticleID(id);
+    }
+
+    private void checkSetOnesignalID(String id) {
+        SubscriberAttributesKt.setOnesignalID(id);
+    }
+
+    private void checkSetAirshipChannelID(String id) {
+        SubscriberAttributesKt.setAirshipChannelID(id);
+    }
+
+    // endregion
+    // region Campaign parameters
+
+    private void checkSetMediaSource(String mediaSource) {
+        SubscriberAttributesKt.setMediaSource(mediaSource);
+    }
+
+    private void checkSetCampaign(String campaign) {
+        SubscriberAttributesKt.setCampaign(campaign);
+    }
+
+    private void checkSetAdGroup(String adGroup) {
+        SubscriberAttributesKt.setAdGroup(adGroup);
+    }
+
+    private void checkSetAd(String ad) {
+        SubscriberAttributesKt.setAd(ad);
+    }
+
+    private void checkSetKeyword(String keyword) {
+        SubscriberAttributesKt.setKeyword(keyword);
+    }
+
+    private void checkSetCreative(String creative) {
+        SubscriberAttributesKt.setCreative(creative);
+    }
+
+    // endregion
+    // region subscriber attributes
+
+    private void checkSetAttributes(Map<String, String> attributes) {
+        SubscriberAttributesKt.setAttributes(attributes);
+    }
+
+    private void checkSetEmail(String email) {
+        SubscriberAttributesKt.setEmail(email);
+    }
+
+    private void checkSetPhoneNumber(String phoneNumber) {
+        SubscriberAttributesKt.setPhoneNumber(phoneNumber);
+    }
+
+    private void checkSetDisplayName(String displayName) {
+        SubscriberAttributesKt.setDisplayName(displayName);
+    }
+
+    private void checkSetPushToken(String pushToken) {
+        SubscriberAttributesKt.setPushToken(pushToken);
+    }
+
+    // endregion
+}

--- a/android/src/test/java/apitests/java/mappers/CustomerInfoMapperApiTests.java
+++ b/android/src/test/java/apitests/java/mappers/CustomerInfoMapperApiTests.java
@@ -1,0 +1,13 @@
+package apitests.java.mappers;
+
+import com.revenuecat.purchases.CustomerInfo;
+import com.revenuecat.purchases.hybridcommon.mappers.CustomerInfoMapperKt;
+
+import java.util.Map;
+
+@SuppressWarnings("unused")
+class CustomerInfoMapperApiTests {
+    private void checkMap(CustomerInfo customerInfo) {
+        Map<String, Object> map = CustomerInfoMapperKt.map(customerInfo);
+    }
+}

--- a/android/src/test/java/apitests/java/mappers/EntitlementInfoMapperApiTests.java
+++ b/android/src/test/java/apitests/java/mappers/EntitlementInfoMapperApiTests.java
@@ -1,0 +1,13 @@
+package apitests.java.mappers;
+
+import com.revenuecat.purchases.EntitlementInfo;
+import com.revenuecat.purchases.hybridcommon.mappers.EntitlementInfoMapperKt;
+
+import java.util.Map;
+
+@SuppressWarnings("unused")
+class EntitlementInfoMapperApiTests {
+    private void checkMap(EntitlementInfo entitlementInfo) {
+        Map<String, Object> map = EntitlementInfoMapperKt.map(entitlementInfo);
+    }
+}

--- a/android/src/test/java/apitests/java/mappers/EntitlementInfosMapperApiTests.java
+++ b/android/src/test/java/apitests/java/mappers/EntitlementInfosMapperApiTests.java
@@ -1,0 +1,13 @@
+package apitests.java.mappers;
+
+import com.revenuecat.purchases.EntitlementInfos;
+import com.revenuecat.purchases.hybridcommon.mappers.EntitlementInfosMapperKt;
+
+import java.util.Map;
+
+@SuppressWarnings("unused")
+class EntitlementInfosMapperApiTests {
+    private void checkMap(EntitlementInfos entitlementInfos) {
+        Map<String, Object> map = EntitlementInfosMapperKt.map(entitlementInfos);
+    }
+}

--- a/android/src/test/java/apitests/java/mappers/MapperHelpersApiTests.java
+++ b/android/src/test/java/apitests/java/mappers/MapperHelpersApiTests.java
@@ -1,0 +1,24 @@
+package apitests.java.mappers;
+
+import com.revenuecat.purchases.hybridcommon.mappers.MappersHelpersKt;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("unused")
+class MapperHelpersApiTests {
+    private void checkConvertToJson(Map<String, Object> map) {
+        JSONObject json = MappersHelpersKt.convertToJson(map);
+    }
+
+    private void checkConvertToJsonArray(List<Object> list) {
+        JSONArray jsonArray = MappersHelpersKt.convertToJsonArray(list);
+    }
+
+    private void checkConvertToMap(JSONObject json) {
+        Map<String, String> map = MappersHelpersKt.convertToMap(json);
+    }
+}

--- a/android/src/test/java/apitests/java/mappers/OfferingsMapperApiTests.java
+++ b/android/src/test/java/apitests/java/mappers/OfferingsMapperApiTests.java
@@ -1,0 +1,13 @@
+package apitests.java.mappers;
+
+import com.revenuecat.purchases.Offerings;
+import com.revenuecat.purchases.hybridcommon.mappers.OfferingsMapperKt;
+
+import java.util.Map;
+
+@SuppressWarnings("unused")
+class OfferingsMapperApiTests {
+    private void checkMap(Offerings offerings) {
+        Map<String, Object> map = OfferingsMapperKt.map(offerings);
+    }
+}

--- a/android/src/test/java/apitests/java/mappers/StoreProductMapperApiTests.java
+++ b/android/src/test/java/apitests/java/mappers/StoreProductMapperApiTests.java
@@ -1,0 +1,18 @@
+package apitests.java.mappers;
+
+import com.revenuecat.purchases.hybridcommon.mappers.StoreProductMapperKt;
+import com.revenuecat.purchases.models.StoreProduct;
+
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("unused")
+class StoreProductMapperApiTests {
+    private void checkItemMap(StoreProduct product) {
+        Map<String, Object> map = StoreProductMapperKt.map(product);
+    }
+
+    private void checkListMap(List<StoreProduct> products) {
+        List<Map<String, Object>> listOfMaps = StoreProductMapperKt.map(products);
+    }
+}

--- a/android/src/test/java/apitests/java/mappers/TransactionMapperApiTests.java
+++ b/android/src/test/java/apitests/java/mappers/TransactionMapperApiTests.java
@@ -1,0 +1,13 @@
+package apitests.java.mappers;
+
+import com.revenuecat.purchases.hybridcommon.mappers.TransactionMapperKt;
+import com.revenuecat.purchases.models.Transaction;
+
+import java.util.Map;
+
+@SuppressWarnings("unused")
+class TransactionMapperApiTests {
+    private void checkMap(Transaction transaction) {
+        Map<String, Object> map = TransactionMapperKt.map(transaction);
+    }
+}

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
@@ -1,0 +1,150 @@
+package apitests.kotlin.com.revenuecat.purchases.hybridcommon
+
+import android.app.Activity
+import android.content.Context
+import com.revenuecat.purchases.DangerousSettings
+import com.revenuecat.purchases.LogHandler
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.common.PlatformInfo
+import com.revenuecat.purchases.hybridcommon.*
+
+@Suppress("unused", "DEPRECATION", "LongParameterList", "UNUSED_VARIABLE")
+private class CommonApiTests {
+    fun checkSetAllowSharingAppStoreAccount(allow: Boolean) {
+        setAllowSharingAppStoreAccount(allow)
+    }
+
+    fun checkGetOfferings(onResult: OnResult) {
+        getOfferings(onResult)
+    }
+
+    fun checkGetProductInfo(
+        productIDs: List<String>,
+        type: String,
+        onResult: OnResultList
+    ) {
+        getProductInfo(productIDs, type, onResult)
+    }
+
+    fun checkPurchaseProduct(
+        activity: Activity?,
+        productIdentifier: String,
+        oldSku: String?,
+        prorationMode: Int?,
+        type: String,
+        onResult: OnResult
+    ) {
+        purchaseProduct(activity, productIdentifier, oldSku, prorationMode, type, onResult)
+    }
+
+    fun checkPurchasePackage(
+        activity: Activity?,
+        packageIdentifier: String,
+        offeringIdentifier: String,
+        oldSku: String?,
+        prorationMode: Int?,
+        onResult: OnResult
+    ) {
+        purchasePackage(
+            activity,
+            packageIdentifier,
+            offeringIdentifier,
+            oldSku,
+            prorationMode,
+            onResult
+        )
+    }
+
+    fun checkGetAppUserId() {
+        val appUserId: String = getAppUserID()
+    }
+
+    fun checkRestorePurchases(onResult: OnResult) {
+        restorePurchases(onResult)
+    }
+
+    fun checkLogIn(
+        appUserID: String,
+        onResult: OnResult
+    ) {
+        logIn(appUserID, onResult)
+    }
+
+    fun checkLogOut(onResult: OnResult) {
+        logOut(onResult)
+    }
+
+    fun checkSetDebugLogsEnabled(enabled: Boolean) {
+        setDebugLogsEnabled(enabled)
+    }
+
+    fun checkSetLogHandler(logHandler: LogHandler) {
+        setLogHandler(logHandler)
+    }
+
+    fun checkSetProxyURLString(proxyURLString: String?) {
+        setProxyURLString(proxyURLString)
+    }
+
+    fun checkGetProxyURLString() {
+        val proxyURLString: String? = getProxyURLString()
+    }
+
+    fun checkGetCustomerInfo(onResult: OnResult) {
+        getCustomerInfo(onResult)
+    }
+
+    fun checkSyncPurchases() {
+        syncPurchases()
+    }
+
+    fun checkIsAnonymous() {
+        val isAnonymous: Boolean = isAnonymous()
+    }
+
+    fun checkSetFinishTransactions(enabled: Boolean) {
+        setFinishTransactions(enabled)
+    }
+
+    fun checkCheckTrialOrIntroductoryPriceEligibility(productIdentifiers: List<String>) {
+        val result: Map<String, Map<String, Any>> = checkTrialOrIntroductoryPriceEligibility(
+            productIdentifiers
+        )
+    }
+
+    fun checkInvalidateCustomerInfoCache() {
+        invalidateCustomerInfoCache()
+    }
+
+    fun checkCanMakePayments(
+        context: Context,
+        features: List<Int>,
+        onResult: OnResultAny<Boolean>
+    ) {
+        canMakePayments(context, features, onResult)
+    }
+
+    fun checkConfigure(
+        context: Context,
+        apiKey: String,
+        appUserID: String?,
+        observerMode: Boolean?,
+        platformInfo: PlatformInfo,
+        store: Store,
+        dangerousSettings: DangerousSettings
+    ) {
+        configure(context, apiKey, appUserID, observerMode, platformInfo)
+        configure(context, apiKey, appUserID, observerMode, platformInfo, store, dangerousSettings)
+    }
+
+    fun checkGetPromotionalOffer() {
+        val errorContainer: ErrorContainer = getPromotionalOffer()
+    }
+
+    fun checkErrorContainer(code: Int, message: String, info: Map<String, Any?>) {
+        val errorContainer = ErrorContainer(code, message, info)
+        val storedCode = errorContainer.code
+        val storedMessage = errorContainer.message
+        val storedInfo = errorContainer.info
+    }
+}

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/OnResultAnyApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/OnResultAnyApiTests.kt
@@ -1,0 +1,21 @@
+package apitests.kotlin.com.revenuecat.purchases.hybridcommon
+
+import com.revenuecat.purchases.hybridcommon.ErrorContainer
+import com.revenuecat.purchases.hybridcommon.OnResultAny
+
+@Suppress("unused")
+private class OnResultAnyApiTests<T> {
+    fun checkOnSuccess(
+        onResult: OnResultAny<T>,
+        result: T
+    ) {
+        onResult.onReceived(result)
+    }
+
+    fun checkOnError(
+        onResult: OnResultAny<T>,
+        errorContainer: ErrorContainer
+    ) {
+        onResult.onError(errorContainer)
+    }
+}

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/OnResultApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/OnResultApiTests.kt
@@ -1,0 +1,21 @@
+package apitests.kotlin.com.revenuecat.purchases.hybridcommon
+
+import com.revenuecat.purchases.hybridcommon.ErrorContainer
+import com.revenuecat.purchases.hybridcommon.OnResult
+
+@Suppress("unused")
+private class OnResultApiTests {
+    fun checkOnReceived(
+        onResult: OnResult,
+        resultMap: Map<String, Any>
+    ) {
+        onResult.onReceived(resultMap)
+    }
+
+    fun checkOnError(
+        onResult: OnResult,
+        errorContainer: ErrorContainer
+    ) {
+        onResult.onError(errorContainer)
+    }
+}

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/OnResultListApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/OnResultListApiTests.kt
@@ -1,0 +1,21 @@
+package apitests.kotlin.com.revenuecat.purchases.hybridcommon
+
+import com.revenuecat.purchases.hybridcommon.ErrorContainer
+import com.revenuecat.purchases.hybridcommon.OnResultList
+
+@Suppress("unused")
+class OnResultListApiTests {
+    fun checkOnReceived(
+        onResult: OnResultList,
+        resultMap: List<Map<String, Any>>
+    ) {
+        onResult.onReceived(resultMap)
+    }
+
+    fun checkOnError(
+        onResult: OnResultList,
+        errorContainer: ErrorContainer
+    ) {
+        onResult.onError(errorContainer)
+    }
+}

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/SubscriberAttributesApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/SubscriberAttributesApiTests.kt
@@ -1,0 +1,89 @@
+package apitests.kotlin.com.revenuecat.purchases.hybridcommon
+
+import com.revenuecat.purchases.hybridcommon.*
+
+@Suppress("unused")
+private class SubscriberAttributesApiTests {
+
+    // region Attribution IDs
+
+    fun checkCollectDeviceIdentifiers() {
+        collectDeviceIdentifiers()
+    }
+
+    fun checkSetAdjustID(id: String?) {
+        setAdjustID(id)
+    }
+
+    fun checkSetAppsflyerID(id: String?) {
+        setAppsflyerID(id)
+    }
+
+    fun checkSetFBAnonymousID(id: String?) {
+        setFBAnonymousID(id)
+    }
+
+    fun checkSetMparticleID(id: String?) {
+        setMparticleID(id)
+    }
+
+    fun checkSetOnesignalID(id: String?) {
+        setOnesignalID(id)
+    }
+
+    fun checkSetAirshipChannelID(id: String?) {
+        setAirshipChannelID(id)
+    }
+
+    // endregion
+    // region Campaign parameters
+
+    fun checkSetMediaSource(mediaSource: String?) {
+        setMediaSource(mediaSource)
+    }
+
+    fun checkSetCampaign(campaign: String?) {
+        setCampaign(campaign)
+    }
+
+    fun checkSetAdGroup(adGroup: String?) {
+        setAdGroup(adGroup)
+    }
+
+    fun checkSetAd(ad: String?) {
+        setAd(ad)
+    }
+
+    fun checkSetKeyword(keyword: String?) {
+        setKeyword(keyword)
+    }
+
+    fun checkSetCreative(creative: String?) {
+        setCreative(creative)
+    }
+
+    // endregion
+    // region subscriber attributes
+
+    fun checkSetAttributes(attributes: Map<String, String?>) {
+        setAttributes(attributes)
+    }
+
+    fun checkSetEmail(email: String?) {
+        setEmail(email)
+    }
+
+    fun checkSetPhoneNumber(phoneNumber: String?) {
+        setPhoneNumber(phoneNumber)
+    }
+
+    fun checkSetDisplayName(displayName: String?) {
+        setDisplayName(displayName)
+    }
+
+    fun checkSetPushToken(fcmToken: String?) {
+        setPushToken(fcmToken)
+    }
+
+    // endregion
+}

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/CustomerInfoMapperApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/CustomerInfoMapperApiTests.kt
@@ -1,0 +1,11 @@
+package apitests.kotlin.com.revenuecat.purchases.hybridcommon.mappers
+
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.hybridcommon.mappers.map
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class CustomerInfoMapperApiTests {
+    fun checkMap(customerInfo: CustomerInfo) {
+        val map: Map<String, Any?> = customerInfo.map()
+    }
+}

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/EntitlementInfoMapperApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/EntitlementInfoMapperApiTests.kt
@@ -1,0 +1,11 @@
+package apitests.kotlin.com.revenuecat.purchases.hybridcommon.mappers
+
+import com.revenuecat.purchases.EntitlementInfo
+import com.revenuecat.purchases.hybridcommon.mappers.map
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class EntitlementInfoMapperApiTests {
+    fun checkMap(entitlementInfo: EntitlementInfo) {
+        val map: Map<String, Any?> = entitlementInfo.map()
+    }
+}

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/EntitlementInfosMapperApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/EntitlementInfosMapperApiTests.kt
@@ -1,0 +1,11 @@
+package apitests.kotlin.com.revenuecat.purchases.hybridcommon.mappers
+
+import com.revenuecat.purchases.EntitlementInfos
+import com.revenuecat.purchases.hybridcommon.mappers.map
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class EntitlementInfosMapperApiTests {
+    fun checkMap(entitlementInfos: EntitlementInfos) {
+        val map: Map<String, Any?> = entitlementInfos.map()
+    }
+}

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/MapperHelpersApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/MapperHelpersApiTests.kt
@@ -1,0 +1,22 @@
+package apitests.kotlin.com.revenuecat.purchases.hybridcommon.mappers
+
+import com.revenuecat.purchases.hybridcommon.mappers.convertToJson
+import com.revenuecat.purchases.hybridcommon.mappers.convertToJsonArray
+import com.revenuecat.purchases.hybridcommon.mappers.convertToMap
+import org.json.JSONArray
+import org.json.JSONObject
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class MapperHelpersApiTests {
+    fun checkConvertToJson(map: Map<String, *>) {
+        val json: JSONObject = map.convertToJson()
+    }
+
+    fun checkConvertToJsonArray(list: List<*>) {
+        val jsonArray: JSONArray = list.convertToJsonArray()
+    }
+
+    fun checkConvertToMap(json: JSONObject) {
+        val map: Map<String, String?> = json.convertToMap()
+    }
+}

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/OfferingsMapperApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/OfferingsMapperApiTests.kt
@@ -1,0 +1,11 @@
+package apitests.kotlin.com.revenuecat.purchases.hybridcommon.mappers
+
+import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.hybridcommon.mappers.map
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class OfferingsMapperApiTests {
+    fun checkMap(offerings: Offerings) {
+        val map: Map<String, Any?> = offerings.map()
+    }
+}

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperApiTests.kt
@@ -1,0 +1,15 @@
+package apitests.kotlin.com.revenuecat.purchases.hybridcommon.mappers
+
+import com.revenuecat.purchases.hybridcommon.mappers.map
+import com.revenuecat.purchases.models.StoreProduct
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class StoreProductMapperApiTests {
+    fun checkItemMap(product: StoreProduct) {
+        val map: Map<String, Any?> = product.map()
+    }
+
+    fun checkListMap(products: List<StoreProduct>) {
+        val listOfMaps: List<Map<String, Any?>> = products.map()
+    }
+}

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/TransactionMapperApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/mappers/TransactionMapperApiTests.kt
@@ -1,0 +1,11 @@
+package apitests.kotlin.com.revenuecat.purchases.hybridcommon.mappers
+
+import com.revenuecat.purchases.hybridcommon.mappers.map
+import com.revenuecat.purchases.models.Transaction
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class TransactionMapperApiTests {
+    fun checkMap(transaction: Transaction) {
+        val map: Map<String, Any?> = transaction.map()
+    }
+}


### PR DESCRIPTION
https://revenuecats.atlassian.net/browse/CSDK-140

As mentioned in the ticket, I added the API tests as part of the test suite of the module. While they are not unit tests, they will be compiled so we will catch any issues when running tests normally, so android api tests don't require any extra steps to run, just the usual `./gradlew lint test`.
