### PR TITLE
iOS Integration Tests: added test for `checkTrialOrIntroductoryPriceEligibility`

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/CommonFunctionality+async.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/CommonFunctionality+async.swift
@@ -72,4 +72,20 @@ extension CommonFunctionality {
         }
     }
 
+    static func syncPurchases() async throws -> [String: Any] {
+        return try await withCheckedThrowingContinuation { continuation in
+            Self.syncPurchases { dictionary, error in
+                continuation.resume(with: Result(dictionary, error?.error))
+            }
+        }
+    }
+
+    static func checkTrialOrIntroductoryPriceEligibility(for products: [String]) async -> [String: Any] {
+        return await withCheckedContinuation { continuation in
+            Self.checkTrialOrIntroductoryPriceEligibility(for: products) { dictionary in
+                continuation.resume(returning: dictionary)
+            }
+        }
+    }
+
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
@@ -95,6 +95,20 @@ class StoreKit1IntegrationTests: BaseIntegrationTests {
         await self.assertSnapshot(loggedOutCustomerInfo)
     }
 
+    func testTrialOrIntroductoryPriceEligibility() async throws {
+        if Self.storeKit2Setting == .disabled {
+            // SK1 implementation relies on the receipt being loaded already.
+            // See `TrialOrIntroPriceEligibilityChecker.sk1CheckEligibility`
+            _ = try await CommonFunctionality.restorePurchases()
+        }
+
+        let product = try await self.monthlyPackage.storeProduct
+
+        let result = await CommonFunctionality.checkTrialOrIntroductoryPriceEligibility(for: [product.productIdentifier])
+
+        await self.assertSnapshot(result)
+    }
+
 }
 
 private extension StoreKit1IntegrationTests {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testTrialOrIntroductoryPriceEligibility.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testTrialOrIntroductoryPriceEligibility.1.json
@@ -1,0 +1,6 @@
+{
+  "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro" : {
+    "description" : "Eligible for trial or introductory price.",
+    "status" : 2
+  }
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testTrialOrIntroductoryPriceEligibility.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testTrialOrIntroductoryPriceEligibility.1.json
@@ -1,0 +1,6 @@
+{
+  "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro" : {
+    "description" : "Eligible for trial or introductory price.",
+    "status" : 2
+  }
+}


### PR DESCRIPTION
This new test failed before #159.