### PR TITLE
`Podspec`: updated `RevenueCat` dependency to 4.6.1

### DIFF
--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.framework      = 'StoreKit'
 
-  s.dependency 'RevenueCat', '4.4.1'
+  s.dependency 'RevenueCat', '4.6.1'
   s.swift_version = '5.0'
 
   s.ios.deployment_target = '11.0'


### PR DESCRIPTION
Missed that this was repeated there when I did #155.

I can't think of a way to enforce that these remain up-to-date though.