### PR TITLE
Update command output timeout to 30m from default 10m for deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ jobs:
       - run:
           name: Deploy new version
           command: bundle exec fastlane ios release
+          no_output_timeout: 30m
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
During deploy we can encounter: `Too long with no output (exceeded 10m0s): context deadline exceeded`
This sets a timeout to 30m instead.