### PR TITLE
CircleCI: fixed `store_test_results`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,11 +63,9 @@ jobs:
           name: Run pod lint tests
           command: pod lib lint
       - store_test_results:
-          working_directory: ios/PurchasesHybridCommon
-          path: test_output
+          path: ios/PurchasesHybridCommon/test_output
       - store_artifacts:
-          working_directory: ios/PurchasesHybridCommon
-          path: test_output
+          path: ios/PurchasesHybridCommon/test_output
           destination: scan-output
 
   integration-test-ios:
@@ -88,11 +86,9 @@ jobs:
           environment:
             SCAN_SCHEME: PurchasesHybridCommonIntegrationTests
       - store_test_results:
-          working_directory: ios/PurchasesHybridCommon
-          path: test_output
+          path: ios/PurchasesHybridCommon/test_output
       - store_artifacts:
-          working_directory: ios/PurchasesHybridCommon
-          path: test_output
+          path: ios/PurchasesHybridCommon/test_output
           destination: scan-output
   
   deploy-ios:


### PR DESCRIPTION
`working_directory` didn't apply to the `path`. See https://app.circleci.com/pipelines/github/RevenueCat/purchases-hybrid-common/901/workflows/7207c2cb-f09f-4c34-86e3-f4e707333fd9/jobs/1906/parallel-runs/0/steps/0-105