### PR TITLE
iOS Integration Tests: retry on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           command: fastlane ios replace_api_key_integration_tests
       - run:
           name: Run ios tests
-          command: fastlane scan --result_bundle=true
+          command: fastlane scan --result_bundle=true --testplan=CI
           working_directory: ios/PurchasesHybridCommon
           environment:
             SCAN_SCHEME: PurchasesHybridCommonIntegrationTests

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
@@ -133,6 +133,8 @@
 		517430C4E8FC91A379B7BFE0 /* Pods-PurchasesHybridCommon-PurchasesHybridCommonIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommon-PurchasesHybridCommonIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommon-PurchasesHybridCommonIntegrationTests/Pods-PurchasesHybridCommon-PurchasesHybridCommonIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		57920F7A286B9B78000461A9 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		57AD0D7928733B0C000932FF /* NonSubscriptionTransaction+HybridAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NonSubscriptionTransaction+HybridAdditions.swift"; sourceTree = "<group>"; };
+		57E56F45288F103A00A4381B /* CI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = CI.xctestplan; sourceTree = "<group>"; };
+		57E56F4B288F10CF00A4381B /* Integration.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Integration.xctestplan; sourceTree = "<group>"; };
 		57FFDE16286A566D0089A57B /* PurchasesHybridCommonIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PurchasesHybridCommonIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		57FFDE18286A566D0089A57B /* BaseIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseIntegrationTests.swift; sourceTree = "<group>"; };
 		57FFDE28286A57580089A57B /* PurchasesHybridCommonIntegrationTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PurchasesHybridCommonIntegrationTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -312,10 +314,20 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		57E56F46288F104600A4381B /* Test Plans */ = {
+			isa = PBXGroup;
+			children = (
+				57E56F4B288F10CF00A4381B /* Integration.xctestplan */,
+				57E56F45288F103A00A4381B /* CI.xctestplan */,
+			);
+			path = "Test Plans";
+			sourceTree = "<group>";
+		};
 		57FFDE17286A566D0089A57B /* PurchasesHybridCommonIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
 				57920F7A286B9B78000461A9 /* __Snapshots__ */,
+				57E56F46288F104600A4381B /* Test Plans */,
 				57FFDE18286A566D0089A57B /* BaseIntegrationTests.swift */,
 				57FFDE3E286A777D0089A57B /* StoreKitIntegrationTests.swift */,
 				57FFDE40286A77E30089A57B /* CommonFunctionality+async.swift */,
@@ -438,7 +450,6 @@
 			);
 			dependencies = (
 				2D6E33262450F68C0022A971 /* PBXTargetDependency */,
-				B3105D7C287E3D6800CA935B /* PBXTargetDependency */,
 			);
 			name = PurchasesHybridCommonTests;
 			productName = PurchasesHybridCommonTests;

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/xcshareddata/xcschemes/PurchasesHybridCommonIntegrationTests.xcscheme
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/xcshareddata/xcschemes/PurchasesHybridCommonIntegrationTests.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1400"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -41,6 +41,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:PurchasesHybridCommonIntegrationTests/Test Plans/Integration.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:PurchasesHybridCommonIntegrationTests/Test Plans/CI.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/Test Plans/CI.xctestplan
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/Test Plans/CI.xctestplan
@@ -1,0 +1,27 @@
+{
+  "configurations" : [
+    {
+      "id" : "B7BDBD8A-9E95-4DFB-9CB2-924985986220",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "maximumTestExecutionTimeAllowance" : 180,
+    "testExecutionOrdering" : "random",
+    "testRepetitionMode" : "retryOnFailure",
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:PurchasesHybridCommon.xcodeproj",
+        "identifier" : "57FFDE15286A566D0089A57B",
+        "name" : "PurchasesHybridCommonIntegrationTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/Test Plans/Integration.xctestplan
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/Test Plans/Integration.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "B7BDBD8A-9E95-4DFB-9CB2-924985986220",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testExecutionOrdering" : "random"
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:PurchasesHybridCommon.xcodeproj",
+        "identifier" : "57FFDE15286A566D0089A57B",
+        "name" : "PurchasesHybridCommonIntegrationTests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
Equivalent to https://github.com/RevenueCat/purchases-ios/pull/1767
Also made the maximum execution time 3 minutes instead of the default 10.