### PR TITLE
iOS Integration Tests: compress `xcresult` so it can be downloaded

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,12 @@ jobs:
           working_directory: ios/PurchasesHybridCommon
           environment:
             SCAN_SCHEME: PurchasesHybridCommonIntegrationTests
+      - run:
+          name: Compress result bundle
+          command: |
+             tar -czf test_output/xcresult.tar.gz test_output/PurchasesHybridCommonIntegrationTests.xcresult && \
+             rm -r test_output/PurchasesHybridCommonIntegrationTests.xcresult
+          working_directory: ios/PurchasesHybridCommon
       - store_test_results:
           path: ios/PurchasesHybridCommon/test_output
       - store_artifacts:


### PR DESCRIPTION
Right now CircleCI shows every single file which is useless on its own to figure out why tests are failing: https://app.circleci.com/pipelines/github/RevenueCat/purchases-hybrid-common/953/workflows/decb5448-cc67-4934-88d9-a67f920d7f22/jobs/2081/artifacts

![Screenshot 2022-07-25 at 11 39 46](https://user-images.githubusercontent.com/685609/180850327-c6f7ce9b-7e87-44c6-a987-f81079be5751.png)

