### PR TITLE
Product serialization: fixed snake_case and camelCase serialization inconsistency

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -9,12 +9,12 @@ fun StoreProduct.map(): Map<String, Any?> =
         "description" to description,
         "title" to title,
         "price" to priceAmountMicros / 1_000_000.0,
-        "price_string" to price,
-        "currency_code" to priceCurrencyCode,
-        "intro_price" to mapIntroPrice(),
+        "priceString" to price,
+        "currencyCode" to priceCurrencyCode,
+        "introPrice" to mapIntroPrice(),
         "discounts" to null,
-        "product_category" to mapProductCategory(),
-        "product_type" to mapProductType()
+        "productCategory" to mapProductCategory(),
+        "productType" to mapProductType()
     )
 
 fun List<StoreProduct>.map(): List<Map<String, Any?>> = this.map { it.map() }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProduct+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/SKProduct+HybridAdditions.swift
@@ -14,21 +14,21 @@ import StoreKit
 
     @objc var rc_dictionary: [String: Any] {
         var dictionary: [String: Any] = [
-            "currency_code": self.currencyCode ?? NSNull(),
+            "currencyCode": self.currencyCode ?? NSNull(),
             "description": self.localizedDescription,
             "discounts": NSNull(),
             "identifier": self.productIdentifier,
-            "intro_price": NSNull(),
+            "introPrice": NSNull(),
             "price": self.price,
-            "price_string": self.localizedPriceString,
-            "product_category": self.productCategoryString,
-            "product_type": self.productTypeString,
+            "priceString": self.localizedPriceString,
+            "productCategory": self.productCategoryString,
+            "productType": self.productTypeString,
             "title": self.localizedTitle,
         ]
 
         if #available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *),
            let introductoryDiscount = self.introductoryDiscount {
-            dictionary["intro_price"] = introductoryDiscount.rc_dictionary
+            dictionary["introPrice"] = introductoryDiscount.rc_dictionary
         }
 
         if #available(iOS 12.2, tvOS 12.2, macOS 10.14.4, *) {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanGetOfferings.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanGetOfferings.1.json
@@ -6,13 +6,13 @@
         "offeringIdentifier" : "default",
         "packageType" : "ANNUAL",
         "product" : {
-          "currency_code" : "USD",
+          "currencyCode" : "USD",
           "description" : "Annual Subscription with 1 week trial",
           "discounts" : [
 
           ],
           "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
-          "intro_price" : {
+          "introPrice" : {
             "cycles" : 1,
             "period" : "P1W",
             "periodNumberOfUnits" : 1,
@@ -21,9 +21,9 @@
             "priceString" : "$0.00"
           },
           "price" : 39.99,
-          "price_string" : "$39.99",
-          "product_category" : "SUBSCRIPTION",
-          "product_type" : "NON_CONSUMABLE",
+          "priceString" : "$39.99",
+          "productCategory" : "SUBSCRIPTION",
+          "productType" : "NON_CONSUMABLE",
           "title" : "Annual Subscription"
         }
       },
@@ -33,13 +33,13 @@
           "offeringIdentifier" : "default",
           "packageType" : "ANNUAL",
           "product" : {
-            "currency_code" : "USD",
+            "currencyCode" : "USD",
             "description" : "Annual Subscription with 1 week trial",
             "discounts" : [
 
             ],
             "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
-            "intro_price" : {
+            "introPrice" : {
               "cycles" : 1,
               "period" : "P1W",
               "periodNumberOfUnits" : 1,
@@ -48,9 +48,9 @@
               "priceString" : "$0.00"
             },
             "price" : 39.99,
-            "price_string" : "$39.99",
-            "product_category" : "SUBSCRIPTION",
-            "product_type" : "NON_CONSUMABLE",
+            "priceString" : "$39.99",
+            "productCategory" : "SUBSCRIPTION",
+            "productType" : "NON_CONSUMABLE",
             "title" : "Annual Subscription"
           }
         },
@@ -59,13 +59,13 @@
           "offeringIdentifier" : "default",
           "packageType" : "MONTHLY",
           "product" : {
-            "currency_code" : "USD",
+            "currencyCode" : "USD",
             "description" : "Monthly Subscription with 1 week trial",
             "discounts" : [
 
             ],
             "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
-            "intro_price" : {
+            "introPrice" : {
               "cycles" : 1,
               "period" : "P1W",
               "periodNumberOfUnits" : 1,
@@ -74,9 +74,9 @@
               "priceString" : "$0.00"
             },
             "price" : 19.99,
-            "price_string" : "$19.99",
-            "product_category" : "SUBSCRIPTION",
-            "product_type" : "NON_CONSUMABLE",
+            "priceString" : "$19.99",
+            "productCategory" : "SUBSCRIPTION",
+            "productType" : "NON_CONSUMABLE",
             "title" : "Monthly Subscription"
           }
         }
@@ -87,13 +87,13 @@
         "offeringIdentifier" : "default",
         "packageType" : "MONTHLY",
         "product" : {
-          "currency_code" : "USD",
+          "currencyCode" : "USD",
           "description" : "Monthly Subscription with 1 week trial",
           "discounts" : [
 
           ],
           "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
-          "intro_price" : {
+          "introPrice" : {
             "cycles" : 1,
             "period" : "P1W",
             "periodNumberOfUnits" : 1,
@@ -102,9 +102,9 @@
             "priceString" : "$0.00"
           },
           "price" : 19.99,
-          "price_string" : "$19.99",
-          "product_category" : "SUBSCRIPTION",
-          "product_type" : "NON_CONSUMABLE",
+          "priceString" : "$19.99",
+          "productCategory" : "SUBSCRIPTION",
+          "productType" : "NON_CONSUMABLE",
           "title" : "Monthly Subscription"
         }
       },
@@ -117,13 +117,13 @@
       "offeringIdentifier" : "default",
       "packageType" : "ANNUAL",
       "product" : {
-        "currency_code" : "USD",
+        "currencyCode" : "USD",
         "description" : "Annual Subscription with 1 week trial",
         "discounts" : [
 
         ],
         "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
-        "intro_price" : {
+        "introPrice" : {
           "cycles" : 1,
           "period" : "P1W",
           "periodNumberOfUnits" : 1,
@@ -132,9 +132,9 @@
           "priceString" : "$0.00"
         },
         "price" : 39.99,
-        "price_string" : "$39.99",
-        "product_category" : "SUBSCRIPTION",
-        "product_type" : "NON_CONSUMABLE",
+        "priceString" : "$39.99",
+        "productCategory" : "SUBSCRIPTION",
+        "productType" : "NON_CONSUMABLE",
         "title" : "Annual Subscription"
       }
     },
@@ -144,13 +144,13 @@
         "offeringIdentifier" : "default",
         "packageType" : "ANNUAL",
         "product" : {
-          "currency_code" : "USD",
+          "currencyCode" : "USD",
           "description" : "Annual Subscription with 1 week trial",
           "discounts" : [
 
           ],
           "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
-          "intro_price" : {
+          "introPrice" : {
             "cycles" : 1,
             "period" : "P1W",
             "periodNumberOfUnits" : 1,
@@ -159,9 +159,9 @@
             "priceString" : "$0.00"
           },
           "price" : 39.99,
-          "price_string" : "$39.99",
-          "product_category" : "SUBSCRIPTION",
-          "product_type" : "NON_CONSUMABLE",
+          "priceString" : "$39.99",
+          "productCategory" : "SUBSCRIPTION",
+          "productType" : "NON_CONSUMABLE",
           "title" : "Annual Subscription"
         }
       },
@@ -170,13 +170,13 @@
         "offeringIdentifier" : "default",
         "packageType" : "MONTHLY",
         "product" : {
-          "currency_code" : "USD",
+          "currencyCode" : "USD",
           "description" : "Monthly Subscription with 1 week trial",
           "discounts" : [
 
           ],
           "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
-          "intro_price" : {
+          "introPrice" : {
             "cycles" : 1,
             "period" : "P1W",
             "periodNumberOfUnits" : 1,
@@ -185,9 +185,9 @@
             "priceString" : "$0.00"
           },
           "price" : 19.99,
-          "price_string" : "$19.99",
-          "product_category" : "SUBSCRIPTION",
-          "product_type" : "NON_CONSUMABLE",
+          "priceString" : "$19.99",
+          "productCategory" : "SUBSCRIPTION",
+          "productType" : "NON_CONSUMABLE",
           "title" : "Monthly Subscription"
         }
       }
@@ -198,13 +198,13 @@
       "offeringIdentifier" : "default",
       "packageType" : "MONTHLY",
       "product" : {
-        "currency_code" : "USD",
+        "currencyCode" : "USD",
         "description" : "Monthly Subscription with 1 week trial",
         "discounts" : [
 
         ],
         "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
-        "intro_price" : {
+        "introPrice" : {
           "cycles" : 1,
           "period" : "P1W",
           "periodNumberOfUnits" : 1,
@@ -213,9 +213,9 @@
           "priceString" : "$0.00"
         },
         "price" : 19.99,
-        "price_string" : "$19.99",
-        "product_category" : "SUBSCRIPTION",
-        "product_type" : "NON_CONSUMABLE",
+        "priceString" : "$19.99",
+        "productCategory" : "SUBSCRIPTION",
+        "productType" : "NON_CONSUMABLE",
         "title" : "Monthly Subscription"
       }
     },

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanGetOfferings.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanGetOfferings.1.json
@@ -6,13 +6,13 @@
         "offeringIdentifier" : "default",
         "packageType" : "ANNUAL",
         "product" : {
-          "currency_code" : "USD",
+          "currencyCode" : "USD",
           "description" : "Annual Subscription with 1 week trial",
           "discounts" : [
 
           ],
           "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
-          "intro_price" : {
+          "introPrice" : {
             "cycles" : 1,
             "period" : "P1W",
             "periodNumberOfUnits" : 1,
@@ -21,9 +21,9 @@
             "priceString" : "$0.00"
           },
           "price" : 39.99,
-          "price_string" : "$39.99",
-          "product_category" : "SUBSCRIPTION",
-          "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+          "priceString" : "$39.99",
+          "productCategory" : "SUBSCRIPTION",
+          "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
           "title" : "Annual Subscription"
         }
       },
@@ -33,13 +33,13 @@
           "offeringIdentifier" : "default",
           "packageType" : "ANNUAL",
           "product" : {
-            "currency_code" : "USD",
+            "currencyCode" : "USD",
             "description" : "Annual Subscription with 1 week trial",
             "discounts" : [
 
             ],
             "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
-            "intro_price" : {
+            "introPrice" : {
               "cycles" : 1,
               "period" : "P1W",
               "periodNumberOfUnits" : 1,
@@ -48,9 +48,9 @@
               "priceString" : "$0.00"
             },
             "price" : 39.99,
-            "price_string" : "$39.99",
-            "product_category" : "SUBSCRIPTION",
-            "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+            "priceString" : "$39.99",
+            "productCategory" : "SUBSCRIPTION",
+            "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
             "title" : "Annual Subscription"
           }
         },
@@ -59,13 +59,13 @@
           "offeringIdentifier" : "default",
           "packageType" : "MONTHLY",
           "product" : {
-            "currency_code" : "USD",
+            "currencyCode" : "USD",
             "description" : "Monthly Subscription with 1 week trial",
             "discounts" : [
 
             ],
             "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
-            "intro_price" : {
+            "introPrice" : {
               "cycles" : 1,
               "period" : "P1W",
               "periodNumberOfUnits" : 1,
@@ -74,9 +74,9 @@
               "priceString" : "$0.00"
             },
             "price" : 19.99,
-            "price_string" : "$19.99",
-            "product_category" : "SUBSCRIPTION",
-            "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+            "priceString" : "$19.99",
+            "productCategory" : "SUBSCRIPTION",
+            "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
             "title" : "Monthly Subscription"
           }
         }
@@ -87,13 +87,13 @@
         "offeringIdentifier" : "default",
         "packageType" : "MONTHLY",
         "product" : {
-          "currency_code" : "USD",
+          "currencyCode" : "USD",
           "description" : "Monthly Subscription with 1 week trial",
           "discounts" : [
 
           ],
           "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
-          "intro_price" : {
+          "introPrice" : {
             "cycles" : 1,
             "period" : "P1W",
             "periodNumberOfUnits" : 1,
@@ -102,9 +102,9 @@
             "priceString" : "$0.00"
           },
           "price" : 19.99,
-          "price_string" : "$19.99",
-          "product_category" : "SUBSCRIPTION",
-          "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+          "priceString" : "$19.99",
+          "productCategory" : "SUBSCRIPTION",
+          "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
           "title" : "Monthly Subscription"
         }
       },
@@ -117,13 +117,13 @@
       "offeringIdentifier" : "default",
       "packageType" : "ANNUAL",
       "product" : {
-        "currency_code" : "USD",
+        "currencyCode" : "USD",
         "description" : "Annual Subscription with 1 week trial",
         "discounts" : [
 
         ],
         "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
-        "intro_price" : {
+        "introPrice" : {
           "cycles" : 1,
           "period" : "P1W",
           "periodNumberOfUnits" : 1,
@@ -132,9 +132,9 @@
           "priceString" : "$0.00"
         },
         "price" : 39.99,
-        "price_string" : "$39.99",
-        "product_category" : "SUBSCRIPTION",
-        "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+        "priceString" : "$39.99",
+        "productCategory" : "SUBSCRIPTION",
+        "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
         "title" : "Annual Subscription"
       }
     },
@@ -144,13 +144,13 @@
         "offeringIdentifier" : "default",
         "packageType" : "ANNUAL",
         "product" : {
-          "currency_code" : "USD",
+          "currencyCode" : "USD",
           "description" : "Annual Subscription with 1 week trial",
           "discounts" : [
 
           ],
           "identifier" : "com.revenuecat.purchases_hybrid_common.annual_39.99_.1_week_intro",
-          "intro_price" : {
+          "introPrice" : {
             "cycles" : 1,
             "period" : "P1W",
             "periodNumberOfUnits" : 1,
@@ -159,9 +159,9 @@
             "priceString" : "$0.00"
           },
           "price" : 39.99,
-          "price_string" : "$39.99",
-          "product_category" : "SUBSCRIPTION",
-          "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+          "priceString" : "$39.99",
+          "productCategory" : "SUBSCRIPTION",
+          "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
           "title" : "Annual Subscription"
         }
       },
@@ -170,13 +170,13 @@
         "offeringIdentifier" : "default",
         "packageType" : "MONTHLY",
         "product" : {
-          "currency_code" : "USD",
+          "currencyCode" : "USD",
           "description" : "Monthly Subscription with 1 week trial",
           "discounts" : [
 
           ],
           "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
-          "intro_price" : {
+          "introPrice" : {
             "cycles" : 1,
             "period" : "P1W",
             "periodNumberOfUnits" : 1,
@@ -185,9 +185,9 @@
             "priceString" : "$0.00"
           },
           "price" : 19.99,
-          "price_string" : "$19.99",
-          "product_category" : "SUBSCRIPTION",
-          "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+          "priceString" : "$19.99",
+          "productCategory" : "SUBSCRIPTION",
+          "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
           "title" : "Monthly Subscription"
         }
       }
@@ -198,13 +198,13 @@
       "offeringIdentifier" : "default",
       "packageType" : "MONTHLY",
       "product" : {
-        "currency_code" : "USD",
+        "currencyCode" : "USD",
         "description" : "Monthly Subscription with 1 week trial",
         "discounts" : [
 
         ],
         "identifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
-        "intro_price" : {
+        "introPrice" : {
           "cycles" : 1,
           "period" : "P1W",
           "periodNumberOfUnits" : 1,
@@ -213,9 +213,9 @@
           "priceString" : "$0.00"
         },
         "price" : 19.99,
-        "price_string" : "$19.99",
-        "product_category" : "SUBSCRIPTION",
-        "product_type" : "AUTO_RENEWABLE_SUBSCRIPTION",
+        "priceString" : "$19.99",
+        "productCategory" : "SUBSCRIPTION",
+        "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
         "title" : "Monthly Subscription"
       }
     },


### PR DESCRIPTION
Pointed out by https://github.com/RevenueCat/react-native-purchases/issues/388
Using the major release in all the hybrids to fix this.