### PR TITLE
Adds .bundle and vendor to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ android/.composite-enable
 .gradle/
 
 fastlane/.env
+.bundle/
+vendor/


### PR DESCRIPTION
This run of the automatic-dependency-update job https://app.circleci.com/pipelines/github/RevenueCat/purchases-hybrid-common/1084/workflows/264faeb7-d99b-4ccc-b2f0-5b2a93a50d91/jobs/2493 failed because the git repository was dirty due to these folders created on bundle install