### PR TITLE
Update fastlane plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 086656f3a2cbf47ee2cdf9f6ee3cf6fb5d4275c0
+  revision: 078609b63c55ad91a674765e68937d805264a827
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,10 @@
-### Releasing a version: 
+### Releasing a version:
 
-1. Create a `fastlane/.env` file with your GitHub API token (see `fastlane/.env.SAMPLE`). This will be used to create the PR, so you should use your own token so the PR gets assigned to you. 
+1. Create a `fastlane/.env` file with your GitHub API token (see `fastlane/.env.SAMPLE`). This will be used to create the PR, so you should use your own token so the PR gets assigned to you.
 2. Run `bundle exec fastlane bump`
-    1. Input new version number
-    2. Update CHANGELOG.latest.md to include the latest changes. Call out API changes (if any). You can use the existing CHANGELOG.md as a base for formatting. To compile the changelog, you can compare the changes between the base branch for the release (usually main) against the latest release, by checking https://github.com/revenuecat/purchases-hybrid-common/compare/<latest_release>...<base_branch>. For example, https://github.com/revenuecat/purchases-hybrid-common/compare/3.3.0...main. 
-    3. A new branch and PR will automatically be created
+    1. Confirm base branch is correct
+    2. Input new version number
+    3. Update CHANGELOG.latest.md to include the latest changes. Call out API changes (if any). You can use the existing CHANGELOG.md as a base for formatting. To compile the changelog, you can compare the changes between the base branch for the release (usually main) against the latest release, by checking https://github.com/revenuecat/purchases-hybrid-common/compare/<latest_release>...<base_branch>. For example, https://github.com/revenuecat/purchases-hybrid-common/compare/3.3.0...main.
+    4. A new branch and PR will automatically be created
 3. Merge PR when approved
 4. Make a tag and push, the rest will be performed automatically by CircleCI. If the automation fails, you can revert to manually calling `bundle exec fastlane deploy`.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -39,7 +39,6 @@ lane :bump do |options|
     files_to_update_without_prerelease_modifiers: files_with_version_number_without_prerelease_modifiers,
     repo_name: repo_name,
     github_rate_limit: options[:github_rate_limit],
-    branch: options[:branch],
     editor: options[:editor]
   )
 end
@@ -64,11 +63,11 @@ end
 desc "Update dependencies to latest GitHub releases and opens a PR"
 lane :open_pr_upgrading_dependencies do |options|
   ensure_git_status_clean
-  
+
   dry_run = options[:dry_run]
-  
+
   new_versions = update_native_dependencies_to_latest
-  
+
   repo_status = sh("git status --porcelain")
 
   repo_clean = repo_status.empty?
@@ -94,9 +93,9 @@ lane :open_pr_upgrading_dependencies do |options|
     sh("git stash pop")
 
     UI.success("Git switched to branch `#{branch}, all good! 💪")
-  
+
     sh("git commit -am \"Upgrades versions\"")
-  
+
     push_to_git_remote(
       set_upstream: true,
       remote_branch: branch
@@ -116,7 +115,7 @@ desc "Update dependencies to latest GitHub releases"
 lane :update_native_dependencies_to_latest do |options|
   current_ios_version = parse_previous_ios_native_version
   latest_ios_release = get_latest_github_release_within_same_major(repo_name: "purchases-ios", current_version: current_ios_version)
-  
+
   current_android_version = parse_previous_android_native_version
   latest_android_release = get_latest_github_release_within_same_major(repo_name: "purchases-android", current_version: current_android_version)
 
@@ -143,8 +142,8 @@ private_lane :update_ios_native_version do |options|
   ]
 
   update_native_version(
-    platform_name: "iOS", 
-    new_version_number: new_version_number, 
+    platform_name: "iOS",
+    new_version_number: new_version_number,
     previous_version_number: previous_version_number,
     files_to_update: files_to_update
   )
@@ -159,8 +158,8 @@ private_lane :update_android_native_version do |options|
   ]
 
   update_native_version(
-    platform_name: "Android", 
-    new_version_number: new_version_number, 
+    platform_name: "Android",
+    new_version_number: new_version_number,
     previous_version_number: previous_version_number,
     files_to_update: files_to_update
   )
@@ -178,7 +177,7 @@ private_lane :update_native_version do |options|
   end
 
   previous_version_number = options[:previous_version_number]
-  
+
   if previous_version_number == new_version_number
     UI.message("ℹ️  #{platform_name} is already in its latest version: #{previous_version_number}")
     next previous_version_number
@@ -191,7 +190,7 @@ private_lane :update_native_version do |options|
     UI.message("ℹ️  Nothing more to do, dry_run: true")
   else
     replace_text_in_files(
-      previous_text: previous_version_number, 
+      previous_text: previous_version_number,
       new_text: new_version_number,
       paths_of_files_to_update: files_to_update
     )
@@ -219,12 +218,12 @@ platform :ios do
     folder = './ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/'
 
     replace_text_in_files(
-      previous_text: "REVENUECAT_API_KEY", 
+      previous_text: "REVENUECAT_API_KEY",
       new_text: ENV["REVENUECAT_API_KEY"],
       paths_of_files_to_update: ["#{folder}/Constants.swift"]
     )
     replace_text_in_files(
-      previous_text: "REVENUECAT_PROXY_URL", 
+      previous_text: "REVENUECAT_PROXY_URL",
       new_text: ENV["REVENUECAT_PROXY_URL"].to_s,
       paths_of_files_to_update: ["#{folder}/Constants.swift"],
       allow_empty: true
@@ -246,7 +245,7 @@ platform :android do
       "RELEASE_SIGNING_ENABLED" => true
     }
     UI.verbose("Deploying #{version}")
-    
+
     gradle(
       tasks: [
         "androidSourcesJar", "androidJavadocJar", "publish --no-daemon --no-parallel"
@@ -257,7 +256,7 @@ platform :android do
 
     UI.verbose("Creating special version for Unity IAP with BillingClient 3 and Amazon 2 for version: #{version}")
     gradleProperties["PUBLISH_VARIANT"] = "unityIAPRelease"
-    
+
     UI.verbose("Adding -unityiap to artifact ids")
 
     gradle(
@@ -267,7 +266,7 @@ platform :android do
       properties: gradleProperties,
       project_dir: 'android'
     )
-    
+
     unless is_snapshot_version?(version)
       gradle(
         tasks: [
@@ -304,14 +303,14 @@ def archive
   )
 
   # fastlane gym doesn't fully support .frameworks, so we need to look for the output
-  # in derived data manually. 
+  # in derived data manually.
   Dir.chdir("..") do
     output_framework_path = Dir["derived_data/**/#{framework_filename}"].first
     UI.error("framework not found!") if output_framework_path.nil?
 
     # compress using ditto because zip can cause issues with symlinks
-    sh("ditto", "-c", "-k", "--sequesterRsrc", "--keepParent", 
-      output_framework_path, 
+    sh("ditto", "-c", "-k", "--sequesterRsrc", "--keepParent",
+      output_framework_path,
       "#{framework_filename}.zip")
   end
 


### PR DESCRIPTION
### Description
This PR bumps the fastlane internal plugin to use the latest version. One of the changes is that we won't be validating the base branch automatically in the `bump` lane anymore. Instead, we will ask for confirmation from the user in a prompt: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/20