### PR TITLE
`open_pr_upgrading_dependencies`: set `label` to `build`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -119,6 +119,7 @@ lane :open_pr_upgrading_dependencies do |options|
       head: "#{branch}",
       base: "main",
       body: "Upgrade iOS to #{new_ios_version} and Android to #{new_android_version}",
+      labels: ["build"]
     )
   end
 end


### PR DESCRIPTION
See https://github.com/RevenueCat/purchases-hybrid-common/pull/207
We need to automatically add `build` as a label.