### PR TITLE
`IntegrationTests`: actually fail test if tests aren't configured

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
@@ -29,8 +29,7 @@ class BaseIntegrationTests: XCTestCase {
         self.continueAfterFailure = isRecording
 
         guard Constants.apiKey != "REVENUECAT_API_KEY", Constants.proxyURL != "REVENUECAT_PROXY_URL" else {
-            XCTFail("Must set configuration in `Constants.swift`")
-            throw ErrorCode.configurationError
+            throw ErrorUtils.configurationError(message: "Must set configuration in `Constants.swift`")
         }
 
         UserDefaults(suiteName: Constants.userDefaultsSuiteName)!


### PR DESCRIPTION
Looks like calling `XCTFail` followed by throwing an error was making the test continue for some reason, which was then making it crash instead because `Purchases.shared` isn't set.
By removing the `XCTFail`, `XCTest` now correctly sees this as a test failure and doesn't run the tests.