### PR TITLE
Replace build with dependencies on automatic upgrade PRs

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,5 +1,5 @@
 def fail_if_no_supported_label_found
-  supported_types = ["breaking", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test", "next_release"]
+  supported_types = ["breaking", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test", "next_release", "dependencies"]
 
   supported_labels_in_pr = supported_types & github.pr_labels
   no_supported_label = supported_labels_in_pr.empty?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -119,7 +119,7 @@ lane :open_pr_upgrading_dependencies do |options|
       head: "#{branch}",
       base: "main",
       body: "Upgrade iOS to #{new_ios_version} and Android to #{new_android_version}",
-      labels: ["build"]
+      labels: ["dependencies"]
     )
   end
 end


### PR DESCRIPTION
https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/27#discussion_r950498680

Changing PRs that update iOS/Android to be labelled with `dependencies` instead of `build`

[CSDK-425]

[CSDK-425]: https://revenuecats.atlassian.net/browse/CSDK-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ