### PR TITLE
Fix CircleCI caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,13 +173,13 @@ jobs:
     steps:
       - checkout
       - revenuecat/install-rubydocker-dependencies
-      - android/accept-licenses
-      - restore_cache:
-          key: jars-{{ checksum "android/build.gradle" }}
-      - android/restore-build-cache
-      - run:
-          name: Deployment
-          command: bundle exec fastlane android deploy
+      # - android/accept-licenses
+      # - restore_cache:
+          # key: jars-{{ checksum "android/build.gradle" }}
+      # - android/restore-build-cache
+      # - run:
+          # name: Deployment
+          # command: bundle exec fastlane android deploy
 
   make-github-release:
     docker:
@@ -258,8 +258,8 @@ workflows:
           <<: *release-branches
       - deploy-ios:
           <<: *release-tags
-      - deploy-android:
-          <<: *release-tags
+      - deploy-android
+          # <<: *release-tags
       - make-github-release:
           <<: *release-tags
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,13 +173,13 @@ jobs:
     steps:
       - checkout
       - revenuecat/install-rubydocker-dependencies
-      # - android/accept-licenses
-      # - restore_cache:
-          # key: jars-{{ checksum "android/build.gradle" }}
-      # - android/restore-build-cache
-      # - run:
-          # name: Deployment
-          # command: bundle exec fastlane android deploy
+      - android/accept-licenses
+      - restore_cache:
+          key: jars-{{ checksum "android/build.gradle" }}
+      - android/restore-build-cache
+      - run:
+          name: Deployment
+          command: bundle exec fastlane android deploy
 
   make-github-release:
     docker:
@@ -258,8 +258,8 @@ workflows:
           <<: *release-branches
       - deploy-ios:
           <<: *release-tags
-      - deploy-android
-          # <<: *release-tags
+      - deploy-android:
+          <<: *release-tags
       - make-github-release:
           <<: *release-tags
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,12 @@ commands:
   install-gems:
     steps:
       - restore_cache:
-          key: v2-gem-cache-{{ checksum "Gemfile.lock" }}
+          key: v3-gem-cache-{{ checksum "Gemfile.lock" }}
       - run: 
           name: Bundle install
           command: bundle install --clean --path vendor/bundle
       - save_cache:
-          key: v2-gem-cache-{{ checksum "Gemfile.lock" }}
+          key: v3-gem-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
       resource-class: large
     steps:
       - checkout
-      - install-gems
+      - revenuecat/install-rubydocker-dependencies
       - android/accept-licenses
       - restore_cache:
           key: jars-{{ checksum "android/build.gradle" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - install-gems
+      - revenuecat/install-rubydocker-dependencies
       - run:
           name: Make GitHub release for current version
           command: bundle exec fastlane github_release_current
@@ -202,7 +202,7 @@ jobs:
           at: .
       - setup-git-credentials
       - trust-github-key
-      - install-gems
+      - revenuecat/install-rubydocker-dependencies
       - run:
           name: Update dependencies to latest versions
           command: bundle exec fastlane open_pr_upgrading_dependencies


### PR DESCRIPTION
Looks like we had a couple of jobs running on ruby machines that were sharing Gem caches with other type of executors. This was causing permission issues.

Look at the `Restoring caches` step in https://app.circleci.com/pipelines/github/RevenueCat/purchases-hybrid-common/1183/workflows/daae7bec-2246-4a9a-ba84-5a933d32fabf/jobs/2884