### PR TITLE
Changed `MockPurchases` to use `PurchasesType`

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -13,10 +13,13 @@ import RevenueCat
 
 @objc(RCCommonFunctionality) public class CommonFunctionality: NSObject {
 
+    static var sharedInstance: PurchasesType!
+
     // MARK: properties and configuration
+
     @objc public static var simulatesAskToBuyInSandbox: Bool = false
-    @objc public static var appUserID: String { Purchases.shared.appUserID }
-    @objc public static var isAnonymous: Bool { Purchases.shared.isAnonymous }
+    @objc public static var appUserID: String { Self.sharedInstance.appUserID }
+    @objc public static var isAnonymous: Bool { Self.sharedInstance.isAnonymous }
 
     @objc public static var proxyURLString: String? {
         get { Purchases.proxyURL?.absoluteString }
@@ -55,7 +58,7 @@ import RevenueCat
 
     @available(*, deprecated, message: "Use the set<NetworkId> functions instead")
     @objc public static func setAllowSharingStoreAccount(_ allowSharingStoreAccount: Bool) {
-        Purchases.shared.allowSharingAppStoreAccount = allowSharingStoreAccount;
+        Self.sharedInstance.allowSharingAppStoreAccount = allowSharingStoreAccount
     }
 
     @objc public static func setDebugLogsEnabled(_ enabled: Bool) {
@@ -71,15 +74,15 @@ import RevenueCat
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     @objc public static func enableAdServicesAttributionTokenCollection() {
-        Purchases.shared.attribution.enableAdServicesAttributionTokenCollection()
+        Self.sharedInstance.attribution.enableAdServicesAttributionTokenCollection()
     }
 
     @objc public static func setFinishTransactions(_ finishTransactions: Bool) {
-        Purchases.shared.finishTransactions = finishTransactions
+        Self.sharedInstance.finishTransactions = finishTransactions
     }
 
     @objc public static func invalidateCustomerInfoCache() {
-        Purchases.shared.invalidateCustomerInfoCache()
+        Self.sharedInstance.invalidateCustomerInfoCache()
     }
 
 #if os(iOS)
@@ -89,7 +92,7 @@ import RevenueCat
     @available(watchOS, unavailable)
     @available(macCatalyst, unavailable)
     @objc public static func presentCodeRedemptionSheet() {
-        Purchases.shared.presentCodeRedemptionSheet()
+        Self.sharedInstance.presentCodeRedemptionSheet()
     }
 #endif
 
@@ -107,27 +110,27 @@ import RevenueCat
     @objc(restorePurchasesWithCompletionBlock:)
     static func restorePurchases(completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
         let customerInfoCompletion = customerInfoCompletionBlock(from: completion)
-        Purchases.shared.restorePurchases(completion: customerInfoCompletion)
+        Self.sharedInstance.restorePurchases(completion: customerInfoCompletion)
     }
 
     @objc(syncPurchasesWithCompletionBlock:)
     static func syncPurchases(completion: (([String: Any]?, ErrorContainer?) -> Void)?) {
         if let completion = completion {
             let customerInfoCompletion = customerInfoCompletionBlock(from: completion)
-            Purchases.shared.syncPurchases(completion: customerInfoCompletion)
+            Self.sharedInstance.syncPurchases(completion: customerInfoCompletion)
         } else {
-            Purchases.shared.syncPurchases(completion: nil)
+            Self.sharedInstance.syncPurchases(completion: nil)
         }
     }
 
     @objc(purchaseProduct:signedDiscountTimestamp:completionBlock:)
     static func purchase(product productIdentifier: String,
                          signedDiscountTimestamp: String?,
-                         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        let hybridCompletion: (StoreTransaction?,
-                               CustomerInfo?,
-                               Error?,
-                               Bool) -> Void = { transaction, customerInfo, error, userCancelled in
+                         completion: @Sendable @escaping ([String: Any]?, ErrorContainer?) -> Void) {
+        let hybridCompletion: @Sendable (StoreTransaction?,
+                                         CustomerInfo?,
+                                         Error?,
+                                         Bool) -> Void = { transaction, customerInfo, error, userCancelled in
             if let error = error {
                 completion(nil, ErrorContainer(error: error, extraPayload: ["userCancelled": userCancelled]))
             } else if let customerInfo = customerInfo,
@@ -157,7 +160,7 @@ import RevenueCat
                         completion(nil, productNotFoundError(description: "Couldn't find discount.", userCancelled: false))
                         return
                     }
-                    Purchases.shared.purchase(product: storeProduct,
+                    Self.sharedInstance.purchase(product: storeProduct,
                                               promotionalOffer: promotionalOffer,
                                               completion: hybridCompletion)
                     return
@@ -165,7 +168,7 @@ import RevenueCat
 
             }
 
-            Purchases.shared.purchase(product: storeProduct, completion: hybridCompletion)
+            Self.sharedInstance.purchase(product: storeProduct, completion: hybridCompletion)
         }
     }
 
@@ -174,10 +177,10 @@ import RevenueCat
                          offeringIdentifier: String,
                          signedDiscountTimestamp: String?,
                          completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        let hybridCompletion: (StoreTransaction?,
-                               CustomerInfo?,
-                               Error?,
-                               Bool) -> Void = { transaction, customerInfo, error, userCancelled in
+        let hybridCompletion: @Sendable (StoreTransaction?,
+                                         CustomerInfo?,
+                                         Error?,
+                                         Bool) -> Void = { transaction, customerInfo, error, userCancelled in
             if let error = error {
                 completion(nil, ErrorContainer(error: error, extraPayload: ["userCancelled": userCancelled]))
             } else if let customerInfo = customerInfo,
@@ -208,7 +211,7 @@ import RevenueCat
                         completion(nil, productNotFoundError(description: "Couldn't find discount.", userCancelled: false))
                         return
                     }
-                    Purchases.shared.purchase(package: package,
+                    Self.sharedInstance.purchase(package: package,
                                               promotionalOffer: promotionalOffer,
                                               completion: hybridCompletion)
                     return
@@ -216,7 +219,7 @@ import RevenueCat
 
             }
 
-            Purchases.shared.purchase(package: package, completion: hybridCompletion)
+            Self.sharedInstance.purchase(package: package, completion: hybridCompletion)
         }
 
     }
@@ -250,7 +253,7 @@ import RevenueCat
 
     @objc(logInWithAppUserID:completionBlock:)
     static func logIn(appUserID: String, completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        Purchases.shared.logIn(appUserID) { customerInfo, created, error in
+        Self.sharedInstance.logIn(appUserID) { customerInfo, created, error in
             if let error = error {
                 completion(nil, ErrorContainer(error: error, extraPayload: [:]))
             } else if let customerInfo = customerInfo {
@@ -270,7 +273,7 @@ import RevenueCat
 
     @objc(logOutWithCompletionBlock:)
     static func logOut(completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        Purchases.shared.logOut(completion: customerInfoCompletionBlock(from: completion))
+        Self.sharedInstance.logOut(completion: customerInfoCompletionBlock(from: completion))
     }
 
     @objc(getCustomerInfoWithCompletionBlock:)
@@ -282,7 +285,7 @@ import RevenueCat
         fetchPolicy: CacheFetchPolicy,
         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void
     ) {
-        Purchases.shared.getCustomerInfo(fetchPolicy: fetchPolicy,
+        Self.sharedInstance.getCustomerInfo(fetchPolicy: fetchPolicy,
                                          completion: customerInfoCompletionBlock(from: completion))
     }
 
@@ -293,7 +296,7 @@ import RevenueCat
 
     @objc(getOfferingsWithCompletionBlock:)
     static func getOfferings(completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        Purchases.shared.getOfferings { offerings, error in
+        Self.sharedInstance.getOfferings { offerings, error in
             if let error = error {
                 let errorContainer = ErrorContainer(error: error, extraPayload: [:])
                 completion(nil, errorContainer)
@@ -308,7 +311,7 @@ import RevenueCat
     static func checkTrialOrIntroductoryPriceEligibility(
         for products: [String],
         completion: @escaping([String: Any]) -> Void) {
-            Purchases.shared.checkTrialOrIntroDiscountEligibility(productIdentifiers: products) { eligibilityByProductId in
+            Self.sharedInstance.checkTrialOrIntroDiscountEligibility(productIdentifiers: products) { eligibilityByProductId in
                 completion(eligibilityByProductId.mapValues { [
                     "status": $0.status.rawValue,
                     "description": $0.description
@@ -319,7 +322,7 @@ import RevenueCat
 
 
     @objc static func getProductInfo(_ productIds: [String], completionBlock: @escaping([[String: Any]]) -> Void) {
-        Purchases.shared.getProducts(productIds) { products in
+        Self.sharedInstance.getProducts(productIds) { products in
             let productDictionaries = products
                 .map { $0.rc_dictionary }
             completionBlock(productDictionaries)
@@ -363,7 +366,7 @@ import RevenueCat
                 completion(promotionalOffer.rc_dictionary, nil)
             }
 
-            Purchases.shared.getPromotionalOffer(forProductDiscount: discountToUse,
+            Self.sharedInstance.getPromotionalOffer(forProductDiscount: discountToUse,
                                                  product: storeProduct,
                                                  completion: promotionalOfferCompletion)
         }
@@ -375,23 +378,23 @@ import RevenueCat
 @objc public extension CommonFunctionality {
 
     @objc static func setAttributes(_ attributes: [String: Any]) {
-        Purchases.shared.attribution.setAttributes(attributes.mapValues { $0 as? String ?? "" })
+        Self.sharedInstance.attribution.setAttributes(attributes.mapValues { $0 as? String ?? "" })
     }
 
     @objc static func setEmail(_ email: String?) {
-        Purchases.shared.attribution.setEmail(email)
+        Self.sharedInstance.attribution.setEmail(email)
     }
 
     @objc static func setPhoneNumber(_ phoneNumber: String?) {
-        Purchases.shared.attribution.setPhoneNumber(phoneNumber)
+        Self.sharedInstance.attribution.setPhoneNumber(phoneNumber)
     }
 
     @objc static func setDisplayName(_ displayName: String?) {
-        Purchases.shared.attribution.setDisplayName(displayName)
+        Self.sharedInstance.attribution.setDisplayName(displayName)
     }
 
     @objc static func setPushToken(_ pushToken: String?) {
-         Purchases.shared.attribution.setPushTokenString(pushToken)
+         Self.sharedInstance.attribution.setPushTokenString(pushToken)
     }
 
 }
@@ -400,34 +403,34 @@ import RevenueCat
 @objc public extension CommonFunctionality {
 
     @objc static func collectDeviceIdentifiers() {
-        Purchases.shared.attribution.collectDeviceIdentifiers()
+        Self.sharedInstance.attribution.collectDeviceIdentifiers()
     }
     @objc static func setAdjustID(_ adjustID: String?) {
-        Purchases.shared.attribution.setAdjustID(adjustID)
+        Self.sharedInstance.attribution.setAdjustID(adjustID)
     }
     @objc static func setCleverTapID(_ cleverTapID: String?) {
-        Purchases.shared.attribution.setCleverTapID(cleverTapID)
+        Self.sharedInstance.attribution.setCleverTapID(cleverTapID)
     }
     @objc static func setAppsflyerID(_ appsflyerID: String?) {
-        Purchases.shared.attribution.setAppsflyerID(appsflyerID)
+        Self.sharedInstance.attribution.setAppsflyerID(appsflyerID)
     }
     @objc static func setFBAnonymousID(_ fbAnonymousID: String?) {
-        Purchases.shared.attribution.setFBAnonymousID(fbAnonymousID)
+        Self.sharedInstance.attribution.setFBAnonymousID(fbAnonymousID)
     }
     @objc static func setMparticleID(_ mParticleID: String?) {
-        Purchases.shared.attribution.setMparticleID(mParticleID)
+        Self.sharedInstance.attribution.setMparticleID(mParticleID)
     }
     @objc static func setMixpanelDistinctID(_ mixpanelDistinctID: String?) {
-        Purchases.shared.attribution.setMixpanelDistinctID(mixpanelDistinctID)
+        Self.sharedInstance.attribution.setMixpanelDistinctID(mixpanelDistinctID)
     }
     @objc static func setFirebaseAppInstanceID(_ firebaseAppInstanceID: String?) {
-        Purchases.shared.attribution.setFirebaseAppInstanceID(firebaseAppInstanceID)
+        Self.sharedInstance.attribution.setFirebaseAppInstanceID(firebaseAppInstanceID)
     }
     @objc static func setOnesignalID(_ onesignalID: String?) {
-        Purchases.shared.attribution.setOnesignalID(onesignalID)
+        Self.sharedInstance.attribution.setOnesignalID(onesignalID)
     }
     @objc static func setAirshipChannelID(_ airshipChannelID: String?) {
-        Purchases.shared.attribution.setAirshipChannelID(airshipChannelID)
+        Self.sharedInstance.attribution.setAirshipChannelID(airshipChannelID)
     }
 
 }
@@ -436,22 +439,22 @@ import RevenueCat
 @objc public extension CommonFunctionality {
 
     @objc static func setMediaSource(_ mediaSource: String?) {
-        Purchases.shared.attribution.setMediaSource(mediaSource)
+        Self.sharedInstance.attribution.setMediaSource(mediaSource)
     }
     @objc static func setCampaign(_ campaign: String?) {
-        Purchases.shared.attribution.setCampaign(campaign)
+        Self.sharedInstance.attribution.setCampaign(campaign)
     }
     @objc static func setAdGroup(_ adGroup: String?) {
-        Purchases.shared.attribution.setAdGroup(adGroup)
+        Self.sharedInstance.attribution.setAdGroup(adGroup)
     }
     @objc static func setAd(_ ad: String?) {
-        Purchases.shared.attribution.setAd(ad)
+        Self.sharedInstance.attribution.setAd(ad)
     }
     @objc static func setKeyword(_ keyword: String?) {
-        Purchases.shared.attribution.setKeyword(keyword)
+        Self.sharedInstance.attribution.setKeyword(keyword)
     }
     @objc static func setCreative(_ creative: String?) {
-        Purchases.shared.attribution.setCreative(creative)
+        Self.sharedInstance.attribution.setCreative(creative)
     }
 
 }
@@ -478,7 +481,7 @@ private extension CommonFunctionality {
     }
 
     static func product(with identifier: String, completion: @escaping (StoreProduct?) -> Void) {
-        Purchases.shared.getProducts([identifier]) { products in
+        Self.sharedInstance.getProducts([identifier]) { products in
             completion(products.first { $0.productIdentifier == identifier })
         }
     }
@@ -498,7 +501,7 @@ private extension CommonFunctionality {
     static func package(withIdentifier packageIdentifier: String,
                         offeringIdentifier: String,
                         completion: @escaping(Package?) -> Void) {
-        Purchases.shared.getOfferings { offerings, error in
+        Self.sharedInstance.getOfferings { offerings, error in
             let offering = offerings?.offering(identifier: offeringIdentifier)
             let package = offering?.package(identifier: packageIdentifier)
             completion(package)

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
@@ -46,7 +46,10 @@ import RevenueCat
             configurationBuilder = configurationBuilder.with(platformInfo: platformInfo)
         }
 
-        return self.configure(with: configurationBuilder.build())
+        let purchases = self.configure(with: configurationBuilder.build())
+        CommonFunctionality.sharedInstance = purchases
+
+        return purchases
     }
 
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
@@ -108,7 +108,7 @@ final class MockPurchases: PurchasesType {
     var invokedProductsParametersList: [(productIdentifiers: [String], completion: ([StoreProduct]) -> ())] = []
 
     func getProducts(_ productIdentifiers: [String],
-                              completion: @escaping ([StoreProduct]) -> ()) {
+                     completion: @escaping ([StoreProduct]) -> ()) {
         invokedProducts = true
         invokedProductsCount += 1
         invokedProductsParameters = (productIdentifiers, completion)
@@ -135,7 +135,7 @@ final class MockPurchases: PurchasesType {
                                                  completion: PurchaseCompletedBlock)]()
 
     func purchase(package: Package,
-                           completion: @escaping PurchaseCompletedBlock) {
+                  completion: @escaping PurchaseCompletedBlock) {
         invokedPurchasePackage = true
         invokedPurchasePackageCount += 1
         invokedPurchasePackageParameters = (package, completion)
@@ -176,7 +176,7 @@ final class MockPurchases: PurchasesType {
         receiveEligibility: ([String : IntroEligibility]) -> Void)]()
 
     func checkTrialOrIntroDiscountEligibility(productIdentifiers: [String],
-                                                       completion receiveEligibility: @escaping ([String : IntroEligibility]) -> Void) {
+                                              completion receiveEligibility: @escaping ([String : IntroEligibility]) -> Void) {
         invokedCheckTrialOrIntroductoryPriceEligibility = true
         invokedCheckTrialOrIntroductoryPriceEligibilityCount += 1
         invokedCheckTrialOrIntroductoryPriceEligibilityParameters = (
@@ -197,8 +197,8 @@ final class MockPurchases: PurchasesType {
         completion: (PromotionalOffer?, PublicError?) -> Void)]()
 
     func getPromotionalOffer(forProductDiscount discount: StoreProductDiscount,
-                                      product: StoreProduct,
-                                      completion: @escaping ((PromotionalOffer?, PublicError?) -> Void)) {
+                             product: StoreProduct,
+                             completion: @escaping ((PromotionalOffer?, PublicError?) -> Void)) {
         invokedGetPromotionalOffer = true
         invokedGetPromotionalOfferCount += 1
         invokedGetPromotionalOfferParameters = (discount, product, completion)
@@ -216,8 +216,8 @@ final class MockPurchases: PurchasesType {
                                                                      completion: PurchaseCompletedBlock)]()
 
     func purchase(product: StoreProduct,
-                           promotionalOffer: PromotionalOffer,
-                           completion: @escaping PurchaseCompletedBlock) {
+                  promotionalOffer: PromotionalOffer,
+                  completion: @escaping PurchaseCompletedBlock) {
         invokedPurchaseProductWithPromotionalOffer = true
         invokedPurchaseProductWithPromotionalOfferCount += 1
         invokedPurchaseProductWithPromotionalOfferParameters = (product,
@@ -238,8 +238,8 @@ final class MockPurchases: PurchasesType {
                                                                      completion: PurchaseCompletedBlock)]()
 
     func purchase(package: Package,
-                           promotionalOffer: PromotionalOffer,
-                           completion: @escaping PurchaseCompletedBlock) {
+                  promotionalOffer: PromotionalOffer,
+                  completion: @escaping PurchaseCompletedBlock) {
         invokedPurchasePackageWithPromotionalOffer = true
         invokedPurchasePackageWithPromotionalOfferCount += 1
         invokedPurchasePackageWithPromotionalOfferParameters = (package, promotionalOffer, completion)

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
@@ -4,7 +4,7 @@
 //
 
 import Foundation
-@testable import RevenueCat
+import RevenueCat
 import StoreKit
 
 final class MockPurchases: PurchasesType {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
@@ -7,125 +7,16 @@ import Foundation
 @testable import RevenueCat
 import StoreKit
 
-class MockPurchases: Purchases {
+final class MockPurchases: PurchasesType {
+    
+    var delegate: RevenueCat.PurchasesDelegate?
 
-    init() {
-        let systemInfo = try! SystemInfo(platformInfo: nil, finishTransactions: true)
-        let deviceCache = DeviceCache(sandboxEnvironmentDetector: systemInfo)
-
-        let operationDispatcher: OperationDispatcher = OperationDispatcher()
-
-        let requestFetcher: StoreKitRequestFetcher = StoreKitRequestFetcher(operationDispatcher: operationDispatcher)
-        let receiptFetcher: ReceiptFetcher = ReceiptFetcher(requestFetcher: requestFetcher, systemInfo: systemInfo)
-        let attributionFetcher: AttributionFetcher = AttributionFetcher(attributionFactory: AttributionTypeFactory(),
-                                                                        systemInfo: systemInfo)
-
-        let eTagManager = ETagManager(userDefaults: UserDefaults.standard)
-        let backend: Backend = Backend(apiKey: "",
-                                       systemInfo: systemInfo,
-                                       eTagManager: eTagManager,
-                                       operationDispatcher: operationDispatcher,
-                                       attributionFetcher:
-                                        attributionFetcher)
-
-        let customerInfoManager: CustomerInfoManager = CustomerInfoManager(operationDispatcher: operationDispatcher,
-                                                                           deviceCache: deviceCache,
-                                                                           backend: backend,
-                                                                           systemInfo: systemInfo)
-
-        let attributionDataMigrator = AttributionDataMigrator()
-
-        let subscriberAttributesManager = SubscriberAttributesManager(backend: backend,
-                                                                      deviceCache: deviceCache,
-                                                                      operationDispatcher: operationDispatcher,
-                                                                      attributionFetcher: attributionFetcher,
-                                                                      attributionDataMigrator: attributionDataMigrator)
-
-        let identityManager = IdentityManager(
-            deviceCache: deviceCache,
-            backend: backend,
-            customerInfoManager: customerInfoManager,
-            attributeSyncing: subscriberAttributesManager,
-            appUserID: nil
-        )
-
-        let attributionPoster: AttributionPoster = AttributionPoster(
-            deviceCache: deviceCache,
-            currentUserProvider: identityManager,
-            backend: backend,
-            attributionFetcher: attributionFetcher,
-            subscriberAttributesManager: subscriberAttributesManager)
-
-        let subscriberAttributes = Attribution(
-            subscriberAttributesManager: subscriberAttributesManager,
-            currentUserProvider: identityManager,
-            attributionPoster: attributionPoster)
-
-        let storeKitWrapper: StoreKitWrapper = StoreKitWrapper()
-        let notificationCenter: NotificationCenter = NotificationCenter.default
-
-        let offeringsFactory: OfferingsFactory = OfferingsFactory()
-
-
-        let productsManager: ProductsManager = ProductsManager(systemInfo: systemInfo, requestTimeout: 1)
-        let offeringsManager: OfferingsManager = OfferingsManager(deviceCache: deviceCache, operationDispatcher: operationDispatcher, systemInfo: systemInfo, backend: backend, offeringsFactory: offeringsFactory, productsManager: productsManager)
-
-        let introEligibilityCalculator: IntroEligibilityCalculator = IntroEligibilityCalculator(productsManager: productsManager, receiptParser: ReceiptParser())
-
-        let manageSubscriptionsHelper = ManageSubscriptionsHelper(systemInfo: systemInfo, customerInfoManager: customerInfoManager, currentUserProvider: identityManager)
-
-        let beginRefundRequestHelper = BeginRefundRequestHelper(systemInfo: systemInfo, customerInfoManager: customerInfoManager, currentUserProvider: identityManager)
-
-        let purchasesOrchestrator = PurchasesOrchestrator(
-            productsManager: productsManager,
-            storeKitWrapper: storeKitWrapper,
-            systemInfo: systemInfo,
-            subscriberAttributes: subscriberAttributes,
-            operationDispatcher: operationDispatcher,
-            receiptFetcher: receiptFetcher,
-            customerInfoManager: customerInfoManager,
-            backend: backend,
-            currentUserProvider: identityManager,
-            transactionsManager: TransactionsManager(storeKit2Setting: .enabledOnlyForOptimizations,
-                                                     receiptParser: ReceiptParser()),
-            deviceCache: deviceCache,
-            offeringsManager: OfferingsManager(deviceCache: deviceCache,
-                                               operationDispatcher: operationDispatcher,
-                                               systemInfo: systemInfo,
-                                               backend: backend,
-                                               offeringsFactory: offeringsFactory,
-                                               productsManager: productsManager),
-            manageSubscriptionsHelper: manageSubscriptionsHelper,
-            beginRefundRequestHelper: beginRefundRequestHelper
-        )
-
-        let trialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityChecker = TrialOrIntroPriceEligibilityChecker(systemInfo: systemInfo, receiptFetcher: receiptFetcher, introEligibilityCalculator: introEligibilityCalculator, backend: backend, currentUserProvider: identityManager, operationDispatcher: operationDispatcher, productsManager: productsManager)
-
-        super.init(appUserID: nil,
-                   requestFetcher: requestFetcher,
-                   receiptFetcher: receiptFetcher,
-                   attributionFetcher: attributionFetcher,
-                   attributionPoster: attributionPoster,
-                   backend: backend,
-                   storeKitWrapper: storeKitWrapper,
-                   notificationCenter: notificationCenter,
-                   systemInfo: systemInfo,
-                   offeringsFactory: offeringsFactory,
-                   deviceCache: deviceCache,
-                   identityManager: identityManager,
-                   subscriberAttributes: subscriberAttributes,
-                   operationDispatcher: operationDispatcher,
-                   customerInfoManager: customerInfoManager,
-                   productsManager: productsManager,
-                   offeringsManager: offeringsManager,
-                   purchasesOrchestrator: purchasesOrchestrator,
-                   trialOrIntroPriceEligibilityChecker: trialOrIntroPriceEligibilityChecker)
-    }
+    init() {}
 
     var invokedAppUserIDGetter = false
     var invokedAppUserIDGetterCount = 0
     var stubbedAppUserID: String! = ""
-    override var appUserID: String {
+    var appUserID: String {
         invokedAppUserIDGetter = true
         invokedAppUserIDGetterCount += 1
         return stubbedAppUserID
@@ -133,21 +24,21 @@ class MockPurchases: Purchases {
     var invokedIsAnonymousGetter = false
     var invokedIsAnonymousGetterCount = 0
     var stubbedIsAnonymous: Bool! = false
-    override var isAnonymous: Bool {
+    var isAnonymous: Bool {
         invokedIsAnonymousGetter = true
         invokedIsAnonymousGetterCount += 1
         return stubbedIsAnonymous
     }
 
-    var invokedLogInError = false
+    var invokedLogInPublicError = false
     var invokedLogInCount = 0
     var invokedLogInParameters: (appUserID: String, Void)?
     var invokedLogInParametersList = [(appUserID: String, Void)]()
-    var stubbedLogInCompletionResult: (CustomerInfo?, Bool, Error?)?
+    var stubbedLogInCompletionResult: (CustomerInfo?, Bool, PublicError?)?
 
-    override func logIn(_ appUserID: String,
-                        completion: @escaping (CustomerInfo?, Bool, Error?) -> ()) {
-        invokedLogInError = true
+    func logIn(_ appUserID: String,
+               completion: @escaping (CustomerInfo?, Bool, PublicError?) -> ()) {
+        invokedLogInPublicError = true
         invokedLogInCount += 1
         invokedLogInParameters = (appUserID, ())
         invokedLogInParametersList.append((appUserID, ()))
@@ -158,11 +49,11 @@ class MockPurchases: Purchases {
 
     var invokedLogOut = false
     var invokedLogOutCount = 0
-    var invokedLogOutParameters: (completion: ((CustomerInfo?, Error?) -> ())?, Void)?
-    var invokedLogOutParametersList = [(completion: ((CustomerInfo?, Error?) -> ())?, Void)]()
-    var stubbedLogOutCompletionResult: (CustomerInfo?, Error?)?
+    var invokedLogOutParameters: (completion: ((CustomerInfo?, PublicError?) -> ())?, Void)?
+    var invokedLogOutParametersList = [(completion: ((CustomerInfo?, PublicError?) -> ())?, Void)]()
+    var stubbedLogOutCompletionResult: (CustomerInfo?, PublicError?)?
 
-    override func logOut(completion: ((CustomerInfo?, Error?) -> ())?) {
+    func logOut(completion: ((CustomerInfo?, PublicError?) -> ())?) {
         invokedLogOut = true
         invokedLogOutCount += 1
         invokedLogOutParameters = (completion, ())
@@ -174,17 +65,25 @@ class MockPurchases: Purchases {
 
     var invokedCreateAlias = false
     var invokedCreateAliasCount = 0
-    var invokedCreateAliasParameters: (alias: String, completion: ((CustomerInfo?, Error?) -> ())?)?
+    var invokedCreateAliasParameters: (alias: String, completion: ((CustomerInfo?, PublicError?) -> ())?)?
     var invokedCreateAliasParametersList = [(alias: String,
-                                             completion: ((CustomerInfo?, Error?) -> ())?)]()
+                                             completion: ((CustomerInfo?, PublicError?) -> ())?)]()
 
     var invokedCustomerInfo = false
     var invokedCustomerInfoCount = 0
-    var invokedCustomerInfoParameters: (completion: ((CustomerInfo?, Error?) -> ()), Void)?
-    var invokedCustomerInfoParametersList = [(completion: ((CustomerInfo?, Error?) -> ()),
+    var invokedCustomerInfoParameters: (completion: ((CustomerInfo?, PublicError?) -> ()), Void)?
+    var invokedCustomerInfoParametersList = [(completion: ((CustomerInfo?, PublicError?) -> ()),
                                               Void)]()
 
-    override func getCustomerInfo(completion: @escaping ((CustomerInfo?, Error?) -> ())) {
+    func getCustomerInfo(completion: @escaping ((CustomerInfo?, PublicError?) -> ())) {
+        invokedCustomerInfo = true
+        invokedCustomerInfoCount += 1
+        invokedCustomerInfoParameters = (completion, ())
+        invokedCustomerInfoParametersList.append((completion, ()))
+    }
+
+
+    func getCustomerInfo(fetchPolicy: CacheFetchPolicy, completion: @escaping (CustomerInfo?, PublicError?) -> Void) {
         invokedCustomerInfo = true
         invokedCustomerInfoCount += 1
         invokedCustomerInfoParameters = (completion, ())
@@ -193,10 +92,10 @@ class MockPurchases: Purchases {
 
     var invokedOfferings = false
     var invokedOfferingsCount = 0
-    var invokedOfferingsParameters: (completion: ((Offerings?, Error?) -> ()), Void)?
-    var invokedOfferingsParametersList = [(completion: ((Offerings?, Error?) -> ()), Void)]()
+    var invokedOfferingsParameters: (completion: ((Offerings?, PublicError?) -> ()), Void)?
+    var invokedOfferingsParametersList = [(completion: ((Offerings?, PublicError?) -> ()), Void)]()
 
-    override func getOfferings(completion: @escaping ((Offerings?, Error?) -> ())) {
+    func getOfferings(completion: @escaping ((Offerings?, PublicError?) -> ())) {
         invokedOfferings = true
         invokedOfferingsCount += 1
         invokedOfferingsParameters = (completion, ())
@@ -208,7 +107,7 @@ class MockPurchases: Purchases {
     var invokedProductsParameters: (productIdentifiers: [String], completion: ([StoreProduct]) -> ())?
     var invokedProductsParametersList: [(productIdentifiers: [String], completion: ([StoreProduct]) -> ())] = []
 
-    override func getProducts(_ productIdentifiers: [String],
+    func getProducts(_ productIdentifiers: [String],
                               completion: @escaping ([StoreProduct]) -> ()) {
         invokedProducts = true
         invokedProductsCount += 1
@@ -222,7 +121,7 @@ class MockPurchases: Purchases {
     var invokedPurchaseProductParametersList = [(product: StoreProduct,
                                                  completion: PurchaseCompletedBlock)]()
 
-    override func purchase(product: StoreProduct, completion: @escaping PurchaseCompletedBlock) {
+    func purchase(product: StoreProduct, completion: @escaping PurchaseCompletedBlock) {
         invokedPurchaseProduct = true
         invokedPurchaseProductCount += 1
         invokedPurchaseProductParameters = (product, completion)
@@ -235,7 +134,7 @@ class MockPurchases: Purchases {
     var invokedPurchasePackageParametersList = [(package: Package,
                                                  completion: PurchaseCompletedBlock)]()
 
-    override func purchase(package: Package,
+    func purchase(package: Package,
                            completion: @escaping PurchaseCompletedBlock) {
         invokedPurchasePackage = true
         invokedPurchasePackageCount += 1
@@ -245,11 +144,11 @@ class MockPurchases: Purchases {
 
     var invokedRestoreTransactions = false
     var invokedRestoreTransactionsCount = 0
-    var invokedRestoreTransactionsParameters: (completion: ((CustomerInfo?, Error?) -> ())?, Void)?
-    var invokedRestoreTransactionsParametersList = [(completion: ((CustomerInfo?, Error?) -> ())?,
+    var invokedRestoreTransactionsParameters: (completion: ((CustomerInfo?, PublicError?) -> ())?, Void)?
+    var invokedRestoreTransactionsParametersList = [(completion: ((CustomerInfo?, PublicError?) -> ())?,
                                                      Void)]()
 
-    override func restorePurchases(completion: ((CustomerInfo?, Error?) -> ())?) {
+    func restorePurchases(completion: ((CustomerInfo?, PublicError?) -> ())?) {
         invokedRestoreTransactions = true
         invokedRestoreTransactionsCount += 1
         invokedRestoreTransactionsParameters = (completion, ())
@@ -258,11 +157,11 @@ class MockPurchases: Purchases {
 
     var invokedSyncPurchases = false
     var invokedSyncPurchasesCount = 0
-    var invokedSyncPurchasesParameters: (completion: ((CustomerInfo?, Error?) -> ())?, Void)?
-    var invokedSyncPurchasesParametersList = [(completion: ((CustomerInfo?, Error?) -> ())?,
+    var invokedSyncPurchasesParameters: (completion: ((CustomerInfo?, PublicError?) -> ())?, Void)?
+    var invokedSyncPurchasesParametersList = [(completion: ((CustomerInfo?, PublicError?) -> ())?,
                                                Void)]()
 
-    override func syncPurchases(completion: ((CustomerInfo?, Error?) -> ())?) {
+    func syncPurchases(completion: ((CustomerInfo?, PublicError?) -> ())?) {
         invokedSyncPurchases = true
         invokedSyncPurchasesCount += 1
         invokedSyncPurchasesParameters = (completion, ())
@@ -276,7 +175,7 @@ class MockPurchases: Purchases {
         productIdentifiers: [String],
         receiveEligibility: ([String : IntroEligibility]) -> Void)]()
 
-    override func checkTrialOrIntroDiscountEligibility(productIdentifiers: [String],
+    func checkTrialOrIntroDiscountEligibility(productIdentifiers: [String],
                                                        completion receiveEligibility: @escaping ([String : IntroEligibility]) -> Void) {
         invokedCheckTrialOrIntroductoryPriceEligibility = true
         invokedCheckTrialOrIntroductoryPriceEligibilityCount += 1
@@ -291,15 +190,15 @@ class MockPurchases: Purchases {
     var invokedGetPromotionalOfferCount = 0
     var invokedGetPromotionalOfferParameters: (discount: StoreProductDiscount,
                                                product: StoreProduct,
-                                               completion: (PromotionalOffer?, Error?) -> Void)?
+                                               completion: (PromotionalOffer?, PublicError?) -> Void)?
     var invokedGetPromotionalOfferParametersList = [(
         discount: StoreProductDiscount,
         product: StoreProduct,
-        completion: (PromotionalOffer?, Error?) -> Void)]()
+        completion: (PromotionalOffer?, PublicError?) -> Void)]()
 
-    override func getPromotionalOffer(forProductDiscount discount: StoreProductDiscount,
+    func getPromotionalOffer(forProductDiscount discount: StoreProductDiscount,
                                       product: StoreProduct,
-                                      completion: @escaping ((PromotionalOffer?, Error?) -> Void)) {
+                                      completion: @escaping ((PromotionalOffer?, PublicError?) -> Void)) {
         invokedGetPromotionalOffer = true
         invokedGetPromotionalOfferCount += 1
         invokedGetPromotionalOfferParameters = (discount, product, completion)
@@ -316,7 +215,7 @@ class MockPurchases: Purchases {
                                                                      promotionalOffer: PromotionalOffer,
                                                                      completion: PurchaseCompletedBlock)]()
 
-    override func purchase(product: StoreProduct,
+    func purchase(product: StoreProduct,
                            promotionalOffer: PromotionalOffer,
                            completion: @escaping PurchaseCompletedBlock) {
         invokedPurchaseProductWithPromotionalOffer = true
@@ -338,7 +237,7 @@ class MockPurchases: Purchases {
                                                                      promotionalOffer: PromotionalOffer,
                                                                      completion: PurchaseCompletedBlock)]()
 
-    override func purchase(package: Package,
+    func purchase(package: Package,
                            promotionalOffer: PromotionalOffer,
                            completion: @escaping PurchaseCompletedBlock) {
         invokedPurchasePackageWithPromotionalOffer = true
@@ -350,7 +249,7 @@ class MockPurchases: Purchases {
     var invokedInvalidateCustomerInfoCache = false
     var invokedInvalidateCustomerInfoCacheCount = 0
 
-    override func invalidateCustomerInfoCache() {
+    func invalidateCustomerInfoCache() {
         invokedInvalidateCustomerInfoCache = true
         invokedInvalidateCustomerInfoCacheCount += 1
     }
@@ -358,7 +257,12 @@ class MockPurchases: Purchases {
     var invokedPresentCodeRedemptionSheet = false
     var invokedPresentCodeRedemptionSheetCount = 0
 
-    override func presentCodeRedemptionSheet() {
+    @available(iOS 14.0, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(macOS, unavailable)
+    @available(macCatalyst, unavailable)
+    func presentCodeRedemptionSheet() {
         invokedPresentCodeRedemptionSheet = true
         invokedPresentCodeRedemptionSheetCount += 1
     }
@@ -368,7 +272,7 @@ class MockPurchases: Purchases {
     var invokedSetAttributesParameters: (attributes: [String: String], Void)?
     var invokedSetAttributesParametersList = [(attributes: [String: String], Void)]()
 
-    override func setAttributes(_ attributes: [String: String]) {
+    func setAttributes(_ attributes: [String: String]) {
         invokedSetAttributes = true
         invokedSetAttributesCount += 1
         invokedSetAttributesParameters = (attributes, ())
@@ -380,7 +284,7 @@ class MockPurchases: Purchases {
     var invokedSetEmailParameters: (email: String?, Void)?
     var invokedSetEmailParametersList = [(email: String?, Void)]()
 
-    override func setEmail(_ email: String?) {
+    func setEmail(_ email: String?) {
         invokedSetEmail = true
         invokedSetEmailCount += 1
         invokedSetEmailParameters = (email, ())
@@ -392,7 +296,7 @@ class MockPurchases: Purchases {
     var invokedSetPhoneNumberParameters: (phoneNumber: String?, Void)?
     var invokedSetPhoneNumberParametersList = [(phoneNumber: String?, Void)]()
 
-    override func setPhoneNumber(_ phoneNumber: String?) {
+    func setPhoneNumber(_ phoneNumber: String?) {
         invokedSetPhoneNumber = true
         invokedSetPhoneNumberCount += 1
         invokedSetPhoneNumberParameters = (phoneNumber, ())
@@ -404,7 +308,7 @@ class MockPurchases: Purchases {
     var invokedSetDisplayNameParameters: (displayName: String?, Void)?
     var invokedSetDisplayNameParametersList = [(displayName: String?, Void)]()
 
-    override func setDisplayName(_ displayName: String?) {
+    func setDisplayName(_ displayName: String?) {
         invokedSetDisplayName = true
         invokedSetDisplayNameCount += 1
         invokedSetDisplayNameParameters = (displayName, ())
@@ -416,7 +320,7 @@ class MockPurchases: Purchases {
     var invokedSetPushTokenParameters: (pushToken: Data?, Void)?
     var invokedSetPushTokenParametersList = [(pushToken: Data?, Void)]()
 
-    override func setPushToken(_ pushToken: Data?) {
+    func setPushToken(_ pushToken: Data?) {
         invokedSetPushToken = true
         invokedSetPushTokenCount += 1
         invokedSetPushTokenParameters = (pushToken, ())
@@ -428,7 +332,7 @@ class MockPurchases: Purchases {
     var invokedSetAdjustIDParameters: (adjustID: String?, Void)?
     var invokedSetAdjustIDParametersList = [(adjustID: String?, Void)]()
 
-    override func setAdjustID(_ adjustID: String?) {
+    func setAdjustID(_ adjustID: String?) {
         invokedSetAdjustID = true
         invokedSetAdjustIDCount += 1
         invokedSetAdjustIDParameters = (adjustID, ())
@@ -440,7 +344,7 @@ class MockPurchases: Purchases {
     var invokedSetAppsflyerIDParameters: (appsflyerID: String?, Void)?
     var invokedSetAppsflyerIDParametersList = [(appsflyerID: String?, Void)]()
 
-    override func setAppsflyerID(_ appsflyerID: String?) {
+    func setAppsflyerID(_ appsflyerID: String?) {
         invokedSetAppsflyerID = true
         invokedSetAppsflyerIDCount += 1
         invokedSetAppsflyerIDParameters = (appsflyerID, ())
@@ -452,7 +356,7 @@ class MockPurchases: Purchases {
     var invokedSetFBAnonymousIDParameters: (fbAnonymousID: String?, Void)?
     var invokedSetFBAnonymousIDParametersList = [(fbAnonymousID: String?, Void)]()
 
-    override func setFBAnonymousID(_ fbAnonymousID: String?) {
+    func setFBAnonymousID(_ fbAnonymousID: String?) {
         invokedSetFBAnonymousID = true
         invokedSetFBAnonymousIDCount += 1
         invokedSetFBAnonymousIDParameters = (fbAnonymousID, ())
@@ -464,7 +368,7 @@ class MockPurchases: Purchases {
     var invokedSetMparticleIDParameters: (mparticleID: String?, Void)?
     var invokedSetMparticleIDParametersList = [(mparticleID: String?, Void)]()
 
-    override func setMparticleID(_ mparticleID: String?) {
+    func setMparticleID(_ mparticleID: String?) {
         invokedSetMparticleID = true
         invokedSetMparticleIDCount += 1
         invokedSetMparticleIDParameters = (mparticleID, ())
@@ -476,7 +380,7 @@ class MockPurchases: Purchases {
     var invokedSetOnesignalIDParameters: (onesignalID: String?, Void)?
     var invokedSetOnesignalIDParametersList = [(onesignalID: String?, Void)]()
 
-    override func setOnesignalID(_ onesignalID: String?) {
+    func setOnesignalID(_ onesignalID: String?) {
         invokedSetOnesignalID = true
         invokedSetOnesignalIDCount += 1
         invokedSetOnesignalIDParameters = (onesignalID, ())
@@ -488,7 +392,7 @@ class MockPurchases: Purchases {
     var invokedSetMediaSourceParameters: (mediaSource: String?, Void)?
     var invokedSetMediaSourceParametersList = [(mediaSource: String?, Void)]()
 
-    override func setMediaSource(_ mediaSource: String?) {
+    func setMediaSource(_ mediaSource: String?) {
         invokedSetMediaSource = true
         invokedSetMediaSourceCount += 1
         invokedSetMediaSourceParameters = (mediaSource, ())
@@ -500,7 +404,7 @@ class MockPurchases: Purchases {
     var invokedSetCampaignParameters: (campaign: String?, Void)?
     var invokedSetCampaignParametersList = [(campaign: String?, Void)]()
 
-    override func setCampaign(_ campaign: String?) {
+    func setCampaign(_ campaign: String?) {
         invokedSetCampaign = true
         invokedSetCampaignCount += 1
         invokedSetCampaignParameters = (campaign, ())
@@ -512,7 +416,7 @@ class MockPurchases: Purchases {
     var invokedSetAdGroupParameters: (adGroup: String?, Void)?
     var invokedSetAdGroupParametersList = [(adGroup: String?, Void)]()
 
-    override func setAdGroup(_ adGroup: String?) {
+    func setAdGroup(_ adGroup: String?) {
         invokedSetAdGroup = true
         invokedSetAdGroupCount += 1
         invokedSetAdGroupParameters = (adGroup, ())
@@ -524,7 +428,7 @@ class MockPurchases: Purchases {
     var invokedSetAdParameters: (ad: String?, Void)?
     var invokedSetAdParametersList = [(ad: String?, Void)]()
 
-    override func setAd(_ ad: String?) {
+    func setAd(_ ad: String?) {
         invokedSetAd = true
         invokedSetAdCount += 1
         invokedSetAdParameters = (ad, ())
@@ -536,7 +440,7 @@ class MockPurchases: Purchases {
     var invokedSetKeywordParameters: (keyword: String?, Void)?
     var invokedSetKeywordParametersList = [(keyword: String?, Void)]()
 
-    override func setKeyword(_ keyword: String?) {
+    func setKeyword(_ keyword: String?) {
         invokedSetKeyword = true
         invokedSetKeywordCount += 1
         invokedSetKeywordParameters = (keyword, ())
@@ -548,7 +452,7 @@ class MockPurchases: Purchases {
     var invokedSetCreativeParameters: (creative: String?, Void)?
     var invokedSetCreativeParametersList = [(creative: String?, Void)]()
 
-    override func setCreative(_ creative: String?) {
+    func setCreative(_ creative: String?) {
         invokedSetCreative = true
         invokedSetCreativeCount += 1
         invokedSetCreativeParameters = (creative, ())
@@ -558,9 +462,135 @@ class MockPurchases: Purchases {
     var invokedCollectDeviceIdentifiers = false
     var invokedCollectDeviceIdentifiersCount = 0
 
-    override func collectDeviceIdentifiers() {
+    func collectDeviceIdentifiers() {
         invokedCollectDeviceIdentifiers = true
         invokedCollectDeviceIdentifiersCount += 1
     }
     
+}
+
+extension MockPurchases {
+
+    func logIn(_ appUserID: String) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Bool) {
+        fatalError("Not mocked")
+    }
+
+    func logOut() async throws -> RevenueCat.CustomerInfo {
+        fatalError("Not mocked")
+    }
+
+    func customerInfo() async throws -> RevenueCat.CustomerInfo {
+        fatalError("Not mocked")
+    }
+
+    func customerInfo(fetchPolicy: RevenueCat.CacheFetchPolicy) async throws -> RevenueCat.CustomerInfo {
+        fatalError("Not mocked")
+    }
+
+    func offerings() async throws -> RevenueCat.Offerings {
+        fatalError("Not mocked")
+    }
+
+    func products(_ productIdentifiers: [String]) async -> [RevenueCat.StoreProduct] {
+        fatalError("Not mocked")
+    }
+
+    func purchase(product: RevenueCat.StoreProduct) async throws -> RevenueCat.PurchaseResultData {
+        fatalError("Not mocked")
+    }
+
+    func purchase(package: RevenueCat.Package) async throws -> RevenueCat.PurchaseResultData {
+        fatalError("Not mocked")
+    }
+
+    func purchase(product: RevenueCat.StoreProduct, promotionalOffer: RevenueCat.PromotionalOffer) async throws -> RevenueCat.PurchaseResultData {
+        fatalError("Not mocked")
+    }
+
+    func purchase(package: RevenueCat.Package, promotionalOffer: RevenueCat.PromotionalOffer) async throws -> RevenueCat.PurchaseResultData {
+        fatalError("Not mocked")
+    }
+
+    func restorePurchases() async throws -> RevenueCat.CustomerInfo {
+        fatalError("Not mocked")
+    }
+
+    func syncPurchases() async throws -> RevenueCat.CustomerInfo {
+        fatalError("Not mocked")
+    }
+
+    func checkTrialOrIntroDiscountEligibility(productIdentifiers: [String]) async -> [String : RevenueCat.IntroEligibility] {
+        fatalError("Not mocked")
+    }
+
+    func checkTrialOrIntroDiscountEligibility(product: RevenueCat.StoreProduct, completion: @escaping (RevenueCat.IntroEligibilityStatus) -> Void) {
+        fatalError("Not mocked")
+    }
+
+    func checkTrialOrIntroDiscountEligibility(product: RevenueCat.StoreProduct) async -> RevenueCat.IntroEligibilityStatus {
+        fatalError("Not mocked")
+    }
+
+    func promotionalOffer(forProductDiscount discount: RevenueCat.StoreProductDiscount, product: RevenueCat.StoreProduct) async throws -> RevenueCat.PromotionalOffer {
+        fatalError("Not mocked")
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func eligiblePromotionalOffers(forProduct product: StoreProduct) async -> [PromotionalOffer] {
+        fatalError("This method is not mocked")
+    }
+
+    func beginRefundRequest(forProduct productID: String) async throws -> RevenueCat.RefundRequestStatus {
+        fatalError("Not mocked")
+    }
+
+    func beginRefundRequest(forEntitlement entitlementID: String) async throws -> RevenueCat.RefundRequestStatus {
+        fatalError("Not mocked")
+    }
+
+    func beginRefundRequestForActiveEntitlement() async throws -> RevenueCat.RefundRequestStatus {
+        fatalError("Not mocked")
+    }
+
+    func showPriceConsentIfNeeded() {
+        fatalError("Not mocked")
+    }
+
+    func showManageSubscriptions(completion: @escaping (RevenueCat.PublicError?) -> Void) {
+        fatalError("Not mocked")
+    }
+
+    func showManageSubscriptions() async throws {
+        fatalError("Not mocked")
+    }
+
+    func setPushTokenString(_ pushToken: String?) {
+        fatalError("Not mocked")
+    }
+
+    func setCleverTapID(_ cleverTapID: String?) {
+        fatalError("Not mocked")
+    }
+
+    func setMixpanelDistinctID(_ mixpanelDistinctID: String?) {
+        fatalError("Not mocked")
+    }
+
+    func setFirebaseAppInstanceID(_ firebaseAppInstanceID: String?) {
+        fatalError("Not mocked")
+    }
+
+    var finishTransactions: Bool {
+        get { fatalError("Not mocked") }
+        set { fatalError("Not mocked") }
+    }
+    var attribution: Attribution {
+        get { fatalError("Not mocked") }
+        set { fatalError("Not mocked") }
+    }
+    var allowSharingAppStoreAccount: Bool {
+        get { fatalError("Not mocked") }
+        set { fatalError("Not mocked") }
+    }
+
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
@@ -67,7 +67,7 @@ class PurchasesHybridCommonTests: QuickSpec {
                 let mockCreated = Bool.random()
                 mockPurchases.stubbedLogInCompletionResult = (Self.mockCustomerInfo, mockCreated, nil)
 
-                Purchases.setDefaultInstance(mockPurchases)
+                CommonFunctionality.sharedInstance = mockPurchases
 
                 let appUserID = "appUserID"
                 CommonFunctionality.logIn(appUserID: appUserID) { _, _ in }
@@ -81,7 +81,8 @@ class PurchasesHybridCommonTests: QuickSpec {
                 let mockCreated = Bool.random()
                 mockPurchases.stubbedLogInCompletionResult = (Self.mockCustomerInfo, mockCreated, nil)
 
-                Purchases.setDefaultInstance(mockPurchases)
+                CommonFunctionality.sharedInstance = mockPurchases
+
                 var receivedResultDict: NSDictionary?
                 var receivedError: ErrorContainer?
 
@@ -107,7 +108,8 @@ class PurchasesHybridCommonTests: QuickSpec {
 
                 mockPurchases.stubbedLogInCompletionResult = (nil, false, mockError)
 
-                Purchases.setDefaultInstance(mockPurchases)
+                CommonFunctionality.sharedInstance = mockPurchases
+
                 var receivedResultDict: NSDictionary?
                 var receivedError: ErrorContainer?
 
@@ -138,7 +140,7 @@ class PurchasesHybridCommonTests: QuickSpec {
                 let mockPurchases = MockPurchases()
                 mockPurchases.stubbedLogOutCompletionResult = (Self.mockCustomerInfo, nil)
 
-                Purchases.setDefaultInstance(mockPurchases)
+                CommonFunctionality.sharedInstance = mockPurchases
 
                 CommonFunctionality.logOut { _, _ in }
 
@@ -149,7 +151,8 @@ class PurchasesHybridCommonTests: QuickSpec {
                 let mockPurchases = MockPurchases()
                 mockPurchases.stubbedLogOutCompletionResult = (Self.mockCustomerInfo, nil)
 
-                Purchases.setDefaultInstance(mockPurchases)
+                CommonFunctionality.sharedInstance = mockPurchases
+
                 var receivedResultDict: [String: Any]?
                 var receivedError: ErrorContainer?
 
@@ -169,7 +172,8 @@ class PurchasesHybridCommonTests: QuickSpec {
 
                 mockPurchases.stubbedLogOutCompletionResult = (nil, mockError)
 
-                Purchases.setDefaultInstance(mockPurchases)
+                CommonFunctionality.sharedInstance = mockPurchases
+
                 var receivedResultDict: NSDictionary?
                 var receivedError: ErrorContainer?
 


### PR DESCRIPTION
Depends on https://github.com/RevenueCat/purchases-ios/pull/1912
This fixes the failures in https://github.com/RevenueCat/purchases-hybrid-common/pull/229