### PR TITLE
Remove step from automatic-release to trigger Flutter update. Use its own job instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,9 +228,6 @@ jobs:
       - run:
           name: Automatically bump release and create release PR
           command: bundle exec fastlane automatic_bump github_rate_limit:10
-      - run:
-          name: Kick off Flutter automatic dependency update
-          command: bundle exec fastlane bump_hybrid_dependencies repo_name:purchases-flutter
 
   trigger-dependent-updates:
     docker:

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -96,7 +96,7 @@ Run automatic bump in other repos
 [bundle exec] fastlane ios release
 ```
 
-Release to CocoaPods, create Carthage archive, and create GitHub release
+Release to CocoaPods, and create GitHub release
 
 ### ios replace_api_key_integration_tests
 


### PR DESCRIPTION
I had this leftover from the development of https://github.com/RevenueCat/purchases-hybrid-common/pull/238

The update should be trigger from its own job on the `deploy` workflow