### PR TITLE
Automatic releases are missing the `AUTOMATIC` title

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,7 +40,8 @@ lane :bump do |options|
     repo_name: repo_name,
     github_rate_limit: options[:github_rate_limit],
     editor: options[:editor],
-    next_version: options[:next_version]
+    next_version: options[:next_version],
+    automatic_release: options[:automatic_release]
   )
 end
 
@@ -51,6 +52,7 @@ lane :automatic_bump do |options|
     github_rate_limit: options[:github_rate_limit]
   )
   options[:next_version] = next_version
+  options[:automatic_release] = true
   if type_of_bump == :skip
     UI.message('Skipping automatic bump since the next version doesn\'t include public facing changes')
     next


### PR DESCRIPTION
We were not passing the `automatic_release` option