### PR TITLE
Adds parameters to run bump and dependency updates manually instead of approval jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,4 +321,4 @@ workflows:
     when:
       equal: [ bump, << pipeline.parameters.action >> ]
     jobs:
-      - revenuecat/automatic-bump
+      - automatic-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
           name: Make GitHub release for current version
           command: bundle exec fastlane github_release_current
   
-  automatic-dependency-update:
+  dependency-update:
     docker:
       - image: cimg/ruby:2.7.2
     steps:
@@ -223,7 +223,7 @@ jobs:
           name: Tag branch
           command: bundle exec fastlane tag_current_branch
 
-  automatic-release:
+  release:
     docker:
       - image: cimg/ruby:3.1.2
     steps:
@@ -290,13 +290,13 @@ workflows:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "update-native-dependencies", << pipeline.schedule.name >> ]
     jobs:
-      - automatic-dependency-update 
+      - dependency-update 
 
-  manual-trigger-dependency-update:
+  trigger-dependency-update:
     when:
       equal: [ dependency-update, << pipeline.parameters.action >> ]
     jobs:
-      - automatic-dependency-update
+      - dependency-update
 
   danger:
     when:
@@ -310,15 +310,15 @@ workflows:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      - automatic-release:
+      - release:
           filters:
             tags:
               ignore: /.*/
             branches:
               only: main
 
-  manual-trigger-bump:
+  trigger-bump:
     when:
       equal: [ bump, << pipeline.parameters.action >> ]
     jobs:
-      - automatic-release
+      - release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,12 @@ orbs:
   revenuecat: revenuecat/sdks-common-config@1.1.0
   macos: circleci/macos@2.0.1
 
+parameters:
+  action:
+    type: enum
+    enum: [ build, dependency-update, bump ]
+    default: build
+
 executors:
   ios-executor:
     resource_class: macos.x86.medium.gen2
@@ -286,21 +292,11 @@ workflows:
     jobs:
       - automatic-dependency-update 
 
-  manual-trigger-automatic-dependency-update:
+  manual-trigger-dependency-update:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      equal: [ dependency-update, << pipeline.parameters.action >> ]
     jobs:
-      - trigger-automatic-dependency-update:
-          type: approval
-          filters:
-            tags:
-              ignore: /.*/
-            branches:
-              only: main
-      - automatic-dependency-update:
-          requires:
-            - trigger-automatic-dependency-update
+      - automatic-dependency-update
 
   danger:
     when:
@@ -321,18 +317,8 @@ workflows:
             branches:
               only: main
 
-  manual-trigger-release:
+  manual-trigger-bump:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      equal: [ bump, << pipeline.parameters.action >> ]
     jobs:
-      - trigger-automatic-release:
-          type: approval
-          filters:
-            tags:
-              ignore: /.*/
-            branches:
-              only: main
-      - automatic-release:
-          requires:
-            - trigger-automatic-release
+      - revenuecat/automatic-bump


### PR DESCRIPTION
This way `automatic-dependency-update` and `automatic-release` jobs can be run from CircleCI UI by passing `dependency-update` or `bump` as parameters when triggering a pipeline


![](https://user-images.githubusercontent.com/664544/191806930-07737e3d-8c44-4bfd-8cef-b471b72643a4.png)
