### PR TITLE
`IntegrationTests`: don't initialize `Purchases` until `SKTestSession` has been re-created

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
@@ -31,8 +31,6 @@ class StoreKit1IntegrationTests: BaseIntegrationTests {
     }
 
     override func setUp() async throws {
-        try await super.setUp()
-
         self.testSession = try SKTestSession(configurationFileNamed: Constants.storeKitConfigFileName)
         self.testSession.resetToDefaultState()
         self.testSession.disableDialogs = true
@@ -42,6 +40,11 @@ class StoreKit1IntegrationTests: BaseIntegrationTests {
         } else {
             self.testSession.timeRate = .oneSecondIsOneDay
         }
+
+        // Initialize `Purchases` *after* the fresh new session has been created
+        // (and transactions has been cleared), to avoid the SDK posting receipts from
+        // a previous test.
+        try await super.setUp()
 
         // SDK initialization begins with an initial request to offerings
         // Which results in a get-create of the initial anonymous user.


### PR DESCRIPTION
Equivalent to https://github.com/RevenueCat/purchases-ios/pull/1946