### PR TITLE
Update maven-publish-plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,8 @@ workflows:
           <<: *release-branches
       - deploy-ios:
           <<: *release-tags
-      - deploy-android
+      - deploy-android:
+          <<: *release-tags
       - make-github-release:
           <<: *release-tags
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,8 +266,7 @@ workflows:
           <<: *release-branches
       - deploy-ios:
           <<: *release-tags
-      - deploy-android:
-          <<: *release-tags
+      - deploy-android
       - make-github-release:
           <<: *release-tags
           requires:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,7 @@ if (publishVariant == "unityIAPRelease") {
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
+    namespace 'com.revenuecat.purchases.hybridcommon'
     compileSdkVersion 32
     buildToolsVersion "32.0.0"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.android_tools = '7.1.0'
+    ext.android_tools = '7.1.2'
     ext.kotlin_version = '1.6.20'
     ext.android_junit5_version = '1.8.2.0'
     ext.junit5 = '5.8.2'
@@ -28,16 +28,12 @@ apply plugin: 'kotlin-android'
 apply plugin: "de.mannodermaus.android-junit5"
 
 def artifactId = project.property("POM_ARTIFACT_ID")
-def publishVariant = project.property("PUBLISH_VARIANT")
+def publishVariant = project.property("ANDROID_VARIANT_TO_PUBLISH")
 if (publishVariant == "unityIAPRelease") {
     project.ext.POM_ARTIFACT_ID = artifactId + "-unityiap"
 }
 
 apply plugin: "com.vanniktech.maven.publish"
-
-mavenPublish {
-    androidVariantToPublish = project.property("PUBLISH_VARIANT")
-}
 
 android {
     compileSdkVersion 32

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.android_tools = '7.1.2'
+    ext.android_tools = '7.3.0'
     ext.kotlin_version = '1.6.20'
     ext.android_junit5_version = '1.8.2.0'
     ext.junit5 = '5.8.2'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.junit5 = '5.8.2'
     ext.assertj_version = '3.22.0'
     ext.mockk_version = '1.12.3'
-    ext.gradle_maven_publish = '0.19.0'
+    ext.gradle_maven_publish = '0.22.0'
     ext.purchases_version = '5.6.1'
     ext.billing_unityiap_purchases_version = '3.0.3'
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -41,4 +41,6 @@ POM_DEVELOPER_ID=revenuecat
 POM_DEVELOPER_NAME=RevenueCat, Inc.
 #Do not sign releases. When calling uploadArchives pass -PRELEASE_SIGNING_ENABLED=true
 RELEASE_SIGNING_ENABLED=false
-PUBLISH_VARIANT=latestDependenciesRelease
+ANDROID_VARIANT_TO_PUBLISH=latestDependenciesRelease
+SONATYPE_HOST=DEFAULT
+SONATYPE_AUTOMATIC_RELEASE=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 13 16:15:21 PDT 2022
+#Thu Sep 29 12:00:12 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.revenuecat.purchases.hybridcommon" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -324,7 +324,7 @@ platform :android do
     )
 
     UI.verbose("Creating special version for Unity IAP with BillingClient 3 and Amazon 2 for version: #{version}")
-    gradleProperties["PUBLISH_VARIANT"] = "unityIAPRelease"
+    gradleProperties["ANDROID_VARIANT_TO_PUBLISH"] = "unityIAPRelease"
 
     UI.verbose("Adding -unityiap to artifact ids")
 
@@ -335,16 +335,6 @@ platform :android do
       properties: gradleProperties,
       project_dir: 'android'
     )
-
-    unless is_snapshot_version?(version)
-      gradle(
-        tasks: [
-          "closeAndReleaseRepository"
-        ],
-        properties: gradleProperties,
-        project_dir: 'android'
-      )
-    end
   end
 end
 


### PR DESCRIPTION
Deploying Android kept timing out. I increased the version of our publishing plugin since I saw in the latest version the timeout has been increased. 

Other changes are:
- `closeAndReleaseRepository` is ran automatically now
- `SONATYPE_HOST` needs to be specified
- AGP plugin had to be increased for this new version to work so I updated it to the latest version
- package name in the AndroidManifest.xml is now deprecated and should be declared in the build.gradle 
- `mavenPublish` has now been deprecated. The Android variant to publish can be defined using a gradle property now

Their changelog is here https://github.com/vanniktech/gradle-maven-publish-plugin/blob/master/CHANGELOG.md#version-0220-2022-09-09

[CSDK-480]

[CSDK-480]: https://revenuecats.atlassian.net/browse/CSDK-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ