### PR TITLE
re-add error message if SDK hasn't been configured

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -13,7 +13,20 @@ import RevenueCat
 
 @objc(RCCommonFunctionality) public class CommonFunctionality: NSObject {
 
-    static var sharedInstance: PurchasesType!
+    static var sharedInstance: PurchasesType {
+        get {
+            guard let purchases = Self._sharedInstance else {
+                fatalError("Purchases has not been configured. Please configure the SDK before calling this method")
+            }
+
+            return purchases
+        }
+        set {
+            Self._sharedInstance = newValue
+        }
+    }
+
+    private static var _sharedInstance: PurchasesType?
 
     // MARK: properties and configuration
 


### PR DESCRIPTION
Added a wrapper around `sharedInstance` so we can check whether the SDK has been configured and error out if it hasn't. 