### PR TITLE
Add `beginRefundRequest` APIs in iOS

### DIFF
--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -93,6 +93,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     [RCCommonFunctionality invalidateCustomerInfoCache];
     BOOL canMakePayments __unused = [RCCommonFunctionality canMakePaymentsWithFeatures:@[]];
+
+    if (@available(iOS 15.0, *)) {
+        [RCCommonFunctionality beginRefundRequestProductId:@""
+                                           completionBlock:^(RCErrorContainer * _Nullable error) {
+        }];
+        [RCCommonFunctionality beginRefundRequestEntitlementId:@""
+                                               completionBlock:^(RCErrorContainer * _Nullable error) {
+        }];
+        [RCCommonFunctionality beginRefundRequestForActiveEntitlementCompletion:^(RCErrorContainer * _Nullable error) {
+        }];
+    }
 }
 
 - (void)testDeprecatedAPI {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -13,7 +13,9 @@ import RevenueCat
 
 @objc(RCCommonFunctionality) public class CommonFunctionality: NSObject {
 
-    static var sharedInstance: PurchasesType {
+    typealias InstanceType = PurchasesType & PurchasesSwiftType
+
+    static var sharedInstance: InstanceType {
         get {
             guard let purchases = Self._sharedInstance else {
                 fatalError("Purchases has not been configured. Please configure the SDK before calling this method")
@@ -26,7 +28,7 @@ import RevenueCat
         }
     }
 
-    private static var _sharedInstance: PurchasesType?
+    private static var _sharedInstance: InstanceType?
 
     // MARK: properties and configuration
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
@@ -466,7 +466,50 @@ final class MockPurchases: PurchasesType {
         invokedCollectDeviceIdentifiers = true
         invokedCollectDeviceIdentifiersCount += 1
     }
-    
+
+
+    var invokedBeginRefundRequestForProduct = false
+    var invokedBeginRefundRequestForProductCount = 0
+    var invokedBeginRefundRequestForProductParameters: (productId: String,
+                                                        (Result<RefundRequestStatus, PublicError>) -> Void)?
+    var invokedBeginRefundRequestForProductParametersList = [(productId: String,
+                                                              (Result<RefundRequestStatus, PublicError>) -> Void)]()
+
+    func beginRefundRequest(forProduct productID: String,
+                            completion: @escaping (Result<RefundRequestStatus, PublicError>) -> Void) {
+        invokedBeginRefundRequestForProduct = true
+        invokedBeginRefundRequestForProductCount += 1
+        invokedBeginRefundRequestForProductParameters = (productID, completion)
+        invokedBeginRefundRequestForProductParametersList.append((productID, completion))
+    }
+
+    var invokedBeginRefundRequestForEntitlement = false
+    var invokedBeginRefundRequestForEntitlementCount = 0
+    var invokedBeginRefundRequestForEntitlementParameters: (entitlementId: String,
+                                                            (Result<RefundRequestStatus, PublicError>) -> Void)?
+    var invokedBeginRefundRequestForEntitlementParametersList = [(entitlementId: String,
+                                                                  (Result<RefundRequestStatus, PublicError>) -> Void)]()
+
+    func beginRefundRequest(forEntitlement entitlementID: String,
+                            completion: @escaping (Result<RefundRequestStatus, PublicError>) -> Void) {
+        invokedBeginRefundRequestForEntitlement = true
+        invokedBeginRefundRequestForEntitlementCount += 1
+        invokedBeginRefundRequestForEntitlementParameters = (entitlementID, completion)
+        invokedBeginRefundRequestForEntitlementParametersList.append((entitlementID, completion))
+    }
+
+    var invokedBeginRefundRequestForActiveEntitlement = false
+    var invokedBeginRefundRequestForActiveEntitlementCount = 0
+    var invokedBeginRefundRequestForActiveEntitlementParameter: ((Result<RefundRequestStatus, PublicError>) -> Void)?
+    var invokedBeginRefundRequestForActiveEntitlementParameterList =
+        [(Result<RefundRequestStatus, PublicError>) -> Void]()
+
+    func beginRefundRequestForActiveEntitlement(completion: @escaping (Result<RefundRequestStatus, PublicError>) -> Void) {
+        invokedBeginRefundRequestForActiveEntitlement = true
+        invokedBeginRefundRequestForActiveEntitlementCount += 1
+        invokedBeginRefundRequestForActiveEntitlementParameter = completion
+        invokedBeginRefundRequestForActiveEntitlementParameterList.append(completion)
+    }
 }
 
 extension MockPurchases {
@@ -577,18 +620,6 @@ extension MockPurchases: PurchasesSwiftType {
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func eligiblePromotionalOffers(forProduct product: StoreProduct) async -> [PromotionalOffer] {
-        fatalError("This method is not mocked")
-    }
-
-    func beginRefundRequest(forProduct productID: String, completion: @escaping (Result<RefundRequestStatus, PublicError>) -> Void) {
-        fatalError("This method is not mocked")
-    }
-
-    func beginRefundRequest(forEntitlement entitlementID: String, completion: @escaping (Result<RefundRequestStatus, PublicError>) -> Void) {
-        fatalError("This method is not mocked")
-    }
-
-    func beginRefundRequestForActiveEntitlement(completion: @escaping (Result<RefundRequestStatus, PublicError>) -> Void) {
         fatalError("This method is not mocked")
     }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
@@ -197,5 +197,221 @@ class PurchasesHybridCommonTests: QuickSpec {
             }
         }
 
+        context("beginRefundRequest") {
+            if #available(iOS 15.0, *) {
+                context("productId") {
+                    it("passes the call correctly to Purchases") {
+                        let mockPurchases = MockPurchases()
+
+                        CommonFunctionality.sharedInstance = mockPurchases
+
+                        CommonFunctionality.beginRefundRequest(productId: "mock-product-id") { _ in }
+
+                        expect(mockPurchases.invokedBeginRefundRequestForProductCount) == 1
+                        expect(mockPurchases.invokedBeginRefundRequestForProductParameters?
+                            .productId) == "mock-product-id"
+                    }
+
+                    it("does not return an error if successful") {
+                        let mockPurchases = MockPurchases()
+
+                        CommonFunctionality.sharedInstance = mockPurchases
+
+                        var completionCallCount = 0
+                        var completionError: ErrorContainer? = nil
+
+                        CommonFunctionality.beginRefundRequest(productId: "mock-product-id") { error in
+                            completionCallCount += 1
+                            completionError = error
+                        }
+                        mockPurchases.invokedBeginRefundRequestForProductParameters?.1(Result(.success, nil))
+
+                        expect(completionCallCount) == 1
+                        expect(completionError).to(beNil())
+                    }
+
+                    it("returns an error with userCancelled extra info set to true") {
+                        let mockPurchases = MockPurchases()
+
+                        CommonFunctionality.sharedInstance = mockPurchases
+
+                        var completionCallCount = 0
+                        var completionError: ErrorContainer? = nil
+
+                        CommonFunctionality.beginRefundRequest(productId: "mock-product-id") { error in
+                            completionCallCount += 1
+                            completionError = error
+                        }
+                        mockPurchases.invokedBeginRefundRequestForProductParameters?.1(Result(.userCancelled, nil))
+
+                        expect(completionCallCount) == 1
+                        expect(completionError).toNot(beNil())
+                        expect(completionError?.info["userCancelled"] as? Bool) == true
+                        expect(completionError?.message) == "User cancelled refund request."
+                    }
+
+                    it("returns an error if request failed") {
+                        let mockPurchases = MockPurchases()
+
+                        CommonFunctionality.sharedInstance = mockPurchases
+
+                        var completionCallCount = 0
+                        var completionError: ErrorContainer? = nil
+
+                        CommonFunctionality.beginRefundRequest(productId: "mock-product-id") { error in
+                            completionCallCount += 1
+                            completionError = error
+                        }
+                        mockPurchases.invokedBeginRefundRequestForProductParameters?.1(Result(.error, nil))
+
+                        expect(completionCallCount) == 1
+                        expect(completionError).toNot(beNil())
+                        expect(completionError?.message) == "Error during refund request."
+                    }
+                }
+
+                context("entitlementId") {
+                    it("passes the call correctly to Purchases") {
+                        let mockPurchases = MockPurchases()
+
+                        CommonFunctionality.sharedInstance = mockPurchases
+
+                        CommonFunctionality.beginRefundRequest(entitlementId: "mock-entitlement-id") { _ in }
+
+                        expect(mockPurchases.invokedBeginRefundRequestForEntitlementCount) == 1
+                        expect(mockPurchases.invokedBeginRefundRequestForEntitlementParameters?
+                            .entitlementId) == "mock-entitlement-id"
+                    }
+
+                    it("does not return an error if successful") {
+                        let mockPurchases = MockPurchases()
+
+                        CommonFunctionality.sharedInstance = mockPurchases
+
+                        var completionCallCount = 0
+                        var completionError: ErrorContainer? = nil
+
+                        CommonFunctionality.beginRefundRequest(entitlementId: "mock-entitlement-id") { error in
+                            completionCallCount += 1
+                            completionError = error
+                        }
+                        mockPurchases.invokedBeginRefundRequestForEntitlementParameters?.1(Result(.success, nil))
+
+                        expect(completionCallCount) == 1
+                        expect(completionError).to(beNil())
+                    }
+
+                    it("returns an error with userCancelled extra info set to true") {
+                        let mockPurchases = MockPurchases()
+
+                        CommonFunctionality.sharedInstance = mockPurchases
+
+                        var completionCallCount = 0
+                        var completionError: ErrorContainer? = nil
+
+                        CommonFunctionality.beginRefundRequest(entitlementId: "mock-entitlement-id") { error in
+                            completionCallCount += 1
+                            completionError = error
+                        }
+                        mockPurchases.invokedBeginRefundRequestForEntitlementParameters?.1(Result(.userCancelled, nil))
+
+                        expect(completionCallCount) == 1
+                        expect(completionError).toNot(beNil())
+                        expect(completionError?.info["userCancelled"] as? Bool) == true
+                        expect(completionError?.message) == "User cancelled refund request."
+                    }
+
+                    it("returns an error if request failed") {
+                        let mockPurchases = MockPurchases()
+
+                        CommonFunctionality.sharedInstance = mockPurchases
+
+                        var completionCallCount = 0
+                        var completionError: ErrorContainer? = nil
+
+                        CommonFunctionality.beginRefundRequest(entitlementId: "mock-entitlement-id") { error in
+                            completionCallCount += 1
+                            completionError = error
+                        }
+                        mockPurchases.invokedBeginRefundRequestForEntitlementParameters?.1(Result(.error, nil))
+
+                        expect(completionCallCount) == 1
+                        expect(completionError).toNot(beNil())
+                        expect(completionError?.message) == "Error during refund request."
+                    }
+                }
+
+                context("forActiveEntitlement") {
+                    it("passes the call correctly to Purchases") {
+                        let mockPurchases = MockPurchases()
+
+                        CommonFunctionality.sharedInstance = mockPurchases
+
+                        CommonFunctionality.beginRefundRequestForActiveEntitlement { _ in }
+
+                        expect(mockPurchases.invokedBeginRefundRequestForActiveEntitlementCount) == 1
+                    }
+
+                    it("does not return an error if successful") {
+                        let mockPurchases = MockPurchases()
+
+                        CommonFunctionality.sharedInstance = mockPurchases
+
+                        var completionCallCount = 0
+                        var completionError: ErrorContainer? = nil
+
+                        CommonFunctionality.beginRefundRequestForActiveEntitlement { error in
+                            completionCallCount += 1
+                            completionError = error
+                        }
+                        mockPurchases.invokedBeginRefundRequestForActiveEntitlementParameter?(Result(.success, nil))
+
+                        expect(completionCallCount) == 1
+                        expect(completionError).to(beNil())
+                    }
+
+                    it("returns an error with userCancelled extra info set to true") {
+                        let mockPurchases = MockPurchases()
+
+                        CommonFunctionality.sharedInstance = mockPurchases
+
+                        var completionCallCount = 0
+                        var completionError: ErrorContainer? = nil
+
+                        CommonFunctionality.beginRefundRequestForActiveEntitlement { error in
+                            completionCallCount += 1
+                            completionError = error
+                        }
+                        mockPurchases.invokedBeginRefundRequestForActiveEntitlementParameter?(Result(.userCancelled,
+                                                                                                     nil))
+
+                        expect(completionCallCount) == 1
+                        expect(completionError).toNot(beNil())
+                        expect(completionError?.info["userCancelled"] as? Bool) == true
+                        expect(completionError?.message) == "User cancelled refund request."
+                    }
+
+                    it("returns an error if request failed") {
+                        let mockPurchases = MockPurchases()
+
+                        CommonFunctionality.sharedInstance = mockPurchases
+
+                        var completionCallCount = 0
+                        var completionError: ErrorContainer? = nil
+
+                        CommonFunctionality.beginRefundRequestForActiveEntitlement { error in
+                            completionCallCount += 1
+                            completionError = error
+                        }
+                        mockPurchases.invokedBeginRefundRequestForActiveEntitlementParameter?(Result(.error, nil))
+
+                        expect(completionCallCount) == 1
+                        expect(completionError).toNot(beNil())
+                        expect(completionError?.message) == "Error during refund request."
+                    }
+                }
+            }
+        }
+
     }
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
@@ -29,6 +29,13 @@ class PurchasesHybridCommonTests: QuickSpec {
     )
 
     override func spec() {
+        var mockPurchases: MockPurchases!
+
+        beforeEach {
+            mockPurchases = .init()
+            CommonFunctionality.sharedInstance = mockPurchases
+        }
+
         context("automaticAppleSearchAdsAttributionCollection") {
             it("sets value") {
                 expect(Purchases.automaticAppleSearchAdsAttributionCollection) == false
@@ -63,11 +70,8 @@ class PurchasesHybridCommonTests: QuickSpec {
 
         context("logIn") {
             it("passes the call correctly to Purchases") {
-                let mockPurchases = MockPurchases()
                 let mockCreated = Bool.random()
                 mockPurchases.stubbedLogInCompletionResult = (Self.mockCustomerInfo, mockCreated, nil)
-
-                CommonFunctionality.sharedInstance = mockPurchases
 
                 let appUserID = "appUserID"
                 CommonFunctionality.logIn(appUserID: appUserID) { _, _ in }
@@ -77,11 +81,8 @@ class PurchasesHybridCommonTests: QuickSpec {
             }
 
             it("returns customerInfo and created if successful") {
-                let mockPurchases = MockPurchases()
                 let mockCreated = Bool.random()
                 mockPurchases.stubbedLogInCompletionResult = (Self.mockCustomerInfo, mockCreated, nil)
-
-                CommonFunctionality.sharedInstance = mockPurchases
 
                 var receivedResultDict: NSDictionary?
                 var receivedError: ErrorContainer?
@@ -103,12 +104,9 @@ class PurchasesHybridCommonTests: QuickSpec {
             }
 
             it("returns error if not successful") {
-                let mockPurchases = MockPurchases()
                 let mockError = NSError(domain: "revenuecat", code: 123)
 
                 mockPurchases.stubbedLogInCompletionResult = (nil, false, mockError)
-
-                CommonFunctionality.sharedInstance = mockPurchases
 
                 var receivedResultDict: NSDictionary?
                 var receivedError: ErrorContainer?
@@ -137,10 +135,7 @@ class PurchasesHybridCommonTests: QuickSpec {
 
         context("logOut") {
             it("passes the call correctly to Purchases") {
-                let mockPurchases = MockPurchases()
                 mockPurchases.stubbedLogOutCompletionResult = (Self.mockCustomerInfo, nil)
-
-                CommonFunctionality.sharedInstance = mockPurchases
 
                 CommonFunctionality.logOut { _, _ in }
 
@@ -148,10 +143,7 @@ class PurchasesHybridCommonTests: QuickSpec {
             }
 
             it("returns customerInfo if successful") {
-                let mockPurchases = MockPurchases()
                 mockPurchases.stubbedLogOutCompletionResult = (Self.mockCustomerInfo, nil)
-
-                CommonFunctionality.sharedInstance = mockPurchases
 
                 var receivedResultDict: [String: Any]?
                 var receivedError: ErrorContainer?
@@ -167,12 +159,9 @@ class PurchasesHybridCommonTests: QuickSpec {
             }
 
             it("returns error if not successful") {
-                let mockPurchases = MockPurchases()
                 let mockError = NSError(domain: "revenuecat", code: 123)
 
                 mockPurchases.stubbedLogOutCompletionResult = (nil, mockError)
-
-                CommonFunctionality.sharedInstance = mockPurchases
 
                 var receivedResultDict: NSDictionary?
                 var receivedError: ErrorContainer?
@@ -201,10 +190,6 @@ class PurchasesHybridCommonTests: QuickSpec {
             if #available(iOS 15.0, *) {
                 context("productId") {
                     it("passes the call correctly to Purchases") {
-                        let mockPurchases = MockPurchases()
-
-                        CommonFunctionality.sharedInstance = mockPurchases
-
                         CommonFunctionality.beginRefundRequest(productId: "mock-product-id") { _ in }
 
                         expect(mockPurchases.invokedBeginRefundRequestForProductCount) == 1
@@ -213,10 +198,6 @@ class PurchasesHybridCommonTests: QuickSpec {
                     }
 
                     it("does not return an error if successful") {
-                        let mockPurchases = MockPurchases()
-
-                        CommonFunctionality.sharedInstance = mockPurchases
-
                         var completionCallCount = 0
                         var completionError: ErrorContainer? = nil
 
@@ -224,17 +205,13 @@ class PurchasesHybridCommonTests: QuickSpec {
                             completionCallCount += 1
                             completionError = error
                         }
-                        mockPurchases.invokedBeginRefundRequestForProductParameters?.1(Result(.success, nil))
+                        mockPurchases.invokedBeginRefundRequestForProductParameters?.1(.success(.success))
 
                         expect(completionCallCount) == 1
                         expect(completionError).to(beNil())
                     }
 
                     it("returns an error with userCancelled extra info set to true") {
-                        let mockPurchases = MockPurchases()
-
-                        CommonFunctionality.sharedInstance = mockPurchases
-
                         var completionCallCount = 0
                         var completionError: ErrorContainer? = nil
 
@@ -242,7 +219,7 @@ class PurchasesHybridCommonTests: QuickSpec {
                             completionCallCount += 1
                             completionError = error
                         }
-                        mockPurchases.invokedBeginRefundRequestForProductParameters?.1(Result(.userCancelled, nil))
+                        mockPurchases.invokedBeginRefundRequestForProductParameters?.1(.success(.userCancelled))
 
                         expect(completionCallCount) == 1
                         expect(completionError).toNot(beNil())
@@ -251,10 +228,6 @@ class PurchasesHybridCommonTests: QuickSpec {
                     }
 
                     it("returns an error if request failed") {
-                        let mockPurchases = MockPurchases()
-
-                        CommonFunctionality.sharedInstance = mockPurchases
-
                         var completionCallCount = 0
                         var completionError: ErrorContainer? = nil
 
@@ -262,7 +235,7 @@ class PurchasesHybridCommonTests: QuickSpec {
                             completionCallCount += 1
                             completionError = error
                         }
-                        mockPurchases.invokedBeginRefundRequestForProductParameters?.1(Result(.error, nil))
+                        mockPurchases.invokedBeginRefundRequestForProductParameters?.1(.success(.error))
 
                         expect(completionCallCount) == 1
                         expect(completionError).toNot(beNil())
@@ -272,10 +245,6 @@ class PurchasesHybridCommonTests: QuickSpec {
 
                 context("entitlementId") {
                     it("passes the call correctly to Purchases") {
-                        let mockPurchases = MockPurchases()
-
-                        CommonFunctionality.sharedInstance = mockPurchases
-
                         CommonFunctionality.beginRefundRequest(entitlementId: "mock-entitlement-id") { _ in }
 
                         expect(mockPurchases.invokedBeginRefundRequestForEntitlementCount) == 1
@@ -284,10 +253,6 @@ class PurchasesHybridCommonTests: QuickSpec {
                     }
 
                     it("does not return an error if successful") {
-                        let mockPurchases = MockPurchases()
-
-                        CommonFunctionality.sharedInstance = mockPurchases
-
                         var completionCallCount = 0
                         var completionError: ErrorContainer? = nil
 
@@ -295,17 +260,13 @@ class PurchasesHybridCommonTests: QuickSpec {
                             completionCallCount += 1
                             completionError = error
                         }
-                        mockPurchases.invokedBeginRefundRequestForEntitlementParameters?.1(Result(.success, nil))
+                        mockPurchases.invokedBeginRefundRequestForEntitlementParameters?.1(.success(.success))
 
                         expect(completionCallCount) == 1
                         expect(completionError).to(beNil())
                     }
 
                     it("returns an error with userCancelled extra info set to true") {
-                        let mockPurchases = MockPurchases()
-
-                        CommonFunctionality.sharedInstance = mockPurchases
-
                         var completionCallCount = 0
                         var completionError: ErrorContainer? = nil
 
@@ -313,7 +274,7 @@ class PurchasesHybridCommonTests: QuickSpec {
                             completionCallCount += 1
                             completionError = error
                         }
-                        mockPurchases.invokedBeginRefundRequestForEntitlementParameters?.1(Result(.userCancelled, nil))
+                        mockPurchases.invokedBeginRefundRequestForEntitlementParameters?.1(.success(.userCancelled))
 
                         expect(completionCallCount) == 1
                         expect(completionError).toNot(beNil())
@@ -322,10 +283,6 @@ class PurchasesHybridCommonTests: QuickSpec {
                     }
 
                     it("returns an error if request failed") {
-                        let mockPurchases = MockPurchases()
-
-                        CommonFunctionality.sharedInstance = mockPurchases
-
                         var completionCallCount = 0
                         var completionError: ErrorContainer? = nil
 
@@ -333,7 +290,7 @@ class PurchasesHybridCommonTests: QuickSpec {
                             completionCallCount += 1
                             completionError = error
                         }
-                        mockPurchases.invokedBeginRefundRequestForEntitlementParameters?.1(Result(.error, nil))
+                        mockPurchases.invokedBeginRefundRequestForEntitlementParameters?.1(.success(.error))
 
                         expect(completionCallCount) == 1
                         expect(completionError).toNot(beNil())
@@ -343,20 +300,12 @@ class PurchasesHybridCommonTests: QuickSpec {
 
                 context("forActiveEntitlement") {
                     it("passes the call correctly to Purchases") {
-                        let mockPurchases = MockPurchases()
-
-                        CommonFunctionality.sharedInstance = mockPurchases
-
                         CommonFunctionality.beginRefundRequestForActiveEntitlement { _ in }
 
                         expect(mockPurchases.invokedBeginRefundRequestForActiveEntitlementCount) == 1
                     }
 
                     it("does not return an error if successful") {
-                        let mockPurchases = MockPurchases()
-
-                        CommonFunctionality.sharedInstance = mockPurchases
-
                         var completionCallCount = 0
                         var completionError: ErrorContainer? = nil
 
@@ -364,17 +313,13 @@ class PurchasesHybridCommonTests: QuickSpec {
                             completionCallCount += 1
                             completionError = error
                         }
-                        mockPurchases.invokedBeginRefundRequestForActiveEntitlementParameter?(Result(.success, nil))
+                        mockPurchases.invokedBeginRefundRequestForActiveEntitlementParameter?(.success(.success))
 
                         expect(completionCallCount) == 1
                         expect(completionError).to(beNil())
                     }
 
                     it("returns an error with userCancelled extra info set to true") {
-                        let mockPurchases = MockPurchases()
-
-                        CommonFunctionality.sharedInstance = mockPurchases
-
                         var completionCallCount = 0
                         var completionError: ErrorContainer? = nil
 
@@ -382,8 +327,7 @@ class PurchasesHybridCommonTests: QuickSpec {
                             completionCallCount += 1
                             completionError = error
                         }
-                        mockPurchases.invokedBeginRefundRequestForActiveEntitlementParameter?(Result(.userCancelled,
-                                                                                                     nil))
+                        mockPurchases.invokedBeginRefundRequestForActiveEntitlementParameter?(.success(.userCancelled))
 
                         expect(completionCallCount) == 1
                         expect(completionError).toNot(beNil())
@@ -392,10 +336,6 @@ class PurchasesHybridCommonTests: QuickSpec {
                     }
 
                     it("returns an error if request failed") {
-                        let mockPurchases = MockPurchases()
-
-                        CommonFunctionality.sharedInstance = mockPurchases
-
                         var completionCallCount = 0
                         var completionError: ErrorContainer? = nil
 
@@ -403,7 +343,7 @@ class PurchasesHybridCommonTests: QuickSpec {
                             completionCallCount += 1
                             completionError = error
                         }
-                        mockPurchases.invokedBeginRefundRequestForActiveEntitlementParameter?(Result(.error, nil))
+                        mockPurchases.invokedBeginRefundRequestForActiveEntitlementParameter?(.success(.error))
 
                         expect(completionCallCount) == 1
                         expect(completionError).toNot(beNil())

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
@@ -208,8 +208,8 @@ class PurchasesHybridCommonTests: QuickSpec {
                         CommonFunctionality.beginRefundRequest(productId: "mock-product-id") { _ in }
 
                         expect(mockPurchases.invokedBeginRefundRequestForProductCount) == 1
-                        expect(mockPurchases.invokedBeginRefundRequestForProductParameters?
-                            .productId) == "mock-product-id"
+                        expect(mockPurchases.invokedBeginRefundRequestForProductParameters?.productId)
+                        == "mock-product-id"
                     }
 
                     it("does not return an error if successful") {


### PR DESCRIPTION
PHC PR for https://revenuecats.atlassian.net/browse/CSDK-94

This PR adds 3 new methods to the iOS API related to `beginRefundRequest`. Users can initiate that request using a `productId`, an `entitlementId` or just refund the current active entitlement. This API doesn't apply to Android so it hasn't been added there.