### PR TITLE
Android: added `CommonKt.setLogLevel`

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.UpgradeInfo
 import com.revenuecat.purchases.BillingFeature
 import com.revenuecat.purchases.DangerousSettings
 import com.revenuecat.purchases.LogHandler
+import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.hybridcommon.mappers.map
 import com.revenuecat.purchases.getNonSubscriptionSkusWith
 import com.revenuecat.purchases.getOfferingsWith
@@ -23,6 +24,7 @@ import com.revenuecat.purchases.logInWith
 import com.revenuecat.purchases.logOutWith
 import com.revenuecat.purchases.restorePurchasesWith
 import com.revenuecat.purchases.common.PlatformInfo
+import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 
@@ -209,10 +211,19 @@ fun logOut(onResult: OnResult) {
     }
 }
 
+@Deprecated(message = "Use setLogLevel instead")
 fun setDebugLogsEnabled(
     enabled: Boolean
 ) {
     Purchases.debugLogsEnabled = enabled
+}
+
+fun setLogLevel(level: String) {
+    try {
+        Purchases.logLevel = LogLevel.valueOf(level)
+    } catch (e: IllegalArgumentException) {
+        warnLog("Unrecognized log level: $level")
+    }
 }
 
 fun setLogHandler(

--- a/android/src/test/java/apitests/java/CommonApiTests.java
+++ b/android/src/test/java/apitests/java/CommonApiTests.java
@@ -84,6 +84,10 @@ class CommonApiTests {
         CommonKt.setDebugLogsEnabled(enabled);
     }
 
+    private void checkSetLogLevel(String level) {
+        CommonKt.setLogLevel(level);
+    }
+
     private void checkSetLogHandler(LogHandler logHandler) {
         CommonKt.setLogHandler(logHandler);
     }

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
@@ -78,6 +78,10 @@ private class CommonApiTests {
         setDebugLogsEnabled(enabled)
     }
 
+    fun checkSetLogLevel(level: String) {
+        setLogLevel(level)
+    }
+
     fun checkSetLogHandler(logHandler: LogHandler) {
         setLogHandler(logHandler)
     }


### PR DESCRIPTION
For [CSDK-609], [CSDK-607], [CSDK-610], [CSDK-608].
Depends on https://github.com/RevenueCat/purchases-android/pull/753.


[CSDK-609]: https://revenuecats.atlassian.net/browse/CSDK-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CSDK-607]: https://revenuecats.atlassian.net/browse/CSDK-607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CSDK-610]: https://revenuecats.atlassian.net/browse/CSDK-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CSDK-608]: https://revenuecats.atlassian.net/browse/CSDK-608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ