### PR TITLE
Add `setLogHandlerWithOnResult`

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/OnResult.java
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/OnResult.java
@@ -1,8 +1,10 @@
 package com.revenuecat.purchases.hybridcommon;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Map;
 
 public interface OnResult {
-    void onReceived(Map<String, ?> map);
-    void onError(ErrorContainer errorContainer);
+    void onReceived(@NotNull Map<String, ?> map);
+    void onError(@NotNull ErrorContainer errorContainer);
 }

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import com.revenuecat.purchases.BillingFeature
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.DangerousSettings
-import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
@@ -234,6 +233,21 @@ fun setLogLevel(level: String) {
  */
 fun setLogHandler(callback: (logDetails: Map<String, String>) -> Unit) {
     Purchases.logHandler = LogHandlerWithMapping(callback)
+}
+
+/**
+ * Sets a log handler and forwards all logs to completion function. Accepts an OnResult so it can be used from
+ * SDKs that don't have Kotlin configured, since they would error because Kotlin's Function1 would not be found.
+ * Function1 is what Kotlin lambdas are converted to. It has a different name than setLogHandler because naming it
+ * the same also gives errors due of missing Function1.
+ *
+ * @param onResult Gets a map with two keys, a `logLevel` which  is one of the ``LogLevel`` name uppercased,
+ * and a `message`, with the log message. The onError of OnResult will never be called.
+ */
+fun setLogHandlerWithOnResult(onResult: OnResult) {
+    setLogHandler { logDetails ->
+        onResult.onReceived(logDetails)
+    }
 }
 
 fun setProxyURLString(proxyURLString: String?) {

--- a/android/src/test/java/apitests/java/CommonApiTests.java
+++ b/android/src/test/java/apitests/java/CommonApiTests.java
@@ -3,6 +3,8 @@ package apitests.java;
 import android.app.Activity;
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import com.revenuecat.purchases.DangerousSettings;
 import com.revenuecat.purchases.LogHandler;
 import com.revenuecat.purchases.Store;
@@ -98,11 +100,11 @@ class CommonApiTests {
     private void checkSetLogHandlerWithOnResult() {
         CommonKt.setLogHandlerWithOnResult(new OnResult() {
             @Override
-            public void onReceived(Map<String, ?> map) {
+            public void onReceived(@NonNull Map<String, ?> map) {
             }
 
             @Override
-            public void onError(ErrorContainer errorContainer) {
+            public void onError(@NonNull ErrorContainer errorContainer) {
             }
         });
     }

--- a/android/src/test/java/apitests/java/CommonApiTests.java
+++ b/android/src/test/java/apitests/java/CommonApiTests.java
@@ -95,6 +95,18 @@ class CommonApiTests {
         CommonKt.setLogHandler(callback);
     }
 
+    private void checkSetLogHandlerWithOnResult() {
+        CommonKt.setLogHandlerWithOnResult(new OnResult() {
+            @Override
+            public void onReceived(Map<String, ?> map) {
+            }
+
+            @Override
+            public void onError(ErrorContainer errorContainer) {
+            }
+        });
+    }
+
     private void checkSetProxyURLString(String proxyUrlString) {
         CommonKt.setProxyURLString(proxyUrlString);
     }

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
@@ -3,7 +3,6 @@ package apitests.kotlin.com.revenuecat.purchases.hybridcommon
 import android.app.Activity
 import android.content.Context
 import com.revenuecat.purchases.DangerousSettings
-import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.hybridcommon.*
@@ -84,6 +83,13 @@ private class CommonApiTests {
 
     fun checkSetLogHandler(callback: (logDetails: Map<String, String>) -> Unit) {
         setLogHandler(callback)
+    }
+
+    fun checkSetLogHandlerWithOnResult() {
+        setLogHandlerWithOnResult(object : OnResult {
+            override fun onReceived(map: Map<String?, *>?) {}
+            override fun onError(errorContainer: ErrorContainer) {}
+        })
     }
 
     fun checkSetProxyURLString(proxyURLString: String?) {

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
@@ -87,7 +87,7 @@ private class CommonApiTests {
 
     fun checkSetLogHandlerWithOnResult() {
         setLogHandlerWithOnResult(object : OnResult {
-            override fun onReceived(map: Map<String?, *>?) {}
+            override fun onReceived(map: Map<String, *>) {}
             override fun onError(errorContainer: ErrorContainer) {}
         })
     }

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -508,6 +508,30 @@ internal class CommonKtTests {
     }
 
     @Test
+    fun `logs are passed correctly to LogHandlerWithOnResult`() {
+        val expectedMessage = "a message"
+        LogLevel.values().forEach { logLevel ->
+            setLogHandlerWithOnResult(object : OnResult {
+                override fun onReceived(logDetails: MutableMap<String, *>?) {
+                    assertEquals(logLevel.name.uppercase(), logDetails?.get("logLevel"))
+                    assertEquals(expectedMessage, logDetails?.get("message"))
+                }
+
+                override fun onError(errorContainer: ErrorContainer?) {
+                    fail("onError shouldn't be called")
+                }
+            })
+            when(logLevel) {
+                LogLevel.VERBOSE -> Purchases.logHandler.v("Purchases", expectedMessage)
+                LogLevel.DEBUG -> Purchases.logHandler.d("Purchases", expectedMessage)
+                LogLevel.INFO -> Purchases.logHandler.i("Purchases", expectedMessage)
+                LogLevel.WARN -> Purchases.logHandler.w("Purchases", expectedMessage)
+                LogLevel.ERROR -> Purchases.logHandler.e("Purchases", expectedMessage, null)
+            }
+        }
+    }
+
+    @Test
     fun `error logs include error in message`() {
         val expectedMessage = "a message"
         setLogHandler { logDetails ->

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -221,7 +221,7 @@ internal class CommonKtTests {
         every { mockPurchases.logIn(appUserID, any()) } just runs
 
         logIn(appUserID = appUserID, onResult = object : OnResult {
-            override fun onReceived(map: Map<String?, *>?) {}
+            override fun onReceived(map: Map<String, *>) {}
             override fun onError(errorContainer: ErrorContainer) {}
         })
 
@@ -314,7 +314,7 @@ internal class CommonKtTests {
         every { mockPurchases.logOut(any() as ReceiveCustomerInfoCallback?) } just runs
 
         logOut(onResult = object : OnResult {
-            override fun onReceived(map: Map<String?, *>?) {}
+            override fun onReceived(map: Map<String, *>) {}
             override fun onError(errorContainer: ErrorContainer) {}
         })
 
@@ -419,11 +419,11 @@ internal class CommonKtTests {
             prorationMode = null,
             type = "subs",
             onResult = object : OnResult {
-                override fun onReceived(map: MutableMap<String, *>?) {
+                override fun onReceived(map: MutableMap<String, *>) {
                     receivedResponse = map
                 }
 
-                override fun onError(errorContainer: ErrorContainer?) {
+                override fun onError(errorContainer: ErrorContainer) {
                     fail("Should be success")
                 }
             }
@@ -474,11 +474,11 @@ internal class CommonKtTests {
             oldSku = null,
             prorationMode = null,
             onResult = object : OnResult {
-                override fun onReceived(map: MutableMap<String, *>?) {
+                override fun onReceived(map: MutableMap<String, *>) {
                     receivedResponse = map
                 }
 
-                override fun onError(errorContainer: ErrorContainer?) {
+                override fun onError(errorContainer: ErrorContainer) {
                     fail("Should be success")
                 }
             },
@@ -512,12 +512,12 @@ internal class CommonKtTests {
         val expectedMessage = "a message"
         LogLevel.values().forEach { logLevel ->
             setLogHandlerWithOnResult(object : OnResult {
-                override fun onReceived(logDetails: MutableMap<String, *>?) {
-                    assertEquals(logLevel.name.uppercase(), logDetails?.get("logLevel"))
-                    assertEquals(expectedMessage, logDetails?.get("message"))
+                override fun onReceived(logDetails: MutableMap<String, *>) {
+                    assertEquals(logLevel.name.uppercase(), logDetails["logLevel"])
+                    assertEquals(expectedMessage, logDetails["message"])
                 }
 
-                override fun onError(errorContainer: ErrorContainer?) {
+                override fun onError(errorContainer: ErrorContainer) {
                     fail("onError shouldn't be called")
                 }
             })


### PR DESCRIPTION
I am having issues when calling the lambda version of `setLogHandler` from Unity because it can't find Function1. I think it's related to purchases-unity not being configured for Kotlin. In order to be able to call `setLogHandler` I created a new version of it that uses the current `OnResult` function, so it can be called like this:

```
         CommonKt.setLogHandlerWithOnResult(new OnResult() {
            @Override
            public void onReceived(Map<String, ?> map) {
                sendJSONObject(MappersHelpersKt.convertToJson(map), HANDLE_LOG);
            }

            @Override
            public void onError(ErrorContainer errorContainer) {
                // intentionally left blank since it will never be called
            }
        });
```        

I couldn't make it an override of `setLogHandler` because I kept getting the same errors of not finding Function1, I don't know why. Possibly an issue with the Kotlin compiler:


<img width="464" alt="Screenshot 2023-02-07 at 10 04 30 PM" src="https://user-images.githubusercontent.com/664544/217448196-ae469ead-b8e4-4178-8526-d419f7c40730.png">
<img width="513" alt="Screenshot 2023-02-07 at 10 04 10 PM" src="https://user-images.githubusercontent.com/664544/217448204-e8adb6e5-30b3-411f-8c59-405e74525400.png">

