### PR TITLE
Passes error instead of two nils

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -405,7 +405,10 @@ import RevenueCat
                                  discountIdentifier: String?,
                                  completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
         guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) else {
-            completion(nil, nil)
+            completion(
+                nil,
+                Self.createErrorContainer(error: ErrorCode.unsupportedError)
+            )
             return
         }
 


### PR DESCRIPTION
While working on https://github.com/RevenueCat/purchases-unity/pull/245 I noticed how we were passing a `nil` error in case of incompatibilities when getting promotional offers. I changed that to return an error for versions of iOS that are not compatible with discounts.