### PR TITLE
Re-enable `pod lib lint` for `watchOS`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ commands:
   run-ios-tests:
     steps:
       - checkout
+      - install-gems
       - run:
           name: Install pods
           command: pod install --repo-update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,8 +91,7 @@ commands:
             SCAN_SCHEME: PurchasesHybridCommon
       - run:
           name: Run pod lint tests
-          # TODO: re-enable watchOS when https://github.com/CocoaPods/CocoaPods/issues/11558 is fixed
-          command: pod lib lint --fail-fast --platforms=ios,osx,tvos
+          command: pod lib lint --fail-fast --platforms=ios,watchos,osx,tvos
       - store_test_results:
           path: ios/PurchasesHybridCommon/test_output
       - store_artifacts:


### PR DESCRIPTION
This was fixed by https://github.com/CocoaPods/CocoaPods/issues/11558 in https://github.com/CocoaPods/CocoaPods/releases/tag/1.12.0
