### PR TITLE
[BC5] Adds PREPAID_SUBSCRIPTION to mapProductType

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.hybridcommon.mappers
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.PricingPhase
+import com.revenuecat.purchases.models.RecurrenceMode
 import com.revenuecat.purchases.models.StoreProduct
 
 val StoreProduct.priceAmountMicros: Long
@@ -53,7 +54,13 @@ internal fun StoreProduct.mapProductCategory(): String {
 internal fun StoreProduct.mapProductType(): String {
     return when (type) {
         ProductType.INAPP -> "CONSUMABLE"
-        ProductType.SUBS -> "AUTO_RENEWABLE_SUBSCRIPTION" // TODO: Add a new string here prepaid (check recurrence mode)
+        ProductType.SUBS -> {
+            if (defaultOption?.fullPricePhase?.recurrenceMode == RecurrenceMode.NON_RECURRING) {
+                "PREPAID_SUBSCRIPTION"
+            } else {
+                "AUTO_RENEWABLE_SUBSCRIPTION"
+            }
+        }
         ProductType.UNKNOWN -> "UNKNOWN"
     }
 }

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -569,59 +569,6 @@ internal class CommonKtTests {
         val offerings = Offerings(current = offering, all = mapOf(offeringIdentifier to offering))
         return Triple(offeringIdentifier, packageToPurchase, offerings)
     }
-
-//    private fun mockSubscriptionProduct(expectedProductIdentifier: String): StoreProduct {
-//        val mockSkuDetails = mockSkuDetails(
-//            productId = expectedProductIdentifier,
-//            type = BillingClient.SkuType.SUBS
-//        )
-//        return mockSkuDetails.toStoreProduct()
-//    }
-//
-//    private fun mockSkuDetails(
-//        productId: String = "monthly_intro_pricing_one_week",
-//        @BillingClient.SkuType type: String = BillingClient.SkuType.SUBS,
-//        price: Double = 4.99,
-//        subscriptionPeriod: String = "P1M",
-//        freeTrialPeriod: String? = null,
-//    ): SkuDetails {
-//        val mockedSkuDetails = mockk<SkuDetails>()
-//        every { mockedSkuDetails.sku } returns productId
-//        every { mockedSkuDetails.type } returns type
-//        every { mockedSkuDetails.price } returns "${'$'}$price"
-//        every { mockedSkuDetails.priceAmountMicros } returns price.times(1_000_000).toLong()
-//        every { mockedSkuDetails.priceCurrencyCode } returns "USD"
-//        every { mockedSkuDetails.subscriptionPeriod } returns subscriptionPeriod
-//        every { mockedSkuDetails.freeTrialPeriod } returns (freeTrialPeriod ?: "")
-//        every { mockedSkuDetails.introductoryPrice } returns ""
-//        every { mockedSkuDetails.introductoryPricePeriod } returns ""
-//        every { mockedSkuDetails.introductoryPriceAmountMicros } returns 0
-//        every { mockedSkuDetails.introductoryPriceCycles } returns 0
-//        every { mockedSkuDetails.iconUrl } returns ""
-//        every { mockedSkuDetails.originalJson } returns """
-//            {
-//            "skuDetailsToken":"AEuhp4KxWQR-b-OAOXVicqHM4QqnqK9vkPnOXw0vSB9zWPBlTsW8TmtjSEJ_rJ6f0_-i",
-//            "productId":"$productId",
-//            "type":"$type",
-//            "price":"${'$'}$price",
-//            "price_amount_micros":${price.times(1_000_000)},
-//            "price_currency_code":"USD",
-//            "subscriptionPeriod":"$subscriptionPeriod",
-//            "freeTrialPeriod":"$freeTrialPeriod",
-//            "introductoryPricePeriod":"",
-//            "introductoryPriceAmountMicros":0,
-//            "introductoryPrice":"",
-//            "introductoryPriceCycles":0,
-//            "title":"Monthly Product Intro Pricing One Week (PurchasesSample)",
-//            "description":"Monthly Product Intro Pricing One Week"
-//        }
-//        """.trimIndent()
-//        every { mockedSkuDetails.title } returns "Monthly Product Intro Pricing One Week (PurchasesSample)"
-//        every { mockedSkuDetails.description } returns "Monthly Product Intro Pricing One Week"
-//        every { mockedSkuDetails.originalPrice } returns mockedSkuDetails.price
-//        every { mockedSkuDetails.originalPriceAmountMicros } returns mockedSkuDetails.priceAmountMicros
-//        return mockedSkuDetails
-//    }
 }
 
 const val MICROS_MULTIPLIER = 1_000_000
@@ -629,27 +576,30 @@ const val MICROS_MULTIPLIER = 1_000_000
 @SuppressWarnings("EmptyFunctionBlock")
 fun stubStoreProduct(
     productId: String,
+    description: String = "",
+    title: String = "",
+    type: ProductType = ProductType.SUBS,
     defaultOption: SubscriptionOption? = stubSubscriptionOption(
         "monthly_base_plan", productId,
         Period(1, Period.Unit.MONTH, "P1M"),
     ),
-    subscriptionOptions: List<SubscriptionOption> = defaultOption?.let { listOf(defaultOption) } ?: emptyList(),
-    price: Price = subscriptionOptions.first().fullPricePhase!!.price
+    subscriptionOptions: List<SubscriptionOption>? = defaultOption?.let { listOf(defaultOption) } ?: emptyList(),
+    price: Price = subscriptionOptions?.firstOrNull()?.fullPricePhase!!.price
 ): StoreProduct = object : StoreProduct {
     override val id: String
         get() = productId
     override val type: ProductType
-        get() = ProductType.SUBS
+        get() = type
     override val price: Price
         get() = price
     override val title: String
-        get() = ""
+        get() = title
     override val description: String
-        get() = ""
+        get() = description
     override val period: Period?
-        get() = subscriptionOptions.firstOrNull { it.isBasePlan }?.pricingPhases?.get(0)?.billingPeriod
-    override val subscriptionOptions: SubscriptionOptions
-        get() = SubscriptionOptions(subscriptionOptions)
+        get() = subscriptionOptions?.firstOrNull { it.isBasePlan }?.pricingPhases?.get(0)?.billingPeriod
+    override val subscriptionOptions: SubscriptionOptions?
+        get() = subscriptionOptions?.let { SubscriptionOptions(it) }
     override val defaultOption: SubscriptionOption?
         get() = defaultOption
     override val purchasingData: PurchasingData
@@ -697,6 +647,7 @@ private data class StubPurchasingData(
 fun stubPricingPhase(
     billingPeriod: Period = Period(1, Period.Unit.MONTH, "P1M"),
     priceCurrencyCodeValue: String = "USD",
+    priceFormatted: String = "$4.99",
     price: Double = 4.99,
     recurrenceMode: Int = ProductDetails.RecurrenceMode.INFINITE_RECURRING,
     billingCycleCount: Int = 0
@@ -704,5 +655,5 @@ fun stubPricingPhase(
     billingPeriod,
     recurrenceMode.toRecurrenceMode(),
     billingCycleCount,
-    Price(if (price == 0.0) "Free" else "${'$'}$price", price.times(MICROS_MULTIPLIER).toLong(), priceCurrencyCodeValue)
+    Price(priceFormatted, price.times(MICROS_MULTIPLIER).toLong(), priceCurrencyCodeValue)
 )

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
@@ -1,7 +1,11 @@
 package com.revenuecat.purchases.hybridcommon.mappers
 
 import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.hybridcommon.stubPricingPhase
 import com.revenuecat.purchases.hybridcommon.stubStoreProduct
+import com.revenuecat.purchases.hybridcommon.stubSubscriptionOption
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.StoreProduct
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
@@ -9,117 +13,211 @@ import org.junit.jupiter.api.Test
 
 internal class StoreProductMapperTest {
 
+    val exptectedProductId = "expected_product_identifier"
+
     @Test
     fun `maps product identifier correctly`() {
-        val expected = "expected_product_identifier"
-        stubStoreProduct(productId = expected).map().let {
-            assertThat(it["identifier"]).isEqualTo(expected)
+        stubStoreProduct(productId = exptectedProductId).map().let {
+            assertThat(it["identifier"]).isEqualTo(exptectedProductId)
         }
     }
 
     // TODO: Fix stubs for all of these tests
-//    @Test
-//    fun `maps product description correctly`() {
-//        val expected = "Expected Description"
-//        stubStoreProduct(description = expected).map().let {
-//            assertThat(it["description"]).isEqualTo(expected)
-//        }
-//    }
-//
-//    @Test
-//    fun `maps product title correctly`() {
-//        val expected = "Expected Title"
-//        stubStoreProduct(title = expected).map().let {
-//            assertThat(it["title"]).isEqualTo(expected)
-//        }
-//    }
-//
-//    @Test
-//    fun `maps product price correctly`() {
-//        val expected = 2.0
-//        stubStoreProduct(priceAmountMicros = (expected * 1_000_000).toLong()).map().let {
-//            assertThat(it["price"]).isEqualTo(expected)
-//        }
-//    }
-//
-//    @Test
-//    fun `maps product price string correctly`() {
-//        val expected = "$2.00"
-//        stubStoreProduct(price = expected).map().let {
-//            assertThat(it["priceString"]).isEqualTo(expected)
-//        }
-//    }
-//
-//    @Test
-//    fun `maps currency code correctly`() {
-//        val expected = "CAD"
-//        stubStoreProduct(priceCurrencyCode = expected).map().let {
-//            assertThat(it["currencyCode"]).isEqualTo(expected)
-//        }
-//    }
-//
-//    @Test
-//    fun `maps introPrice correctly`() {
-//        stubStoreProduct(freeTrialPeriod = "P7D").map().let {
-//            @Suppress("UNCHECKED_CAST")
-//            val introPriceMap: Map<String, Any> = it["introPrice"] as Map<String, Any>
-//            assertThat(introPriceMap["period"]).isNotNull
-//        }
-//        // Testing for the intro price mapping is performed in StoreProductIntroPriceMapperTest
-//    }
-//
-//    @Test
-//    fun `maps null introPrice correctly`() {
-//        stubStoreProduct(freeTrialPeriod = null, introductoryPrice = null).map().let {
-//            assertThat(it["introPrice"]).isNull()
-//        }
-//    }
-//
-//    @Test
-//    fun `maps null discounts correctly`() {
-//        stubStoreProduct().map().let {
-//            assertThat(it["discounts"]).isNull()
-//        }
-//    }
-//
-//    @Test
-//    fun `maps product category correctly`() {
-//        stubStoreProduct(type = ProductType.SUBS).map().let {
-//            assertThat(it["productCategory"]).isEqualTo("SUBSCRIPTION")
-//        }
-//        stubStoreProduct(type = ProductType.INAPP).map().let {
-//            assertThat(it["productCategory"]).isEqualTo("NON_SUBSCRIPTION")
-//        }
-//        stubStoreProduct(type = ProductType.UNKNOWN).map().let {
-//            assertThat(it["productCategory"]).isEqualTo("UNKNOWN")
-//        }
-//    }
-//
-//    @Test
-//    fun `maps product type correctly`() {
-//        stubStoreProduct(type = ProductType.SUBS).map().let {
-//            assertThat(it["productType"]).isEqualTo("AUTO_RENEWABLE_SUBSCRIPTION")
-//        }
-//        stubStoreProduct(type = ProductType.INAPP).map().let {
-//            assertThat(it["productType"]).isEqualTo("CONSUMABLE")
-//        }
-//        stubStoreProduct(type = ProductType.UNKNOWN).map().let {
-//            assertThat(it["productType"]).isEqualTo("UNKNOWN")
-//        }
-//    }
-//
-//    @Test
-//    fun `maps subscription period correctly`() {
-//        stubStoreProduct().map().let {
-//            assertThat(it["subscriptionPeriod"]).isNull()
-//        }
-//        stubStoreProduct(subscriptionPeriod = "P1M").map().let {
-//            assertThat(it["subscriptionPeriod"]).isEqualTo("P1M")
-//        }
-//        stubStoreProduct(subscriptionPeriod = "P1Y").map().let {
-//            assertThat(it["subscriptionPeriod"]).isEqualTo("P1Y")
-//        }
-//    }
+    @Test
+    fun `maps product description correctly`() {
+        val expected = "Expected Description"
+        stubStoreProduct(
+            productId = exptectedProductId,
+            description = expected
+        ).map().let {
+            assertThat(it["description"]).isEqualTo(expected)
+        }
+    }
+
+    @Test
+    fun `maps product title correctly`() {
+        val expected = "Expected Title"
+        stubStoreProduct(
+            productId = exptectedProductId,
+            title = expected
+        ).map().let {
+            assertThat(it["title"]).isEqualTo(expected)
+        }
+    }
+
+    @Test
+    fun `maps product price correctly`() {
+        val duration = Period(1, Period.Unit.MONTH, "P1M")
+
+        val expected = 2.0
+        val expectedFormatted = "$2.00"
+        val expectedCurrencyCode = "USD"
+        stubStoreProduct(
+            productId = exptectedProductId,
+            defaultOption = stubSubscriptionOption(
+                "monthly_base_plan", exptectedProductId,
+                duration,
+                pricingPhases = listOf(
+                    stubPricingPhase(
+                        billingPeriod = duration,
+                        priceCurrencyCodeValue = expectedCurrencyCode,
+                        priceFormatted = expectedFormatted,
+                        price = expected
+                    )
+                )
+            )
+        ).map().let {
+            assertThat(it["price"]).isEqualTo(expected)
+            assertThat(it["priceString"]).isEqualTo(expectedFormatted)
+            assertThat(it["currencyCode"]).isEqualTo(expectedCurrencyCode)
+        }
+    }
+
+    @Test
+    fun `maps free introPrice correctly`() {
+        val freeTrialDuration = Period(1, Period.Unit.MONTH, "P7D")
+        val duration = Period(1, Period.Unit.MONTH, "P1M")
+
+        stubStoreProduct(
+            productId = exptectedProductId,
+            defaultOption = stubSubscriptionOption(
+                "monthly_base_plan", exptectedProductId,
+                duration,
+                pricingPhases = listOf(
+                    stubPricingPhase(
+                        billingPeriod = freeTrialDuration,
+                        priceFormatted = "$0.00",
+                        price = 0.0
+                    ),
+                    stubPricingPhase(
+                        billingPeriod = duration,
+                    )
+                )
+            )
+        ).map().let {
+            @Suppress("UNCHECKED_CAST")
+            val introPriceMap: Map<String, Any> = it["introPrice"] as Map<String, Any>
+            assertThat(introPriceMap["period"]).isNotNull
+        }
+        // Testing for the intro price mapping is performed in StoreProductIntroPriceMapperTest
+    }
+
+    @Test
+    fun `maps null introPrice correctly`() {
+        stubStoreProduct(
+            productId = exptectedProductId,
+            defaultOption = stubSubscriptionOption(
+                "monthly_base_plan", exptectedProductId,
+            )
+        ).map().let {
+            assertThat(it["introPrice"]).isNull()
+        }
+    }
+
+    @Test
+    fun `maps null discounts correctly`() {
+        stubStoreProduct(
+            productId = exptectedProductId,
+            defaultOption = stubSubscriptionOption(
+                "monthly_base_plan", exptectedProductId,
+            )
+        ).map().let {
+            assertThat(it["discounts"]).isNull()
+        }
+    }
+
+    @Test
+    fun `maps product category correctly`() {
+        stubStoreProduct(
+            productId = exptectedProductId,
+            type = ProductType.SUBS
+        ).map().let {
+            assertThat(it["productCategory"]).isEqualTo("SUBSCRIPTION")
+        }
+        stubStoreProduct(
+            productId = exptectedProductId,
+            type = ProductType.INAPP
+        ).map().let {
+            assertThat(it["productCategory"]).isEqualTo("NON_SUBSCRIPTION")
+        }
+        stubStoreProduct(
+            productId = exptectedProductId,
+            type = ProductType.UNKNOWN
+        ).map().let {
+            assertThat(it["productCategory"]).isEqualTo("UNKNOWN")
+        }
+    }
+
+    @Test
+    fun `maps product type correctly`() {
+        val duration = Period(1, Period.Unit.MONTH, "P1M")
+
+        stubStoreProduct(
+            productId = exptectedProductId,
+            type = ProductType.SUBS
+        ).map().let {
+            assertThat(it["productType"]).isEqualTo("AUTO_RENEWABLE_SUBSCRIPTION")
+        }
+        stubStoreProduct(
+            productId = exptectedProductId,
+            type = ProductType.SUBS,
+            defaultOption = stubSubscriptionOption(
+                "monthly_base_plan", exptectedProductId,
+                duration,
+                pricingPhases = listOf(
+                    stubPricingPhase(
+                        billingPeriod = duration,
+                        recurrenceMode = 3
+                    )
+                )
+            )
+        ).map().let {
+            assertThat(it["productType"]).isEqualTo("PREPAID_SUBSCRIPTION")
+        }
+        stubStoreProduct(
+            productId = exptectedProductId,
+            type = ProductType.INAPP
+        ).map().let {
+            assertThat(it["productType"]).isEqualTo("CONSUMABLE")
+        }
+        stubStoreProduct(
+            productId = exptectedProductId,
+            type = ProductType.UNKNOWN
+        ).map().let {
+            assertThat(it["productType"]).isEqualTo("UNKNOWN")
+        }
+    }
+
+    @Test
+    fun `maps subscription period correctly`() {
+        stubStoreProduct(
+            productId = exptectedProductId,
+            type = ProductType.INAPP,
+            defaultOption = null,
+            subscriptionOptions = emptyList(),
+            price = Price("$1.99", 19900000, "USD")
+        ).map().let {
+            assertThat(it["subscriptionPeriod"]).isNull()
+        }
+        stubStoreProduct(
+            productId = exptectedProductId,
+            defaultOption = stubSubscriptionOption(
+                "monthly_base_plan", exptectedProductId,
+                Period(1, Period.Unit.MONTH, "P1M")
+            )
+        ).map().let {
+            assertThat(it["subscriptionPeriod"]).isEqualTo("P1M")
+        }
+        stubStoreProduct(
+            productId = exptectedProductId,
+            defaultOption = stubSubscriptionOption(
+                "monthly_base_plan", exptectedProductId,
+                Period(1, Period.Unit.MONTH, "P1Y")
+            )
+        ).map().let {
+            assertThat(it["subscriptionPeriod"]).isEqualTo("P1Y")
+        }
+    }
 
     @Test
     fun `map has correct size`() {
@@ -128,41 +226,3 @@ internal class StoreProductMapperTest {
         }
     }
 }
-
-//fun stubStoreProduct(
-//    sku: String = "monthly_product",
-//    type: ProductType = ProductType.SUBS,
-//    price: String = "$1.00",
-//    priceAmountMicros: Long = 1_000_000,
-//    priceCurrencyCode: String = "USD",
-//    originalPrice: String? = "$1.00",
-//    originalPriceAmountMicros: Long = 0,
-//    title: String = "A product title",
-//    description: String = "A product description",
-//    subscriptionPeriod: String? = null,
-//    freeTrialPeriod: String? = "P7D",
-//    introductoryPrice: String? = null,
-//    introductoryPriceAmountMicros: Long = 0,
-//    introductoryPricePeriod: String? = null,
-//    introductoryPriceCycles: Int = 0,
-//    iconUrl: String = "http://url.com",
-//    originalJson: JSONObject = JSONObject("{}")
-//) = StoreProduct(
-//    sku = sku,
-//    type = type,
-//    price = price,
-//    priceAmountMicros = priceAmountMicros,
-//    priceCurrencyCode = priceCurrencyCode,
-//    originalPrice = originalPrice,
-//    originalPriceAmountMicros = originalPriceAmountMicros,
-//    title = title,
-//    description = description,
-//    subscriptionPeriod = subscriptionPeriod,
-//    freeTrialPeriod = freeTrialPeriod,
-//    introductoryPrice = introductoryPrice,
-//    introductoryPriceAmountMicros = introductoryPriceAmountMicros,
-//    introductoryPricePeriod = introductoryPricePeriod,
-//    introductoryPriceCycles = introductoryPriceCycles,
-//    iconUrl = iconUrl,
-//    originalJson = originalJson
-//)


### PR DESCRIPTION
## Motivation

[CF-1265](https://revenuecats.atlassian.net/browse/CF-1265)

## Description

`StoreProduct.mapProductType` only had a value of `AUTO_RENEWABLE_SUBSCRIPTION` which does not work if its a prepaid subscription. Even though we don't _really_ say we support prepaid subscriptions yet, it just made sense to add a support for this right away since minimal effort.

So... `PREPAID_SUBSCRIPTION` is now a value if its a `ProductType.SUBS` and `RecurrenceMode.NON_RECURRING`

I also fixed a bunch of tests I had commented out that I forgot to fix in the main `bc5-support` PR 🤷‍♂️ 

[CF-1265]: https://revenuecats.atlassian.net/browse/CF-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ