### PR TITLE
[BC5] Add isPersonalizedPrice to purchaseProduct and purchasePackage

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -58,6 +58,7 @@ fun purchaseProduct(
     oldSku: String?,
     prorationMode: GoogleProrationMode?,
     type: String,
+    isPersonalizedPrice: Boolean?,
     onResult: OnResult
 ) {
     if (activity != null) {
@@ -69,6 +70,7 @@ fun purchaseProduct(
             if (productToBuy != null) {
                 val purchaseParams = PurchaseParams.Builder(productToBuy, activity)
 
+                // Product upgrade
                 if (oldSku != null && oldSku.isNotBlank()) {
                     purchaseParams.oldProductId(oldSku)
                     if (prorationMode != null) {
@@ -76,6 +78,12 @@ fun purchaseProduct(
                     }
                 }
 
+                // Personalized price
+                isPersonalizedPrice?.let {
+                    purchaseParams.isPersonalizedPrice(isPersonalizedPrice)
+                }
+
+                // Perform purchase
                 Purchases.sharedInstance.purchaseWith(
                     purchaseParams.build(),
                     onError = getPurchaseErrorFunction(onResult),
@@ -123,6 +131,7 @@ fun purchasePackage(
     offeringIdentifier: String,
     oldSku: String?,
     prorationMode: GoogleProrationMode?,
+    isPersonalizedPrice: Boolean?,
     onResult: OnResult
 ) {
     if (activity != null) {
@@ -136,6 +145,7 @@ fun purchasePackage(
                 if (packageToBuy != null) {
                     val purchaseParams = PurchaseParams.Builder(packageToBuy, activity)
 
+                    // Product upgrade
                     if (oldSku != null && oldSku.isNotBlank()) {
                         purchaseParams.oldProductId(oldSku)
                         if (prorationMode != null) {
@@ -143,6 +153,12 @@ fun purchasePackage(
                         }
                     }
 
+                    // Personalized price
+                    isPersonalizedPrice?.let {
+                        purchaseParams.isPersonalizedPrice(isPersonalizedPrice)
+                    }
+
+                    // Perform purchase
                     Purchases.sharedInstance.purchaseWith(
                         purchaseParams.build(),
                         onError = getPurchaseErrorFunction(onResult),

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -55,10 +55,10 @@ fun getProductInfo(
 fun purchaseProduct(
     activity: Activity?,
     productIdentifier: String,
-    oldSku: String?,
-    prorationMode: GoogleProrationMode?,
     type: String,
-    isPersonalizedPrice: Boolean?,
+    googleOldProductId: String?,
+    googleProrationMode: GoogleProrationMode?,
+    googleIsPersonalizedPrice: Boolean?,
     onResult: OnResult
 ) {
     if (activity != null) {
@@ -71,16 +71,16 @@ fun purchaseProduct(
                 val purchaseParams = PurchaseParams.Builder(productToBuy, activity)
 
                 // Product upgrade
-                if (oldSku != null && oldSku.isNotBlank()) {
-                    purchaseParams.oldProductId(oldSku)
-                    if (prorationMode != null) {
-                        purchaseParams.googleProrationMode(prorationMode)
+                if (googleOldProductId != null && googleOldProductId.isNotBlank()) {
+                    purchaseParams.oldProductId(googleOldProductId)
+                    if (googleProrationMode != null) {
+                        purchaseParams.googleProrationMode(googleProrationMode)
                     }
                 }
 
                 // Personalized price
-                isPersonalizedPrice?.let {
-                    purchaseParams.isPersonalizedPrice(isPersonalizedPrice)
+                googleIsPersonalizedPrice?.let {
+                    purchaseParams.isPersonalizedPrice(googleIsPersonalizedPrice)
                 }
 
                 // Perform purchase
@@ -129,9 +129,9 @@ fun purchasePackage(
     activity: Activity?,
     packageIdentifier: String,
     offeringIdentifier: String,
-    oldSku: String?,
-    prorationMode: GoogleProrationMode?,
-    isPersonalizedPrice: Boolean?,
+    googleOldProductId: String?,
+    googleProrationMode: GoogleProrationMode?,
+    googleIsPersonalizedPrice: Boolean?,
     onResult: OnResult
 ) {
     if (activity != null) {
@@ -146,16 +146,16 @@ fun purchasePackage(
                     val purchaseParams = PurchaseParams.Builder(packageToBuy, activity)
 
                     // Product upgrade
-                    if (oldSku != null && oldSku.isNotBlank()) {
-                        purchaseParams.oldProductId(oldSku)
-                        if (prorationMode != null) {
-                            purchaseParams.googleProrationMode(prorationMode)
+                    if (googleOldProductId != null && googleOldProductId.isNotBlank()) {
+                        purchaseParams.oldProductId(googleOldProductId)
+                        if (googleProrationMode != null) {
+                            purchaseParams.googleProrationMode(googleProrationMode)
                         }
                     }
 
                     // Personalized price
-                    isPersonalizedPrice?.let {
-                        purchaseParams.isPersonalizedPrice(isPersonalizedPrice)
+                    googleIsPersonalizedPrice?.let {
+                        purchaseParams.isPersonalizedPrice(googleIsPersonalizedPrice)
                     }
 
                     // Perform purchase

--- a/android/src/test/java/apitests/java/CommonApiTests.java
+++ b/android/src/test/java/apitests/java/CommonApiTests.java
@@ -36,18 +36,18 @@ class CommonApiTests {
 
     private void checkPurchaseProduct(Activity activity,
                               String productIdentifier,
-                              String oldSku,
-                              GoogleProrationMode prorationMode,
                               String type,
-                              Boolean isPersonalizedPrice,
+                              String googleOldProductId,
+                              GoogleProrationMode googleProrationMode,
+                              Boolean googleIsPersonalizedPrice,
                               OnResult onResult) {
         CommonKt.purchaseProduct(
                 activity,
                 productIdentifier,
-                oldSku,
-                prorationMode,
                 type,
-                isPersonalizedPrice,
+                googleOldProductId,
+                googleProrationMode,
+                googleIsPersonalizedPrice,
                 onResult
         );
     }
@@ -55,17 +55,17 @@ class CommonApiTests {
     private void checkPurchasePackage(Activity activity,
                               String packageIdentifier,
                               String offeringIdentifier,
-                              String oldSku,
-                              GoogleProrationMode prorationMode,
-                              Boolean isPersonalizedPrice,
+                              String googleOldProductId,
+                              GoogleProrationMode googleProrationMode,
+                              Boolean googleIsPersonalizedPrice,
                               OnResult onResult) {
         CommonKt.purchasePackage(
                 activity,
                 packageIdentifier,
                 offeringIdentifier,
-                oldSku,
-                prorationMode,
-                isPersonalizedPrice,
+                googleOldProductId,
+                googleProrationMode,
+                googleIsPersonalizedPrice,
                 onResult
         );
     }

--- a/android/src/test/java/apitests/java/CommonApiTests.java
+++ b/android/src/test/java/apitests/java/CommonApiTests.java
@@ -39,6 +39,7 @@ class CommonApiTests {
                               String oldSku,
                               GoogleProrationMode prorationMode,
                               String type,
+                              Boolean isPersonalizedPrice,
                               OnResult onResult) {
         CommonKt.purchaseProduct(
                 activity,
@@ -46,6 +47,7 @@ class CommonApiTests {
                 oldSku,
                 prorationMode,
                 type,
+                isPersonalizedPrice,
                 onResult
         );
     }
@@ -55,6 +57,7 @@ class CommonApiTests {
                               String offeringIdentifier,
                               String oldSku,
                               GoogleProrationMode prorationMode,
+                              Boolean isPersonalizedPrice,
                               OnResult onResult) {
         CommonKt.purchasePackage(
                 activity,
@@ -62,6 +65,7 @@ class CommonApiTests {
                 offeringIdentifier,
                 oldSku,
                 prorationMode,
+                isPersonalizedPrice,
                 onResult
         );
     }

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
@@ -25,31 +25,31 @@ private class CommonApiTests {
     fun checkPurchaseProduct(
         activity: Activity?,
         productIdentifier: String,
-        oldSku: String?,
-        prorationMode: GoogleProrationMode?,
         type: String,
-        isPersonalizedPrice: Boolean?,
+        googleOldProductId: String?,
+        googleProrationMode: GoogleProrationMode?,
+        googleIsPersonalizedPrice: Boolean?,
         onResult: OnResult
     ) {
-        purchaseProduct(activity, productIdentifier, oldSku, prorationMode, type, isPersonalizedPrice, onResult)
+        purchaseProduct(activity, productIdentifier, type, googleOldProductId, googleProrationMode, googleIsPersonalizedPrice, onResult)
     }
 
     fun checkPurchasePackage(
         activity: Activity?,
         packageIdentifier: String,
         offeringIdentifier: String,
-        oldSku: String?,
-        prorationMode: GoogleProrationMode?,
-        isPersonalizedPrice: Boolean?,
+        googleOldProductId: String?,
+        googleProrationMode: GoogleProrationMode?,
+        googleIsPersonalizedPrice: Boolean?,
         onResult: OnResult
     ) {
         purchasePackage(
             activity,
             packageIdentifier,
             offeringIdentifier,
-            oldSku,
-            prorationMode,
-            isPersonalizedPrice,
+            googleOldProductId,
+            googleProrationMode,
+            googleIsPersonalizedPrice,
             onResult
         )
     }

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
@@ -28,9 +28,10 @@ private class CommonApiTests {
         oldSku: String?,
         prorationMode: GoogleProrationMode?,
         type: String,
+        isPersonalizedPrice: Boolean?,
         onResult: OnResult
     ) {
-        purchaseProduct(activity, productIdentifier, oldSku, prorationMode, type, onResult)
+        purchaseProduct(activity, productIdentifier, oldSku, prorationMode, type, isPersonalizedPrice, onResult)
     }
 
     fun checkPurchasePackage(
@@ -39,6 +40,7 @@ private class CommonApiTests {
         offeringIdentifier: String,
         oldSku: String?,
         prorationMode: GoogleProrationMode?,
+        isPersonalizedPrice: Boolean?,
         onResult: OnResult
     ) {
         purchasePackage(
@@ -47,6 +49,7 @@ private class CommonApiTests {
             offeringIdentifier,
             oldSku,
             prorationMode,
+            isPersonalizedPrice,
             onResult
         )
     }

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -430,10 +430,10 @@ internal class CommonKtTests {
         purchaseProduct(
             mockActivity,
             productIdentifier = expectedProductIdentifier,
-            oldSku = null,
-            prorationMode = null,
             type = "subs",
-            isPersonalizedPrice = null,
+            googleOldProductId = null,
+            googleProrationMode = null,
+            googleIsPersonalizedPrice = null,
             onResult = object : OnResult {
                 override fun onReceived(map: MutableMap<String, *>) {
                     receivedResponse = map
@@ -491,10 +491,10 @@ internal class CommonKtTests {
         purchaseProduct(
             mockActivity,
             productIdentifier = expectedProductIdentifier,
-            oldSku = null,
-            prorationMode = null,
             type = "subs",
-            isPersonalizedPrice = true,
+            googleOldProductId = null,
+            googleProrationMode = null,
+            googleIsPersonalizedPrice = true,
             onResult = object : OnResult {
                 override fun onReceived(map: MutableMap<String, *>) {
                     receivedResponse = map
@@ -551,9 +551,9 @@ internal class CommonKtTests {
         purchasePackage(
             mockActivity,
             packageIdentifier = "packageIdentifier",
-            oldSku = null,
-            prorationMode = null,
-            isPersonalizedPrice = null,
+            googleOldProductId = null,
+            googleProrationMode = null,
+            googleIsPersonalizedPrice = null,
             onResult = object : OnResult {
                 override fun onReceived(map: MutableMap<String, *>) {
                     receivedResponse = map
@@ -611,9 +611,9 @@ internal class CommonKtTests {
         purchasePackage(
             mockActivity,
             packageIdentifier = "packageIdentifier",
-            oldSku = null,
-            prorationMode = null,
-            isPersonalizedPrice = true,
+            googleOldProductId = null,
+            googleProrationMode = null,
+            googleIsPersonalizedPrice = true,
             onResult = object : OnResult {
                 override fun onReceived(map: MutableMap<String, *>) {
                     receivedResponse = map


### PR DESCRIPTION
## Motivation

[CF-1266](https://revenuecats.atlassian.net/browse/CF-1266)

## Description

Adds `isPersonalizedPrice: Boolean?` argument onto `purchaseProduct` and `purchasePackage`

[CF-1266]: https://revenuecats.atlassian.net/browse/CF-1266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ