### PR TITLE
[BC5] Temporarily remove Unity IAP from tests and release until its supported

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,10 +276,6 @@ jobs:
           name: Kick off Cordova automatic dependency update
           command: bundle exec fastlane bump_hybrid_dependencies repo_name:cordova-plugin-purchases
           when: always
-      - run:
-          name: Kick off Unity automatic dependency update
-          command: bundle exec fastlane bump_hybrid_dependencies repo_name:purchases-unity
-          when: always
 
 workflows:
   version: 2

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,6 @@ buildscript {
     ext.mockk_version = '1.12.3'
     ext.gradle_maven_publish = '0.22.0'
     ext.purchases_version = '6.0.0-beta.2'
-    ext.billing_unityiap_purchases_version = '3.0.3'
 
     repositories {
         google()
@@ -29,9 +28,6 @@ apply plugin: "de.mannodermaus.android-junit5"
 
 def artifactId = project.property("POM_ARTIFACT_ID")
 def publishVariant = project.property("ANDROID_VARIANT_TO_PUBLISH")
-if (publishVariant == "unityIAPRelease") {
-    project.ext.POM_ARTIFACT_ID = artifactId + "-unityiap"
-}
 
 apply plugin: "com.vanniktech.maven.publish"
 
@@ -69,10 +65,6 @@ android {
     }
     flavorDimensions "dependencyVersions"
     productFlavors {
-        // Temporarily removing this until Unity is supported for BC5
-//        unityIAP {
-//            dimension "dependencyVersions"
-//        }
         latestDependencies {
             dimension "dependencyVersions"
         }
@@ -89,13 +81,6 @@ dependencies {
     latestDependenciesApi "com.revenuecat.purchases:purchases-core-common:$purchases_version"
     latestDependenciesApi "com.revenuecat.purchases:purchases-core-utils:$purchases_version"
     latestDependenciesApi "com.revenuecat.purchases:purchases-store-amazon:$purchases_version"
-
-    // Temporarily removing this until Unity is supported for BC5
-//    unityIAPApi "com.revenuecat.purchases:purchases-unityiap:$purchases_version"
-//    unityIAPApi "com.revenuecat.purchases:purchases-core-common-unityiap:$purchases_version"
-//    unityIAPApi "com.revenuecat.purchases:purchases-core-utils-unityiap:$purchases_version"
-//    unityIAPApi "com.revenuecat.purchases:purchases-store-amazon-unityiap:$purchases_version"
-//    testUnityIAPImplementation "com.android.billingclient:billing:$billing_unityiap_purchases_version"
 
     // assertion
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,9 +69,10 @@ android {
     }
     flavorDimensions "dependencyVersions"
     productFlavors {
-        unityIAP {
-            dimension "dependencyVersions"
-        }
+        // Temporarily removing this until Unity is supported for BC5
+//        unityIAP {
+//            dimension "dependencyVersions"
+//        }
         latestDependencies {
             dimension "dependencyVersions"
         }
@@ -89,11 +90,12 @@ dependencies {
     latestDependenciesApi "com.revenuecat.purchases:purchases-core-utils:$purchases_version"
     latestDependenciesApi "com.revenuecat.purchases:purchases-store-amazon:$purchases_version"
 
-    unityIAPApi "com.revenuecat.purchases:purchases-unityiap:$purchases_version"
-    unityIAPApi "com.revenuecat.purchases:purchases-core-common-unityiap:$purchases_version"
-    unityIAPApi "com.revenuecat.purchases:purchases-core-utils-unityiap:$purchases_version"
-    unityIAPApi "com.revenuecat.purchases:purchases-store-amazon-unityiap:$purchases_version"
-    testUnityIAPImplementation "com.android.billingclient:billing:$billing_unityiap_purchases_version"
+    // Temporarily removing this until Unity is supported for BC5
+//    unityIAPApi "com.revenuecat.purchases:purchases-unityiap:$purchases_version"
+//    unityIAPApi "com.revenuecat.purchases:purchases-core-common-unityiap:$purchases_version"
+//    unityIAPApi "com.revenuecat.purchases:purchases-core-utils-unityiap:$purchases_version"
+//    unityIAPApi "com.revenuecat.purchases:purchases-store-amazon-unityiap:$purchases_version"
+//    testUnityIAPImplementation "com.android.billingclient:billing:$billing_unityiap_purchases_version"
 
     // assertion
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -355,19 +355,6 @@ platform :android do
       properties: gradleProperties,
       project_dir: 'android'
     )
-
-    UI.verbose("Creating special version for Unity IAP with BillingClient 3 and Amazon 2 for version: #{version}")
-    gradleProperties["ANDROID_VARIANT_TO_PUBLISH"] = "unityIAPRelease"
-
-    UI.verbose("Adding -unityiap to artifact ids")
-
-    gradle(
-      tasks: [
-        "publish --no-daemon --no-parallel"
-      ],
-      properties: gradleProperties,
-      project_dir: 'android'
-    )
   end
 end
 


### PR DESCRIPTION
## Motivation

[CF-1274](https://revenuecats.atlassian.net/browse/CF-1274)

CircleCI failing trying to install `purchases-unityiap:6.0.0-beta.2`

## Description

- Removes `unityIAP` flavor from the `build.gradle`
- Remove kicking off a unity bump on release

[CF-1274]: https://revenuecats.atlassian.net/browse/CF-1274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ