### PR TITLE
[BC5] Add subscription options support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.assertj_version = '3.22.0'
     ext.mockk_version = '1.12.3'
     ext.gradle_maven_publish = '0.22.0'
-    ext.purchases_version = '6.0.0-beta.2'
+    ext.purchases_version = '6.0.1'
 
     repositories {
         google()

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -204,13 +204,14 @@ fun purchaseSubscriptionOption(
 ) {
     if (activity != null) {
         val onReceiveStoreProducts: (List<StoreProduct>) -> Unit = { storeProducts ->
-            val allSubscriptionOptions = storeProducts.mapNotNull { storeProduct ->
-                storeProduct.subscriptionOptions?.map { Pair(storeProduct, it) }
-            }.flatten()
-
-            val optionToPurchase = allSubscriptionOptions.firstOrNull { (storeProduct, subscriptionOption) ->
-                storeProduct.purchasingData.productId == productIdentifier && subscriptionOption.id == optionIdentifier
-            }?.second
+            // Iterates over StoreProducts and SubscriptionOptions to find
+            // the first matching product id and subscription option id
+            val optionToPurchase = storeProducts.firstNotNullOfOrNull { storeProduct ->
+                storeProduct.subscriptionOptions?.firstOrNull { subscriptionOption ->
+                    storeProduct.purchasingData.productId == productIdentifier &&
+                            subscriptionOption.id == optionIdentifier
+                }
+            }
 
             if (optionToPurchase != null) {
                 val purchaseParams = PurchaseParams.Builder(activity, optionToPurchase)

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -207,7 +207,6 @@ fun purchaseSubscriptionOption(
             val optionToBuy = storeProducts.mapNotNull { storeProduct ->
                 storeProduct.subscriptionOptions?.map { Pair(storeProduct, it) }
             }.flatten().firstOrNull { (storeProduct, subscriptionOption) ->
-                // TODO: Verify this works because "subId:basePlanId" (it should but strings are silly)
                 storeProduct.purchasingData.productId == productIdentifier && subscriptionOption.id == optionIdentifier
             }?.second
 

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -20,7 +20,7 @@ val StoreProduct.freeTrialCycles: Int?
     get() = this.subscriptionOptions?.freeTrial?.freePhase?.billingCycleCount
 
 private val StoreProduct.introductoryPhase: PricingPhase?
-    get() = this.subscriptionOptions?.introTrial?.introPhase
+    get() = this.subscriptionOptions?.introOffer?.introPhase
 val StoreProduct.introductoryPrice: String?
     get() = this.introductoryPhase?.price?.formatted
 val StoreProduct.introductoryPricePeriodNEW: Period?
@@ -130,9 +130,21 @@ private fun Period.mapPeriod(): Map<String, Any?>? {
 
 private fun SubscriptionOption.mapSubscriptionOption(storeProduct: StoreProduct): Map<String, Any?> {
     return mapOf(
+        // For Google subscriptions, <basePlanId>:<offerId>
+        // For Google and Amazon INAPPs, <productId>
+        // For Amazon subscriptions, <termSkus>
         "id" to id,
+
+        // For Google subscriptions, <productId>:<basePlanId>
+        // For Google and Amazon INAPPs, <productId>
+        // For Amazon subscriptions, <termSkus>
         "storeProductId" to storeProduct.id,
+
+        // For Google subscriptions, <productId>
+        // For Google and Amazon INAPPs, <productId>
+        // For Amazon subscriptions, <termSkus>
         "productId" to storeProduct.purchasingData.productId,
+
         "pricingPhases" to pricingPhases.map { it.mapPricingPhase() },
         "tags" to tags,
         "isBasePlan" to isBasePlan,

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -43,8 +43,8 @@ fun StoreProduct.map(): Map<String, Any?> =
         "productCategory" to mapProductCategory(),
         "productType" to mapProductType(),
         "subscriptionPeriod" to period?.iso8601,
-        "defaultOption" to defaultOption?.mapSubscriptionOption(),
-        "subscriptionOptions" to subscriptionOptions?.map { it.mapSubscriptionOption() },
+        "defaultOption" to defaultOption?.mapSubscriptionOption(this),
+        "subscriptionOptions" to subscriptionOptions?.map { it.mapSubscriptionOption(this) },
     )
 
 fun List<StoreProduct>.map(): List<Map<String, Any?>> = this.map { it.map() }
@@ -128,9 +128,11 @@ private fun Period.mapPeriod(): Map<String, Any?>? {
     }
 }
 
-private fun SubscriptionOption.mapSubscriptionOption(): Map<String, Any?> {
+private fun SubscriptionOption.mapSubscriptionOption(storeProduct: StoreProduct): Map<String, Any?> {
     return mapOf(
         "id" to id,
+        "storeProductId" to storeProduct.id,
+        "productId" to storeProduct.purchasingData.productId,
         "pricingPhases" to pricingPhases.map { it.mapPricingPhase() },
         "tags" to tags,
         "isBasePlan" to isBasePlan,

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -132,17 +132,17 @@ private fun SubscriptionOption.mapSubscriptionOption(storeProduct: StoreProduct)
     return mapOf(
         // For Google subscriptions, <basePlanId>:<offerId>
         // For Google and Amazon INAPPs, <productId>
-        // For Amazon subscriptions, <termSkus>
+        // For Amazon subscriptions, <termSku>
         "id" to id,
 
         // For Google subscriptions, <productId>:<basePlanId>
         // For Google and Amazon INAPPs, <productId>
-        // For Amazon subscriptions, <termSkus>
+        // For Amazon subscriptions, <termSku>
         "storeProductId" to storeProduct.id,
 
         // For Google subscriptions, <productId>
         // For Google and Amazon INAPPs, <productId>
-        // For Amazon subscriptions, <termSkus>
+        // For Amazon subscriptions, <termSku>
         "productId" to storeProduct.purchasingData.productId,
 
         "pricingPhases" to pricingPhases.map { it.mapPricingPhase() },

--- a/android/src/test/java/apitests/java/CommonApiTests.java
+++ b/android/src/test/java/apitests/java/CommonApiTests.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 
 import com.revenuecat.purchases.DangerousSettings;
-import com.revenuecat.purchases.LogHandler;
 import com.revenuecat.purchases.Store;
 import com.revenuecat.purchases.common.PlatformInfo;
 import com.revenuecat.purchases.hybridcommon.CommonKt;
@@ -33,18 +32,18 @@ class CommonApiTests {
     }
 
     private void checkGetProductInfo(List<String> productIDs,
-                             String type,
-                             OnResultList onResult) {
+                                     String type,
+                                     OnResultList onResult) {
         CommonKt.getProductInfo(productIDs, type, onResult);
     }
 
     private void checkPurchaseProduct(Activity activity,
-                              String productIdentifier,
-                              String type,
-                              String googleOldProductId,
-                              GoogleProrationMode googleProrationMode,
-                              Boolean googleIsPersonalizedPrice,
-                              OnResult onResult) {
+                                      String productIdentifier,
+                                      String type,
+                                      String googleOldProductId,
+                                      GoogleProrationMode googleProrationMode,
+                                      Boolean googleIsPersonalizedPrice,
+                                      OnResult onResult) {
         CommonKt.purchaseProduct(
                 activity,
                 productIdentifier,
@@ -57,16 +56,34 @@ class CommonApiTests {
     }
 
     private void checkPurchasePackage(Activity activity,
-                              String packageIdentifier,
-                              String offeringIdentifier,
-                              String googleOldProductId,
-                              GoogleProrationMode googleProrationMode,
-                              Boolean googleIsPersonalizedPrice,
-                              OnResult onResult) {
+                                      String packageIdentifier,
+                                      String offeringIdentifier,
+                                      String googleOldProductId,
+                                      GoogleProrationMode googleProrationMode,
+                                      Boolean googleIsPersonalizedPrice,
+                                      OnResult onResult) {
         CommonKt.purchasePackage(
                 activity,
                 packageIdentifier,
                 offeringIdentifier,
+                googleOldProductId,
+                googleProrationMode,
+                googleIsPersonalizedPrice,
+                onResult
+        );
+    }
+
+    private void checkPurchaseSubscriptionOption(Activity activity,
+                                                 String productIdentifier,
+                                                 String optionIdentifier,
+                                                 String googleOldProductId,
+                                                 GoogleProrationMode googleProrationMode,
+                                                 Boolean googleIsPersonalizedPrice,
+                                                 OnResult onResult) {
+        CommonKt.purchaseSubscriptionOption(
+                activity,
+                productIdentifier,
+                optionIdentifier,
                 googleOldProductId,
                 googleProrationMode,
                 googleIsPersonalizedPrice,

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
@@ -35,7 +35,15 @@ private class CommonApiTests {
         googleIsPersonalizedPrice: Boolean?,
         onResult: OnResult
     ) {
-        purchaseProduct(activity, productIdentifier, type, googleOldProductId, googleProrationMode, googleIsPersonalizedPrice, onResult)
+        purchaseProduct(
+            activity,
+            productIdentifier,
+            type,
+            googleOldProductId,
+            googleProrationMode,
+            googleIsPersonalizedPrice,
+            onResult
+        )
     }
 
     fun checkPurchasePackage(
@@ -51,6 +59,26 @@ private class CommonApiTests {
             activity,
             packageIdentifier,
             offeringIdentifier,
+            googleOldProductId,
+            googleProrationMode,
+            googleIsPersonalizedPrice,
+            onResult
+        )
+    }
+
+    fun checkPurchaseSubscriptionOption(
+        activity: Activity?,
+        productIdentifier: String,
+        optionIdentifier: String,
+        googleOldProductId: String?,
+        googleProrationMode: GoogleProrationMode?,
+        googleIsPersonalizedPrice: Boolean?,
+        onResult: OnResult
+    ) {
+        purchaseSubscriptionOption(
+            activity,
+            productIdentifier,
+            optionIdentifier,
             googleOldProductId,
             googleProrationMode,
             googleIsPersonalizedPrice,

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -626,7 +626,7 @@ internal class CommonKtTests {
     }
 
     @Test
-    fun `purchaseSubsscriptionOption passes correct productIdentifier after a successful purchase`() {
+    fun `purchaseSubscriptionOption passes correct productIdentifier after a successful purchase`() {
         configure(
             context = mockContext,
             apiKey = "api_key",

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -4,10 +4,7 @@ package com.revenuecat.purchases.hybridcommon
 import android.app.Activity
 import android.app.Application
 import android.content.Context
-import android.os.Parcel
-import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.ProductDetails
-import com.android.billingclient.api.SkuDetails
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
@@ -20,7 +17,6 @@ import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.PlatformInfo
-import com.revenuecat.purchases.google.toStoreProduct
 import com.revenuecat.purchases.hybridcommon.mappers.map
 import com.revenuecat.purchases.interfaces.Callback
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
@@ -38,7 +34,6 @@ import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.SubscriptionOptions
 import com.revenuecat.purchases.models.toRecurrenceMode
-import com.revenuecat.purchases.purchaseWith
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -794,10 +794,6 @@ fun stubStoreProduct(
         )
     override val sku: String
         get() = productId
-
-    override fun describeContents(): Int = 0
-
-    override fun writeToParcel(dest: Parcel?, flags: Int) {}
 }
 
 @SuppressWarnings("EmptyFunctionBlock")
@@ -817,9 +813,6 @@ fun stubSubscriptionOption(
         get() = StubPurchasingData(
             productId = productId
         )
-
-    override fun describeContents(): Int = 0
-    override fun writeToParcel(dest: Parcel?, flags: Int) {}
 }
 
 @SuppressWarnings("MatchingDeclarationName")

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
@@ -223,7 +223,7 @@ internal class StoreProductMapperTest {
     @Test
     fun `map has correct size`() {
         stubStoreProduct("monthly_product").map().let {
-            assertThat(it.size).isEqualTo(11)
+            assertThat(it.size).isEqualTo(13)
         }
     }
 


### PR DESCRIPTION
## Motivation

[CF-1221](https://revenuecats.atlassian.net/browse/CF-1221)
[CF-1227](https://revenuecats.atlassian.net/browse/CF-1267)

Hybrids should have the ability to view and purchase subscription options.

## Description

- Added `defaultOption` and `subscriptionOptions` to `StoreProduct` mapper
- Add new `purchaseSubscriptionOption()` function
  - Uses `productIdentifier` (sub) and `optionIdentifier` (base plan + optional offer) to find the `SubscriptionOption`

See https://github.com/RevenueCat/purchases-flutter/pull/641 on how this is used in Flutter

[CF-1221]: https://revenuecats.atlassian.net/browse/CF-1221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CF-1227]: https://revenuecats.atlassian.net/browse/CF-1227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ