### PR TITLE
[BC5] Add `iso8601` to `Period` for subscription option pricing phases

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -23,7 +23,7 @@ private val StoreProduct.introductoryPhase: PricingPhase?
     get() = this.subscriptionOptions?.introOffer?.introPhase
 val StoreProduct.introductoryPrice: String?
     get() = this.introductoryPhase?.price?.formatted
-val StoreProduct.introductoryPricePeriodNEW: Period?
+val StoreProduct.introductoryPricePeriod: Period?
     get() = this.introductoryPhase?.billingPeriod
 val StoreProduct.introductoryPriceAmountMicros: Long
     get() = this.introductoryPhase?.price?.amountMicros ?: 0
@@ -87,11 +87,11 @@ internal fun StoreProduct.mapIntroPrice(): Map<String, Any?>? {
             }
         }
         introductoryPrice != null -> {
-            introductoryPricePeriodNEW?.mapPeriodForStoreProduct()?.let { periodFields ->
+            introductoryPricePeriod?.mapPeriodForStoreProduct()?.let { periodFields ->
                 mapOf(
                     "price" to introductoryPriceAmountMicros / 1_000_000.0,
                     "priceString" to introductoryPrice,
-                    "period" to introductoryPricePeriodNEW?.iso8601,
+                    "period" to introductoryPricePeriod?.iso8601,
                     "cycles" to introductoryPriceCycles
                 ) + periodFields
             }

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -151,7 +151,7 @@ private fun Period.mapPeriod(): Map<String, Any?>? {
             "unit" to "DAY",
             "value" to 0
         )
-    }
+    } + mapOf("iso8601" to this.iso8601)
 }
 
 private fun SubscriptionOption.mapSubscriptionOption(storeProduct: StoreProduct): Map<String, Any?> {

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductIntroPriceMapperTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductIntroPriceMapperTests.kt
@@ -98,7 +98,7 @@ internal class StoreProductIntroPriceMapperTests {
         @Test
         fun `of 7 days, the map has the correct intro price values`() {
             every { mockStoreProduct.freeTrialPeriod } returns null
-            every { mockStoreProduct.introductoryPricePeriodNEW } returns Period(7, Period.Unit.DAY, "P7D")
+            every { mockStoreProduct.introductoryPricePeriod } returns Period(7, Period.Unit.DAY, "P7D")
             received = mockStoreProduct.mapIntroPrice()
             val expected = mapOf(
                 "period" to "P7D",
@@ -111,7 +111,7 @@ internal class StoreProductIntroPriceMapperTests {
         @Test
         fun `of 1 month, the map has the correct intro price values`() {
             every { mockStoreProduct.freeTrialPeriod } returns null
-            every { mockStoreProduct.introductoryPricePeriodNEW } returns Period(1, Period.Unit.MONTH, "P1M")
+            every { mockStoreProduct.introductoryPricePeriod } returns Period(1, Period.Unit.MONTH, "P1M")
             received = mockStoreProduct.mapIntroPrice()
 
             val expected = mapOf(
@@ -125,7 +125,7 @@ internal class StoreProductIntroPriceMapperTests {
         @Test
         fun `of 0 days, the map has the correct intro price values`() {
             every { mockStoreProduct.freeTrialPeriod } returns null
-            every { mockStoreProduct.introductoryPricePeriodNEW } returns Period(0, Period.Unit.DAY, "P0D")
+            every { mockStoreProduct.introductoryPricePeriod } returns Period(0, Period.Unit.DAY, "P0D")
             received = mockStoreProduct.mapIntroPrice()
 
             val expected = mapOf(

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
@@ -292,7 +292,8 @@ internal class StoreProductMapperTest {
     private fun testBasePlanOption(option: Map<String, Any?>) {
         val billingPeriod = mapOf(
             "unit" to "MONTH",
-            "value" to 1
+            "value" to 1,
+            "iso8601" to "P1M"
         )
 
         assertThat(option).isNotNull
@@ -319,15 +320,18 @@ internal class StoreProductMapperTest {
     private fun testMultiPhaseOption(option: Map<String, Any?>) {
         val billingPeriod = mapOf(
             "unit" to "MONTH",
-            "value" to 1
+            "value" to 1,
+            "iso8601" to "P1M"
         )
         val freeBillingPeriod = mapOf(
             "unit" to "DAY",
-            "value" to 7
+            "value" to 7,
+            "iso8601" to "P7D"
         )
         val introBillingPeriod = mapOf(
             "unit" to "MONTH",
-            "value" to 1
+            "value" to 1,
+            "iso8601" to "P1M"
         )
 
         assertThat(option).isNotNull


### PR DESCRIPTION
## Motivation

Adds `iso8601` to `Period` for hybrids to use because why not if we have the data 🤷‍♂️ 

And also @vegaro requested it - https://github.com/RevenueCat/purchases-flutter/pull/641#discussion_r1156145971 😇 

## Description

Adds `iso8601` field to the `Period` mapping 👇 

```json
{
  "unit": "MONTH",
  "value": 1,
  "iso8601": "P1M"
}
```
