### PR TITLE
Add  platform check,`OfferPaymentMode`, and `presentedOfferingIdentifier`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.assertj_version = '3.22.0'
     ext.mockk_version = '1.12.3'
     ext.gradle_maven_publish = '0.22.0'
-    ext.purchases_version = '6.0.1'
+    ext.purchases_version = '6.1.1'
 
     repositories {
         google()

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.hybridcommon
 
 import android.app.Activity
 import android.content.Context
+import com.android.billingclient.api.Purchase
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.DangerousSettings
 import com.revenuecat.purchases.LogLevel
@@ -246,6 +247,15 @@ fun purchaseSubscriptionOption(
     presentedOfferingIdentifier: String?,
     onResult: OnResult
 ) {
+    if (Purchases.sharedInstance.store != Store.PLAY_STORE) {
+        onResult.onError(
+            PurchasesError(PurchasesErrorCode.UnknownError,
+                "purchaseSubscriptionOption() is only supported on the Play Store."
+            ).map()
+        )
+        return
+    }
+
     val googleProrationMode = try {
         getGoogleProrationMode(googleProrationMode)
     } catch (e: InvalidProrationModeException) {

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.hybridcommon.mappers
 
 import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.models.OfferPaymentMode
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
@@ -187,6 +188,7 @@ private fun PricingPhase.mapPricingPhase(): Map<String, Any?> {
         "recurrenceMode" to recurrenceMode.identifier,
         "billingCycleCount" to billingCycleCount,
         "price" to price.mapPrice(),
+        "offerPaymentMode" to offerPaymentMode?.toString()
     )
 }
 

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -46,6 +46,7 @@ fun StoreProduct.map(): Map<String, Any?> =
         "subscriptionPeriod" to period?.iso8601,
         "defaultOption" to defaultOption?.mapSubscriptionOption(this),
         "subscriptionOptions" to subscriptionOptions?.map { it.mapSubscriptionOption(this) },
+        "presentedOfferingIdentifier" to presentedOfferingIdentifier
     )
 
 fun List<StoreProduct>.map(): List<Map<String, Any?>> = this.map { it.map() }
@@ -178,7 +179,8 @@ private fun SubscriptionOption.mapSubscriptionOption(storeProduct: StoreProduct)
         "billingPeriod" to billingPeriod?.mapPeriod(),
         "fullPricePhase" to fullPricePhase?.mapPricingPhase(),
         "freePhase" to freePhase?.mapPricingPhase(),
-        "introPhase" to introPhase?.mapPricingPhase()
+        "introPhase" to introPhase?.mapPricingPhase(),
+        "presentedOfferingIdentifier" to presentedOfferingIdentifier
     )
 }
 

--- a/android/src/test/java/apitests/java/CommonApiTests.java
+++ b/android/src/test/java/apitests/java/CommonApiTests.java
@@ -44,6 +44,7 @@ class CommonApiTests {
                                       String googleOldProductId,
                                       Integer googleProrationMode,
                                       Boolean googleIsPersonalizedPrice,
+                                      String presentedOfferingIdentifier,
                                       OnResult onResult) {
         CommonKt.purchaseProduct(
                 activity,
@@ -53,6 +54,7 @@ class CommonApiTests {
                 googleOldProductId,
                 googleProrationMode,
                 googleIsPersonalizedPrice,
+                presentedOfferingIdentifier,
                 onResult
         );
     }
@@ -81,6 +83,7 @@ class CommonApiTests {
                                                  String googleOldProductId,
                                                  Integer googleProrationMode,
                                                  Boolean googleIsPersonalizedPrice,
+                                                 String presentedOfferingIdentifier,
                                                  OnResult onResult) {
         CommonKt.purchaseSubscriptionOption(
                 activity,
@@ -89,6 +92,7 @@ class CommonApiTests {
                 googleOldProductId,
                 googleProrationMode,
                 googleIsPersonalizedPrice,
+                presentedOfferingIdentifier,
                 onResult
         );
     }

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
@@ -34,6 +34,7 @@ private class CommonApiTests {
         googleOldProductId: String?,
         googleProrationMode: Int?,
         googleIsPersonalizedPrice: Boolean?,
+        presentedOfferingIdentifier: String?,
         onResult: OnResult
     ) {
         purchaseProduct(
@@ -44,6 +45,7 @@ private class CommonApiTests {
             googleOldProductId,
             googleProrationMode,
             googleIsPersonalizedPrice,
+            presentedOfferingIdentifier,
             onResult
         )
     }
@@ -75,6 +77,7 @@ private class CommonApiTests {
         googleOldProductId: String?,
         googleProrationMode: Int?,
         googleIsPersonalizedPrice: Boolean?,
+        presentedOfferingIdentifier: String?,
         onResult: OnResult
     ) {
         purchaseSubscriptionOption(
@@ -84,6 +87,7 @@ private class CommonApiTests {
             googleOldProductId,
             googleProrationMode,
             googleIsPersonalizedPrice,
+            presentedOfferingIdentifier,
             onResult
         )
     }

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.PurchaseParams
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.hybridcommon.mappers.map
 import com.revenuecat.purchases.interfaces.Callback
@@ -71,6 +72,7 @@ internal class CommonKtTests {
         } returns mockPurchases
         every { mockContext.applicationContext } returns mockApplicationContext
         every { Purchases.sharedInstance } returns mockPurchases
+        every { mockPurchases.store } returns Store.PLAY_STORE
     }
 
 
@@ -976,6 +978,34 @@ internal class CommonKtTests {
 
         assertNotNull(receivedResponse)
         assertEquals(expectedProductIdentifier, receivedResponse?.get("productIdentifier"))
+    }
+
+    @Test
+    fun `purchaseSubscriptionOption errors when store is Amazon`() {
+        every { mockPurchases.store } returns Store.AMAZON
+
+        var receivedErrorContainer: ErrorContainer? = null
+
+        purchaseSubscriptionOption(
+            mockActivity,
+            productIdentifier = "product",
+            optionIdentifier = "option",
+            googleOldProductId = null,
+            googleProrationMode = null,
+            googleIsPersonalizedPrice = null,
+            presentedOfferingIdentifier = null,
+            onResult = object : OnResult {
+                override fun onReceived(map: MutableMap<String, *>) {
+                    fail("Should be success")
+                }
+
+                override fun onError(errorContainer: ErrorContainer) {
+                    receivedErrorContainer = errorContainer
+                }
+            }
+        )
+
+        assertNotNull(receivedErrorContainer)
     }
 
     @Test

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -31,6 +31,7 @@ import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.PurchasingData
+import com.revenuecat.purchases.models.RecurrenceMode
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.SubscriptionOption
@@ -963,12 +964,18 @@ fun stubStoreProduct(
         Period(1, Period.Unit.MONTH, "P1M"),
     ),
     subscriptionOptions: List<SubscriptionOption>? = defaultOption?.let { listOf(defaultOption) } ?: emptyList(),
-    price: Price = subscriptionOptions?.firstOrNull()?.fullPricePhase!!.price
+    price: Price = subscriptionOptions?.firstOrNull()?.fullPricePhase!!.price,
+    presentedOfferingIdentifier: String? = null
 ): StoreProduct = object : StoreProduct {
     override val id: String
         get() = productId
     override val type: ProductType
         get() = type
+
+    override fun copyWithOfferingId(offeringId: String): StoreProduct {
+        return this
+    }
+
     override val price: Price
         get() = price
     override val title: String
@@ -977,6 +984,8 @@ fun stubStoreProduct(
         get() = description
     override val period: Period?
         get() = subscriptionOptions?.firstOrNull { it.isBasePlan }?.pricingPhases?.get(0)?.billingPeriod
+    override val presentedOfferingIdentifier: String?
+        get() = presentedOfferingIdentifier
     override val subscriptionOptions: SubscriptionOptions?
         get() = subscriptionOptions?.let { SubscriptionOptions(it) }
     override val defaultOption: SubscriptionOption?
@@ -994,10 +1003,13 @@ fun stubSubscriptionOption(
     id: String,
     productId: String,
     duration: Period = Period(1, Period.Unit.MONTH, "P1M"),
-    pricingPhases: List<PricingPhase> = listOf(stubPricingPhase(billingPeriod = duration))
+    pricingPhases: List<PricingPhase> = listOf(stubPricingPhase(billingPeriod = duration)),
+    presentedOfferingIdentifier: String? = null
 ): SubscriptionOption = object : SubscriptionOption {
     override val id: String
         get() = id
+    override val presentedOfferingIdentifier: String?
+        get() = presentedOfferingIdentifier
     override val pricingPhases: List<PricingPhase>
         get() = pricingPhases
     override val tags: List<String>
@@ -1021,11 +1033,11 @@ fun stubPricingPhase(
     priceCurrencyCodeValue: String = "USD",
     priceFormatted: String = "$4.99",
     price: Double = 4.99,
-    recurrenceMode: Int = ProductDetails.RecurrenceMode.INFINITE_RECURRING,
+    recurrenceMode: RecurrenceMode = RecurrenceMode.INFINITE_RECURRING,
     billingCycleCount: Int = 0
 ): PricingPhase = PricingPhase(
     billingPeriod,
-    recurrenceMode.toRecurrenceMode(),
+    recurrenceMode,
     billingCycleCount,
-    Price(priceFormatted, price.times(MICROS_MULTIPLIER).toLong(), priceCurrencyCodeValue)
+    Price(priceFormatted, price.times(MICROS_MULTIPLIER).toLong(), priceCurrencyCodeValue),
 )

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
@@ -225,7 +225,7 @@ internal class StoreProductMapperTest {
     @Test
     fun `map has correct size`() {
         stubStoreProduct("monthly_product").map().let {
-            assertThat(it.size).isEqualTo(13)
+            assertThat(it.size).isEqualTo(14)
         }
     }
 
@@ -292,6 +292,28 @@ internal class StoreProductMapperTest {
             val subscriptionOptions = it["subscriptionOptions"] as List<Map<String, Any?>>
             testBasePlanOption(subscriptionOptions[0])
             testMultiPhaseOption(subscriptionOptions[1])
+        }
+    }
+
+    @Test
+    fun `map presentedOfferingIdentifier correctly when null`() {
+        stubStoreProduct(
+            productId = exptectedProductId,
+            presentedOfferingIdentifier = null
+        ).map().let {
+            assertThat(it["presentedOfferingIdentifier"]).isEqualTo(null)
+        }
+    }
+
+    @Test
+    fun `map presentedOfferingIdentifier correctly when not null`() {
+        val expectedPresentedOfferingIdentifier = "mainoffer"
+
+        stubStoreProduct(
+            productId = exptectedProductId,
+            presentedOfferingIdentifier = expectedPresentedOfferingIdentifier
+        ).map().let {
+            assertThat(it["presentedOfferingIdentifier"]).isEqualTo(expectedPresentedOfferingIdentifier)
         }
     }
 

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
@@ -5,8 +5,10 @@ import com.revenuecat.purchases.hybridcommon.MICROS_MULTIPLIER
 import com.revenuecat.purchases.hybridcommon.stubPricingPhase
 import com.revenuecat.purchases.hybridcommon.stubStoreProduct
 import com.revenuecat.purchases.hybridcommon.stubSubscriptionOption
+import com.revenuecat.purchases.models.OfferPaymentMode
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.RecurrenceMode
 import com.revenuecat.purchases.models.StoreProduct
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
@@ -168,7 +170,7 @@ internal class StoreProductMapperTest {
                 pricingPhases = listOf(
                     stubPricingPhase(
                         billingPeriod = duration,
-                        recurrenceMode = 3
+                        recurrenceMode = RecurrenceMode.NON_RECURRING
                     )
                 )
             )
@@ -262,12 +264,16 @@ internal class StoreProductMapperTest {
                 stubPricingPhase(
                     billingPeriod = freeTrialDuration,
                     priceFormatted = "$0.00",
-                    price = 0.0
+                    price = 0.0,
+                    recurrenceMode = RecurrenceMode.FINITE_RECURRING,
+                    billingCycleCount = 1
                 ),
                 stubPricingPhase(
                     billingPeriod = introTrialDuration,
                     priceFormatted = "$2.99",
-                    price = 2.99
+                    price = 2.99,
+                    recurrenceMode = RecurrenceMode.FINITE_RECURRING,
+                    billingCycleCount = 1
                 ),
                 stubPricingPhase(
                     billingPeriod = duration,
@@ -287,6 +293,13 @@ internal class StoreProductMapperTest {
             testBasePlanOption(subscriptionOptions[0])
             testMultiPhaseOption(subscriptionOptions[1])
         }
+    }
+
+    @Test
+    fun `OfferPaymentMode maps to correct string value`() {
+        assertThat(OfferPaymentMode.FREE_TRIAL.toString()).isEqualTo("FREE_TRIAL")
+        assertThat(OfferPaymentMode.SINGLE_PAYMENT.toString()).isEqualTo("SINGLE_PAYMENT")
+        assertThat(OfferPaymentMode.DISCOUNTED_RECURRING_PAYMENT.toString()).isEqualTo("DISCOUNTED_RECURRING_PAYMENT")
     }
 
     private fun testBasePlanOption(option: Map<String, Any?>) {
@@ -311,6 +324,7 @@ internal class StoreProductMapperTest {
                     "amountMicros" to (4.99 * MICROS_MULTIPLIER).toLong(),
                     "currencyCode" to "USD"
                 ),
+                "offerPaymentMode" to null
             )
         )
         assertThat(option["freePhase"]).isNull()
@@ -349,30 +363,33 @@ internal class StoreProductMapperTest {
                     "amountMicros" to (4.99 * MICROS_MULTIPLIER).toLong(),
                     "currencyCode" to "USD"
                 ),
+                "offerPaymentMode" to null
             )
         )
         assertThat(option["freePhase"]).isEqualTo(
             mapOf(
                 "billingPeriod" to freeBillingPeriod,
-                "recurrenceMode" to 1,
-                "billingCycleCount" to 0,
+                "recurrenceMode" to 2,
+                "billingCycleCount" to 1,
                 "price" to mapOf(
                     "formatted" to "$0.00",
                     "amountMicros" to 0L,
                     "currencyCode" to "USD"
                 ),
+                "offerPaymentMode" to "FREE_TRIAL"
             )
         )
         assertThat(option["introPhase"]).isEqualTo(
             mapOf(
                 "billingPeriod" to introBillingPeriod,
-                "recurrenceMode" to 1,
-                "billingCycleCount" to 0,
+                "recurrenceMode" to 2,
+                "billingCycleCount" to 1,
                 "price" to mapOf(
                     "formatted" to "$2.99",
                     "amountMicros" to (2.99 * MICROS_MULTIPLIER).toLong(),
                     "currencyCode" to "USD"
                 ),
+                "offerPaymentMode" to "SINGLE_PAYMENT"
             )
         )
     }


### PR DESCRIPTION
## Motivation

[CF-1329](https://revenuecats.atlassian.net/browse/CF-1329)

- Updated to Android `6.1.1`
- New `Purchases.sharedInstance.store` to limit `purchaseSubscriptionOption()` only for `PLAY_STORE`
- New `OfferPaymentMode` on `PricingPhase` and put in mapper
- Need to show `presentedOfferingIdentifier` in mapper and pass into purchase methods

## Description

- Bumped native Android version to `6.1.1`
- Added `offerPaymentMode` to the `PricingPhase` mapper
- Check `Purchases.sharedInstance.store` in `purchaseSubscriptionOption()` only for `PLAY_STORE`
- Added `presentedOfferingIdentifier` to `StoreProduct` and `SubscriptionOption` mapper
- `purchaseProduct()` and `purchaseSubscriptionOption()` have a new `presentedOfferingIdentifier: String?` parameter
- Fixed `purchaseSubscriptionOption()` tests that were actually called `purchaseProduct()` 🤦‍♂️ 

### Reapplying the `presentedOfferingIdentifier`

In the native Android SDK, the `presentedOfferingIdentifier` is a property of `StoreProduct` and `SubscriptionOption`. When the users called `purchase()` with one of these objects, that offering identifier is used without the developer having to do anything.

Because the way hybrids works, the `StoreProduct`s and `SubscriptionOption`s instances that get fetched and are aren't up to the hybrid level, aren't the same instances that are purchased going back down to the native layer. Because of this, the `presentedOfferingIdentifier` needs to get passed to the hybrid common `purchaseProduct()` and `purchaseSubscriptionOption()` methods and reapplied.



[CF-1329]: https://revenuecats.atlassian.net/browse/CF-1329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ