### PR TITLE
[BC5] Rename `productCategory` to `productType` and `productType` to `productSubtype`

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.hybridcommon.mappers
 
 import com.revenuecat.purchases.ProductType
-import com.revenuecat.purchases.models.OfferPaymentMode
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
@@ -41,8 +40,8 @@ fun StoreProduct.map(): Map<String, Any?> =
         "currencyCode" to priceCurrencyCode,
         "introPrice" to mapIntroPrice(),
         "discounts" to null,
-        "productCategory" to mapProductCategory(),
         "productType" to mapProductType(),
+        "productSubtype" to mapProductSubtype(),
         "subscriptionPeriod" to period?.iso8601,
         "defaultOption" to defaultOption?.mapSubscriptionOption(this),
         "subscriptionOptions" to subscriptionOptions?.map { it.mapSubscriptionOption(this) },
@@ -51,7 +50,7 @@ fun StoreProduct.map(): Map<String, Any?> =
 
 fun List<StoreProduct>.map(): List<Map<String, Any?>> = this.map { it.map() }
 
-internal fun StoreProduct.mapProductCategory(): String {
+internal fun StoreProduct.mapProductType(): String {
     return when (type) {
         ProductType.INAPP -> "NON_SUBSCRIPTION"
         ProductType.SUBS -> "SUBSCRIPTION"
@@ -59,7 +58,7 @@ internal fun StoreProduct.mapProductCategory(): String {
     }
 }
 
-internal fun StoreProduct.mapProductType(): String {
+internal fun StoreProduct.mapProductSubtype(): String {
     return when (type) {
         ProductType.INAPP -> "CONSUMABLE"
         ProductType.SUBS -> {

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
@@ -130,36 +130,36 @@ internal class StoreProductMapperTest {
     }
 
     @Test
-    fun `maps product category correctly`() {
+    fun `maps product type correctly`() {
         stubStoreProduct(
             productId = exptectedProductId,
             type = ProductType.SUBS
         ).map().let {
-            assertThat(it["productCategory"]).isEqualTo("SUBSCRIPTION")
+            assertThat(it["productType"]).isEqualTo("SUBSCRIPTION")
         }
         stubStoreProduct(
             productId = exptectedProductId,
             type = ProductType.INAPP
         ).map().let {
-            assertThat(it["productCategory"]).isEqualTo("NON_SUBSCRIPTION")
+            assertThat(it["productType"]).isEqualTo("NON_SUBSCRIPTION")
         }
         stubStoreProduct(
             productId = exptectedProductId,
             type = ProductType.UNKNOWN
         ).map().let {
-            assertThat(it["productCategory"]).isEqualTo("UNKNOWN")
+            assertThat(it["productType"]).isEqualTo("UNKNOWN")
         }
     }
 
     @Test
-    fun `maps product type correctly`() {
+    fun `maps product subtype correctly`() {
         val duration = Period(1, Period.Unit.MONTH, "P1M")
 
         stubStoreProduct(
             productId = exptectedProductId,
             type = ProductType.SUBS
         ).map().let {
-            assertThat(it["productType"]).isEqualTo("AUTO_RENEWABLE_SUBSCRIPTION")
+            assertThat(it["productSubtype"]).isEqualTo("AUTO_RENEWABLE_SUBSCRIPTION")
         }
         stubStoreProduct(
             productId = exptectedProductId,
@@ -175,19 +175,19 @@ internal class StoreProductMapperTest {
                 )
             )
         ).map().let {
-            assertThat(it["productType"]).isEqualTo("PREPAID_SUBSCRIPTION")
+            assertThat(it["productSubtype"]).isEqualTo("PREPAID_SUBSCRIPTION")
         }
         stubStoreProduct(
             productId = exptectedProductId,
             type = ProductType.INAPP
         ).map().let {
-            assertThat(it["productType"]).isEqualTo("CONSUMABLE")
+            assertThat(it["productSubtype"]).isEqualTo("CONSUMABLE")
         }
         stubStoreProduct(
             productId = exptectedProductId,
             type = ProductType.UNKNOWN
         ).map().let {
-            assertThat(it["productType"]).isEqualTo("UNKNOWN")
+            assertThat(it["productSubtype"]).isEqualTo("UNKNOWN")
         }
     }
 


### PR DESCRIPTION
## Motivation

Rename... 
- `productCategory` to `productType`
- `productType` to `productSubtype`

This was confusing and making mapping of store mapper JSON to hybrid models kind of weird 🤷‍♂️ 

## Description

Rename... 
- `productCategory` to `productType`
- `productType` to `productSubtype`

None of these were being used before the BC5 versions and not being used on iOS so this is pretty safe to change right now 😇 