### PR TITLE
[BC5] iOS rename `productCategory` to `product type` and `productType` to `productSubtype`

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProduct+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProduct+HybridAdditions.swift
@@ -21,8 +21,8 @@ import StoreKit
             "introPrice": NSNull(),
             "price": self.price,
             "priceString": self.localizedPriceString,
-            "productCategory": self.productCategoryString,
-            "productType": self.productTypeString,
+            "productType": self.productCategoryString,
+            "productSubtype": self.productTypeString,
             "title": self.localizedTitle,
             "subscriptionPeriod": NSNull(),
         ]

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanGetOfferings.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanGetOfferings.1.json
@@ -22,8 +22,8 @@
           },
           "price" : 39.99,
           "priceString" : "$39.99",
-          "productCategory" : "SUBSCRIPTION",
-          "productType" : "NON_CONSUMABLE",
+          "productType" : "SUBSCRIPTION",
+          "productSubtype" : "NON_CONSUMABLE",
           "subscriptionPeriod" : "P1Y",
           "title" : "Annual Subscription"
         }
@@ -50,8 +50,8 @@
             },
             "price" : 39.99,
             "priceString" : "$39.99",
-            "productCategory" : "SUBSCRIPTION",
-            "productType" : "NON_CONSUMABLE",
+            "productType" : "SUBSCRIPTION",
+            "productSubtype" : "NON_CONSUMABLE",
             "subscriptionPeriod" : "P1Y",
             "title" : "Annual Subscription"
           }
@@ -85,8 +85,8 @@
             },
             "price" : 19.99,
             "priceString" : "$19.99",
-            "productCategory" : "SUBSCRIPTION",
-            "productType" : "NON_CONSUMABLE",
+            "productType" : "SUBSCRIPTION",
+            "productSubtype" : "NON_CONSUMABLE",
             "subscriptionPeriod" : "P1M",
             "title" : "Monthly Subscription"
           }
@@ -122,8 +122,8 @@
           },
           "price" : 19.99,
           "priceString" : "$19.99",
-          "productCategory" : "SUBSCRIPTION",
-          "productType" : "NON_CONSUMABLE",
+          "productType" : "SUBSCRIPTION",
+          "productSubtype" : "NON_CONSUMABLE",
           "subscriptionPeriod" : "P1M",
           "title" : "Monthly Subscription"
         }
@@ -153,8 +153,8 @@
         },
         "price" : 39.99,
         "priceString" : "$39.99",
-        "productCategory" : "SUBSCRIPTION",
-        "productType" : "NON_CONSUMABLE",
+        "productType" : "SUBSCRIPTION",
+        "productSubtype" : "NON_CONSUMABLE",
         "subscriptionPeriod" : "P1Y",
         "title" : "Annual Subscription"
       }
@@ -181,8 +181,8 @@
           },
           "price" : 39.99,
           "priceString" : "$39.99",
-          "productCategory" : "SUBSCRIPTION",
-          "productType" : "NON_CONSUMABLE",
+          "productType" : "SUBSCRIPTION",
+          "productSubtype" : "NON_CONSUMABLE",
           "subscriptionPeriod" : "P1Y",
           "title" : "Annual Subscription"
         }
@@ -216,8 +216,8 @@
           },
           "price" : 19.99,
           "priceString" : "$19.99",
-          "productCategory" : "SUBSCRIPTION",
-          "productType" : "NON_CONSUMABLE",
+          "productType" : "SUBSCRIPTION",
+          "productSubtype" : "NON_CONSUMABLE",
           "subscriptionPeriod" : "P1M",
           "title" : "Monthly Subscription"
         }
@@ -253,8 +253,8 @@
         },
         "price" : 19.99,
         "priceString" : "$19.99",
-        "productCategory" : "SUBSCRIPTION",
-        "productType" : "NON_CONSUMABLE",
+        "productType" : "SUBSCRIPTION",
+        "productSubtype" : "NON_CONSUMABLE",
         "subscriptionPeriod" : "P1M",
         "title" : "Monthly Subscription"
       }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanGetOfferings.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanGetOfferings.1.json
@@ -22,8 +22,8 @@
           },
           "price" : 39.99,
           "priceString" : "$39.99",
-          "productCategory" : "SUBSCRIPTION",
-          "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
+          "productType" : "SUBSCRIPTION",
+          "productSubtype" : "AUTO_RENEWABLE_SUBSCRIPTION",
           "subscriptionPeriod" : "P1Y",
           "title" : "Annual Subscription"
         }
@@ -50,8 +50,8 @@
             },
             "price" : 39.99,
             "priceString" : "$39.99",
-            "productCategory" : "SUBSCRIPTION",
-            "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
+            "productType" : "SUBSCRIPTION",
+            "productSubtype" : "AUTO_RENEWABLE_SUBSCRIPTION",
             "subscriptionPeriod" : "P1Y",
             "title" : "Annual Subscription"
           }
@@ -85,8 +85,8 @@
             },
             "price" : 19.99,
             "priceString" : "$19.99",
-            "productCategory" : "SUBSCRIPTION",
-            "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
+            "productType" : "SUBSCRIPTION",
+            "productSubtype" : "AUTO_RENEWABLE_SUBSCRIPTION",
             "subscriptionPeriod" : "P1M",
             "title" : "Monthly Subscription"
           }
@@ -122,8 +122,8 @@
           },
           "price" : 19.99,
           "priceString" : "$19.99",
-          "productCategory" : "SUBSCRIPTION",
-          "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
+          "productType" : "SUBSCRIPTION",
+          "productSubtype" : "AUTO_RENEWABLE_SUBSCRIPTION",
           "subscriptionPeriod" : "P1M",
           "title" : "Monthly Subscription"
         }
@@ -153,8 +153,8 @@
         },
         "price" : 39.99,
         "priceString" : "$39.99",
-        "productCategory" : "SUBSCRIPTION",
-        "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
+        "productType" : "SUBSCRIPTION",
+        "productSubtype" : "AUTO_RENEWABLE_SUBSCRIPTION",
         "subscriptionPeriod" : "P1Y",
         "title" : "Annual Subscription"
       }
@@ -181,8 +181,8 @@
           },
           "price" : 39.99,
           "priceString" : "$39.99",
-          "productCategory" : "SUBSCRIPTION",
-          "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
+          "productType" : "SUBSCRIPTION",
+          "productSubtype" : "AUTO_RENEWABLE_SUBSCRIPTION",
           "subscriptionPeriod" : "P1Y",
           "title" : "Annual Subscription"
         }
@@ -216,8 +216,8 @@
           },
           "price" : 19.99,
           "priceString" : "$19.99",
-          "productCategory" : "SUBSCRIPTION",
-          "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
+          "productType" : "SUBSCRIPTION",
+          "productSubtype" : "AUTO_RENEWABLE_SUBSCRIPTION",
           "subscriptionPeriod" : "P1M",
           "title" : "Monthly Subscription"
         }
@@ -253,8 +253,8 @@
         },
         "price" : 19.99,
         "priceString" : "$19.99",
-        "productCategory" : "SUBSCRIPTION",
-        "productType" : "AUTO_RENEWABLE_SUBSCRIPTION",
+        "productType" : "SUBSCRIPTION",
+        "productSubtype" : "AUTO_RENEWABLE_SUBSCRIPTION",
         "subscriptionPeriod" : "P1M",
         "title" : "Monthly Subscription"
       }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/StoreProduct+HybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/StoreProduct+HybridAdditionsTests.swift
@@ -70,16 +70,16 @@ class StoreProductHybridAdditionsTests: QuickSpec {
             it("maps productCategory correctly") {
                 var receivedDictionary = self.storeProductDictionary(subscriptionPeriod: SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .month))
 
-                expect(receivedDictionary["productCategory"] as? NSString) == "SUBSCRIPTION"
+                expect(receivedDictionary["productType"] as? NSString) == "SUBSCRIPTION"
 
                 receivedDictionary = self.storeProductDictionary(subscriptionPeriod: nil)
 
-                expect(receivedDictionary["productCategory"] as? NSString) == "NON_SUBSCRIPTION"
+                expect(receivedDictionary["productType"] as? NSString) == "NON_SUBSCRIPTION"
             }
             it("maps productType to NON_CONSUMABLE for SK1Products") {
                 let receivedDictionary = self.storeProductDictionary()
 
-                expect(receivedDictionary["productType"] as? NSString) == "NON_CONSUMABLE"
+                expect(receivedDictionary["productSubtype"] as? NSString) == "NON_CONSUMABLE"
             }
             it("maps title correctly") {
                 let expected = "Testing product title"


### PR DESCRIPTION
## Motivation

iOS counterpart to #376 

Rename `productCategory` to `product type` and `productType` to `productSubtype` for `StoreProduct`

## Description

These were _not_ being used by any of the hybrid models (in Flutter, React Native, etc). Even though this is a slightly weird rename for iOS, Android and the other hybrids were using "Product Type" and "Purchase Type" so this will bring naming similar on hybrids.

The only kind of breaking change this _could_ have is if developers in the Javascript/Typescript environment were looking at these undocumented `productCategory` and `productType` keys but this will be called out in the changelogs.
