### PR TITLE
`CircleCI`: don't allow deploy until tests have finished

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,6 +300,11 @@ workflows:
     jobs:
       - hold:
           type: approval
+          requires:
+            - test-ios
+            - test-xcode-13-2
+            - integration-test-ios
+            - test-android
           <<: *release-branches
       - tag-release-branch:
           requires:


### PR DESCRIPTION
Right now the "hold" job can be approved and the release started before tests have passed. This prevents that.
