### PR TITLE
[BC5] Use new mapped product type values for `purchaseProduct()` and `getProductInfo()`

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.getCustomerInfoWith
 import com.revenuecat.purchases.getOfferingsWith
 import com.revenuecat.purchases.getProductsWith
 import com.revenuecat.purchases.hybridcommon.mappers.LogHandlerWithMapping
+import com.revenuecat.purchases.hybridcommon.mappers.MappedProductType
 import com.revenuecat.purchases.hybridcommon.mappers.map
 import com.revenuecat.purchases.logInWith
 import com.revenuecat.purchases.logOutWith
@@ -58,7 +59,7 @@ fun getProductInfo(
     val onError: (PurchasesError) -> Unit = { onResult.onError(it.map()) }
     val onReceived: (List<StoreProduct>) -> Unit = { onResult.onReceived(it.map()) }
 
-    if (type.equals("subs", ignoreCase = true)) {
+    if (mapStringTypeToProductType(type) == ProductType.SUBS) {
         Purchases.sharedInstance.getProductsWith(productIDs, ProductType.SUBS, onError, onReceived)
     } else {
         Purchases.sharedInstance.getProductsWith(productIDs, ProductType.INAPP, onError, onReceived)
@@ -87,18 +88,20 @@ fun purchaseProduct(
         return
     }
 
+    val productType = mapStringTypeToProductType(type)
+
     if (activity != null) {
         val onReceiveStoreProducts: (List<StoreProduct>) -> Unit = { storeProducts ->
             val productToBuy = storeProducts.firstOrNull {
                 // Comparison for when productIdentifier is "subId:basePlanId"
                 val foundByProductIdContainingBasePlan =
-                    (it.id == productIdentifier && it.type.name.equals(type, ignoreCase = true))
+                    (it.id == productIdentifier && it.type == productType)
 
                 // Comparison for when productIdentifier is "subId" and googleBasePlanId is "basePlanId"
                 val foundByProductIdAndGoogleBasePlanId = (
                     it.purchasingData.productId == productIdentifier
                         && it.googleProduct?.basePlanId == googleBasePlanId
-                        && it.type.name.equals(type, ignoreCase = true)
+                        && it.type == productType
                     )
 
                 // Finding the matching StoreProduct two different ways:
@@ -139,7 +142,7 @@ fun purchaseProduct(
             }
 
         }
-        if (type.equals("subs", ignoreCase = true)) {
+        if (productType == ProductType.SUBS) {
             // The "productIdentifier"
             val productIdWithoutBasePlanId = productIdentifier.split(":").first()
 
@@ -492,6 +495,27 @@ fun getPromotionalOffer() : ErrorContainer {
 }
 
 // region private functions
+
+internal fun mapStringTypeToProductType(type: String) : ProductType {
+    MappedProductType.values().firstOrNull { it.value.equals(type, ignoreCase = true) }?.let {
+        return when(it) {
+            MappedProductType.NON_SUBSCRIPTION -> ProductType.INAPP
+            MappedProductType.SUBSCRIPTION -> ProductType.SUBS
+            MappedProductType.UNKNOWN -> ProductType.UNKNOWN
+        }
+    }
+
+    // Maps strings used in deprecated hybrid methods to native ProductType enum
+    // "subs" and "inapp" are legacy purchase types used in v4 and below
+    return when(type.lowercase()) {
+        "subs" -> ProductType.SUBS
+        "inapp" -> ProductType.INAPP
+        else -> {
+            warnLog("Unrecognized product type: $type... Defaulting to INAPP")
+            ProductType.INAPP
+        }
+    }
+}
 
 internal class InvalidProrationModeException(): Exception()
 

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -497,13 +497,11 @@ fun getPromotionalOffer() : ErrorContainer {
 // region private functions
 
 internal fun mapStringTypeToProductType(type: String) : ProductType {
-    MappedProductType.values().firstOrNull { it.value.equals(type, ignoreCase = true) }?.let {
-        return when(it) {
-            MappedProductType.NON_SUBSCRIPTION -> ProductType.INAPP
-            MappedProductType.SUBSCRIPTION -> ProductType.SUBS
-            MappedProductType.UNKNOWN -> ProductType.UNKNOWN
+    MappedProductType.values()
+        .firstOrNull { it.value.equals(type, ignoreCase = true) }
+        ?.let {
+            return it.toProductType
         }
-    }
 
     // Maps strings used in deprecated hybrid methods to native ProductType enum
     // "subs" and "inapp" are legacy purchase types used in v4 and below

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -40,7 +40,7 @@ fun StoreProduct.map(): Map<String, Any?> =
         "currencyCode" to priceCurrencyCode,
         "introPrice" to mapIntroPrice(),
         "discounts" to null,
-        "productType" to mapProductType(),
+        "productType" to mapProductType().value,
         "productSubtype" to mapProductSubtype(),
         "subscriptionPeriod" to period?.iso8601,
         "defaultOption" to defaultOption?.mapSubscriptionOption(this),
@@ -50,11 +50,17 @@ fun StoreProduct.map(): Map<String, Any?> =
 
 fun List<StoreProduct>.map(): List<Map<String, Any?>> = this.map { it.map() }
 
-internal fun StoreProduct.mapProductType(): String {
+internal enum class MappedProductType(val value: String) {
+    SUBSCRIPTION("SUBSCRIPTION"),
+    NON_SUBSCRIPTION("NON_SUBSCRIPTION"),
+    UNKNOWN("UNKNOWN");
+}
+
+internal fun StoreProduct.mapProductType(): MappedProductType {
     return when (type) {
-        ProductType.INAPP -> "NON_SUBSCRIPTION"
-        ProductType.SUBS -> "SUBSCRIPTION"
-        ProductType.UNKNOWN -> "UNKNOWN"
+        ProductType.INAPP -> MappedProductType.NON_SUBSCRIPTION
+        ProductType.SUBS -> MappedProductType.SUBSCRIPTION
+        ProductType.UNKNOWN -> MappedProductType.UNKNOWN
     }
 }
 

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -54,6 +54,13 @@ internal enum class MappedProductType(val value: String) {
     SUBSCRIPTION("SUBSCRIPTION"),
     NON_SUBSCRIPTION("NON_SUBSCRIPTION"),
     UNKNOWN("UNKNOWN");
+
+    val toProductType: ProductType
+        get() = when(this) {
+            NON_SUBSCRIPTION -> ProductType.INAPP
+            SUBSCRIPTION -> ProductType.SUBS
+            UNKNOWN -> ProductType.UNKNOWN
+        }
 }
 
 internal fun StoreProduct.mapProductType(): MappedProductType {

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -430,6 +430,65 @@ internal class CommonKtTests {
         purchaseProduct(
             mockActivity,
             productIdentifier = expectedProductIdentifier,
+            type = "SUBSCRIPTION",
+            googleBasePlanId = null,
+            googleOldProductId = null,
+            googleProrationMode = null,
+            googleIsPersonalizedPrice = null,
+            presentedOfferingIdentifier = null,
+            onResult = object : OnResult {
+                override fun onReceived(map: MutableMap<String, *>) {
+                    receivedResponse = map
+                }
+
+                override fun onError(errorContainer: ErrorContainer) {
+                    fail("Should be success")
+                }
+            }
+        )
+
+        assertNotNull(receivedResponse)
+        assertEquals(expectedProductIdentifier, receivedResponse?.get("productIdentifier"))
+    }
+
+    @Test
+    fun `purchaseProduct passes correct productIdentifier and legacy product type after a successful purchase`() {
+        configure(
+            context = mockContext,
+            apiKey = "api_key",
+            appUserID = "appUserID",
+            observerMode = true,
+            platformInfo = PlatformInfo("flavor", "version")
+        )
+        val expectedProductIdentifier = "product"
+        var receivedResponse: MutableMap<String, *>? = null
+
+        val capturedGetStoreProductsCallback = slot<GetStoreProductsCallback>()
+        val mockStoreProduct = stubStoreProduct(expectedProductIdentifier)
+        val mockPurchase = mockk<StoreTransaction>()
+        every {
+            mockPurchase.productIds
+        } returns ArrayList(listOf(expectedProductIdentifier, "other"))
+
+        every {
+            mockPurchases.getProducts(listOf(expectedProductIdentifier), ProductType.SUBS, capture(capturedGetStoreProductsCallback))
+        } answers {
+            capturedGetStoreProductsCallback.captured.onReceived(listOf(mockStoreProduct))
+        }
+
+        val capturedPurchaseCallback = slot<PurchaseCallback>()
+        every {
+            mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
+        } answers {
+            val params = it.invocation.args.first() as PurchaseParams
+            assertEquals(false, params.isPersonalizedPrice)
+
+            capturedPurchaseCallback.captured.onCompleted(mockPurchase, mockk(relaxed = true))
+        }
+
+        purchaseProduct(
+            mockActivity,
+            productIdentifier = expectedProductIdentifier,
             type = "subs",
             googleBasePlanId = null,
             googleOldProductId = null,
@@ -1110,6 +1169,30 @@ internal class CommonKtTests {
         }
 
         assertTrue(catchWasCalled)
+    }
+
+    @Test
+    fun `mapStringTypeToProductType returns ProductType SUBS for subs`() {
+        val productType = mapStringTypeToProductType("subs")
+        assertEquals(ProductType.SUBS, productType)
+    }
+
+    @Test
+    fun `mapStringTypeToProductType returns ProductType SUBS for SUBSCRIPTION`() {
+        val productType = mapStringTypeToProductType("SUBSCRIPTION")
+        assertEquals(ProductType.SUBS, productType)
+    }
+
+    @Test
+    fun `mapStringTypeToProductType returns ProductType INAPP for inapp`() {
+        val productType = mapStringTypeToProductType("inapp")
+        assertEquals(ProductType.INAPP, productType)
+    }
+
+    @Test
+    fun `mapStringTypeToProductType returns ProductType INAPP for NON_SUBSCRIPTION`() {
+        val productType = mapStringTypeToProductType("NON_SUBSCRIPTION")
+        assertEquals(ProductType.INAPP, productType)
     }
 
     private fun getOfferings(mockStoreProduct: StoreProduct): Triple<String, Package, Offerings> {


### PR DESCRIPTION
## Motivation

There were inconsistencies between the product type being sent to the hybrid on `StoreProduct` and the purchase type being used `purchaseProduct()` and `getProductInfo()`

## Description

This version of hybrid will now use `SUBSCRIPTION` and `NON_SUBSCRIPTION` as its `ProductType`.
This `ProductType` is used on `StoreProduct` and on the method calls for `purchaseProduct()` and `getProductInfo()`

Created a new hybrid common internal `MappedProductType` enum that is used for generating the mapped `StoreProduct` JSON and mapping the product type string on `purchaseProduct` and `getProductInfo` into native Android SDK `ProductType`s.

This still supports the legacy "subs" and "inapp" that come from deprecated hybrid methods that may still be used.