### PR TITLE
[BC5] Add product category  support in `getProductInfo()` and `purchaseProduct()`

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.hybridcommon.mappers
 
 import com.revenuecat.purchases.ProductType
-import com.revenuecat.purchases.models.OfferPaymentMode
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
@@ -41,7 +40,7 @@ fun StoreProduct.map(): Map<String, Any?> =
         "currencyCode" to priceCurrencyCode,
         "introPrice" to mapIntroPrice(),
         "discounts" to null,
-        "productCategory" to mapProductCategory(),
+        "productCategory" to mapProductCategory().value,
         "productType" to mapProductType(),
         "subscriptionPeriod" to period?.iso8601,
         "defaultOption" to defaultOption?.mapSubscriptionOption(this),
@@ -51,11 +50,24 @@ fun StoreProduct.map(): Map<String, Any?> =
 
 fun List<StoreProduct>.map(): List<Map<String, Any?>> = this.map { it.map() }
 
-internal fun StoreProduct.mapProductCategory(): String {
+internal enum class MappedProductCategory(val value: String) {
+    SUBSCRIPTION("SUBSCRIPTION"),
+    NON_SUBSCRIPTION("NON_SUBSCRIPTION"),
+    UNKNOWN("UNKNOWN");
+
+    val toProductType: ProductType
+        get() = when(this) {
+            NON_SUBSCRIPTION -> ProductType.INAPP
+            SUBSCRIPTION -> ProductType.SUBS
+            UNKNOWN -> ProductType.UNKNOWN
+        }
+}
+
+internal fun StoreProduct.mapProductCategory(): MappedProductCategory {
     return when (type) {
-        ProductType.INAPP -> "NON_SUBSCRIPTION"
-        ProductType.SUBS -> "SUBSCRIPTION"
-        ProductType.UNKNOWN -> "UNKNOWN"
+        ProductType.INAPP -> MappedProductCategory.NON_SUBSCRIPTION
+        ProductType.SUBS -> MappedProductCategory.SUBSCRIPTION
+        ProductType.UNKNOWN -> MappedProductCategory.UNKNOWN
     }
 }
 


### PR DESCRIPTION
## Motivation

Currently, the `purchaseProduct(identifier, type)` method requires the developer to manually pass the type (either "subs" or "inapp") of the product they are purchasing. Even if they are basing this off of a fetched `StoreProduct`, the developer would need to determine what type of product it is because its currently not exposed in any of the hybrid SDKs.

New hybrids versions will have a new `productCategory` property on `StoreProduct`. This value has always been sent from the Hybrid Common layer but was just never exposed on the models. It has values of "SUBSCRIPTION" and "NON_SUBSCRIPTION".

These values should be able to be passed into the type of `purchaseProduct()` without any developer modification to make a purchase

Example: 

```dart
Purchases.purchaseProduct(storeProduct.identifier, storeProduct.productCategory)
``` 

Goal of this is to **not** be a breaking API change but for Hybrid Common to handle these different values of legacy values ("subs" and "inapp") and the product categories of "SUBSCRIPTION" and "NON_SUBSCRIPTION" going forward.

## Description

Mostly taken from #384 (which was reverted in the great unmigration of product type)

- Moved hardcoded strings into `MappedProductCategory` enum with values of:
  - `SUBSCRIPTION`
  - `NON_SUBSCRIPTION`
  - `UNKNOWN`
- New `mapStringToProductType()` helper method for converting from `String` to `ProductType`
  - First checks if string is a `MappedProductCategory`
  - Then sees if legacy value of "subs" or "inapp"
- `mapStringToProductType()` is used in `getProductInfo()` and `purchaseProduct()