### PR TITLE
Add metadata to offering for iOS

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2CC09B252A27E35B0047DA34 /* Offering+HybridAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC09B242A27E35B0047DA34 /* Offering+HybridAdditionsTests.swift */; };
 		2D0D2080245797B900614E47 /* Date+HybridAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0D207F245797B900614E47 /* Date+HybridAdditionsTests.swift */; };
 		2D44523E2491198A006AA26F /* CustomerInfo+HybridAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D44523D2491198A006AA26F /* CustomerInfo+HybridAdditionsTests.swift */; };
 		2D44524124916501006AA26F /* PurchasesHybridCommonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D44524024916501006AA26F /* PurchasesHybridCommonTests.swift */; };
@@ -94,6 +95,7 @@
 /* Begin PBXFileReference section */
 		03AC07491DFE4DAB6F79517F /* Pods-PurchasesHybridCommonSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommonSwift.debug.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommonSwift/Pods-PurchasesHybridCommonSwift.debug.xcconfig"; sourceTree = "<group>"; };
 		21013A2D5F7BCDB086F7B742 /* Pods-PurchasesHybridCommonSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommonSwift.release.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommonSwift/Pods-PurchasesHybridCommonSwift.release.xcconfig"; sourceTree = "<group>"; };
+		2CC09B242A27E35B0047DA34 /* Offering+HybridAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Offering+HybridAdditionsTests.swift"; sourceTree = "<group>"; };
 		2D0D207F245797B900614E47 /* Date+HybridAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+HybridAdditionsTests.swift"; sourceTree = "<group>"; };
 		2D44523D2491198A006AA26F /* CustomerInfo+HybridAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+HybridAdditionsTests.swift"; sourceTree = "<group>"; };
 		2D44524024916501006AA26F /* PurchasesHybridCommonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesHybridCommonTests.swift; sourceTree = "<group>"; };
@@ -244,6 +246,7 @@
 				2DC85B57246B2A7B003CD22E /* PurchasesHybridAdditionsTests.swift */,
 				2D0D207F245797B900614E47 /* Date+HybridAdditionsTests.swift */,
 				2D44523D2491198A006AA26F /* CustomerInfo+HybridAdditionsTests.swift */,
+				2CC09B242A27E35B0047DA34 /* Offering+HybridAdditionsTests.swift */,
 				2D44524024916501006AA26F /* PurchasesHybridCommonTests.swift */,
 				35F6FD5F2673FE5600ABCB53 /* ErrorContainerTests.swift */,
 				2DD3D1842810A81F00A19EC6 /* XCTestCase+Expectations.swift */,
@@ -757,6 +760,7 @@
 			files = (
 				FD922B66283D7493009E36C3 /* EntitlementInfo+HybridAdditionsTests.swift in Sources */,
 				2D0D2080245797B900614E47 /* Date+HybridAdditionsTests.swift in Sources */,
+				2CC09B252A27E35B0047DA34 /* Offering+HybridAdditionsTests.swift in Sources */,
 				2DD3D1852810A81F00A19EC6 /* XCTestCase+Expectations.swift in Sources */,
 				35A672FC295C9FC9009F986F /* StoreProduct+HybridAdditionsTests.swift in Sources */,
 				2D44524124916501006AA26F /* PurchasesHybridCommonTests.swift in Sources */,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/Offering+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/Offering+HybridAdditions.swift
@@ -15,6 +15,7 @@ import RevenueCat
         var result: [String: Any] = [
             "identifier": identifier,
             "serverDescription": serverDescription,
+            "metadata": metadata,
             "availablePackages": availablePackages.map { $0.dictionary(identifier) }
         ]
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanGetOfferings.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanGetOfferings.1.json
@@ -93,6 +93,9 @@
         }
       ],
       "identifier" : "default",
+      "metadata" : {
+        "dontdeletethis" : "useforintegrationtesting"
+      },
       "monthly" : {
         "identifier" : "$rc_monthly",
         "offeringIdentifier" : "default",
@@ -224,6 +227,9 @@
       }
     ],
     "identifier" : "default",
+    "metadata" : {
+      "dontdeletethis" : "useforintegrationtesting"
+    },
     "monthly" : {
       "identifier" : "$rc_monthly",
       "offeringIdentifier" : "default",

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanGetOfferings.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanGetOfferings.1.json
@@ -93,6 +93,9 @@
         }
       ],
       "identifier" : "default",
+      "metadata" : {
+        "dontdeletethis" : "useforintegrationtesting"
+      },
       "monthly" : {
         "identifier" : "$rc_monthly",
         "offeringIdentifier" : "default",
@@ -224,6 +227,9 @@
       }
     ],
     "identifier" : "default",
+    "metadata" : {
+      "dontdeletethis" : "useforintegrationtesting"
+    },
     "monthly" : {
       "identifier" : "$rc_monthly",
       "offeringIdentifier" : "default",

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Offering+HybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Offering+HybridAdditionsTests.swift
@@ -1,0 +1,101 @@
+//
+//  Offering+HybridAdditionsTests.swift
+//  PurchasesHybridCommonTests
+//
+//  Created by Josh Holtz on 5/31/23.
+//  Copyright © 2023 RevenueCat. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import PurchasesHybridCommon
+@testable import RevenueCat
+import Foundation
+
+class OfferingInfoHybridAdditionsTests: QuickSpec {
+
+    override func spec() {
+        describe("rc_dictionary") {
+            context("metadata") {
+                it("contains the empty metadata") {
+                    let mockOffering = Offering(
+                        identifier: "default",
+                        serverDescription: "The default offering",
+                        metadata: [:],
+                        availablePackages: [
+                            .init(
+                                identifier: "annual",
+                                packageType: .annual,
+                                storeProduct: MockStoreProduct(),
+                                offeringIdentifier: "default"
+                            )
+                        ]
+                    )
+
+                    let dictionary = mockOffering.dictionary
+                    expect(dictionary["metadata"] as? [String: Any]).to(haveCount(0))
+                }
+
+                it("contains the metadata of all types") {
+                    let mockOffering = Offering(
+                        identifier: "default",
+                        serverDescription: "The default offering",
+                        metadata: [
+                            "int": 5,
+                            "double": 5.5,
+                            "boolean": true,
+                            "string": "five",
+                            "array": ["five"],
+                            "dictionary": [
+                                "string": "five"
+                            ]
+                        ],
+                        availablePackages: [
+                            .init(
+                                identifier: "annual",
+                                packageType: .annual,
+                                storeProduct: MockStoreProduct(),
+                                offeringIdentifier: "default"
+                            )
+                        ]
+                    )
+
+                    let dictionary = mockOffering.dictionary
+                    expect(dictionary["metadata"] as? [String: Any]).to(haveCount(6))
+                }
+            }
+        }
+    }
+}
+
+private final class MockStoreProduct: StoreProductType, Sendable {
+
+    var productCategory: RevenueCat.StoreProduct.ProductCategory = .subscription
+
+    var productType: RevenueCat.StoreProduct.ProductType = .autoRenewableSubscription
+
+    var localizedDescription: String = ""
+
+    var localizedTitle: String = ""
+
+    var currencyCode: String? = ""
+
+    var price: Decimal = 0.0
+
+    var localizedPriceString: String = ""
+
+    var productIdentifier: String = ""
+
+    var isFamilyShareable: Bool = false
+
+    var subscriptionGroupIdentifier: String? = nil
+
+    var priceFormatter: NumberFormatter? = nil
+
+    var subscriptionPeriod: RevenueCat.SubscriptionPeriod? = nil
+
+    var introductoryDiscount: RevenueCat.StoreProductDiscount? = nil
+
+    var discounts: [RevenueCat.StoreProductDiscount] = []
+
+}


### PR DESCRIPTION
## Motivation

Adds metadata to iOS side of Purchase Hybrid Common

_Note: Android is happening in the https://github.com/RevenueCat/purchases-hybrid-common/tree/bc5-support branch_

## Description

- Adds `metadata` into `dictionary` property on `Offering`
- Added new `Offering` tests
- Updated integration tests (added metadata onto the hybrid common RC project)