### PR TITLE
Makes pushing to Cocoapods its own job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,9 +303,6 @@ workflows:
             - deploy-android
       - push-pods:
           <<: *release-tags
-          # Xcode 14 not supported until https://github.com/CocoaPods/CocoaPods/issues/11558 is fixed.
-          # This runs as its own job until https://github.com/CocoaPods/CocoaPods/issues/11621 is fixed.
-          xcode_version: '13.4.1'
           requires:
             - make-github-release
       - trigger-dependent-updates:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,16 @@
 version: 2.1
 
 aliases:
+  base-ios-job: &base-ios-job
+    resource_class: macos.x86.medium.gen2
+    macos:
+      xcode: << parameters.xcode_version >>
+    parameters:
+      xcode_version:
+        type: string
+        default: '14.3.0'
+    working_directory: ~/ios
+    shell: /bin/bash --login -o pipefail
   release-tags: &release-tags
     filters:
       tags:
@@ -19,7 +29,7 @@ aliases:
 
 orbs:
   android: circleci/android@1.0.3
-  revenuecat: revenuecat/sdks-common-config@1.1.0
+  revenuecat: revenuecat/sdks-common-config@2.2.0
   macos: circleci/macos@2.0.1
 
 parameters:
@@ -27,13 +37,6 @@ parameters:
     type: enum
     enum: [ build, dependency-update, bump ]
     default: build
-
-executors:
-  ios-executor:
-    resource_class: macos.x86.medium.gen2
-    working_directory: ~/ios
-    macos:
-      xcode: 14.1.0
 
 commands:
   setup-git-credentials:
@@ -53,18 +56,6 @@ commands:
               do ssh-keyscan github.com,$ip; \
               ssh-keyscan $ip; \
               done 2>/dev/null >> ~/.ssh/known_hosts
-
-  install-gems:
-    steps:
-      - restore_cache:
-          key: v3-gem-cache-{{ checksum "Gemfile.lock" }}
-      - run: 
-          name: Bundle install
-          command: bundle install --clean --path vendor/bundle
-      - save_cache:
-          key: v3-gem-cache-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
 
   run-ios-tests:
     steps:
@@ -90,15 +81,16 @@ commands:
 
 jobs:
   test-ios:
-    executor: ios-executor
+    <<: *base-ios-job
     steps:
       - run-ios-tests
 
   integration-test-ios:
-    executor: ios-executor
+    <<: *base-ios-job
     steps:
       - checkout
-      - install-gems
+      - revenuecat/install-gem-mac-dependencies:
+          cache-version: v1
       - run:
           name: Install pods
           command: pod install
@@ -126,8 +118,7 @@ jobs:
           destination: scan-output
   
   deploy-ios:
-    executor: ios-executor
-    shell: /bin/bash --login -o pipefail
+    <<: *base-ios-job
     steps:
       - checkout
       - trust-github-key
@@ -154,6 +145,18 @@ jobs:
           command: bundle exec fastlane ios release
           no_output_timeout: 30m
 
+  push-pods:
+    <<: *base-ios-job
+    steps:
+      - checkout
+      - revenuecat/install-gem-mac-dependencies:
+          cache-version: v1
+      - trust-github-key
+      - run:
+          name: Deploy new version to Cocoapods
+          command: bundle exec fastlane push_pods
+          no_output_timeout: 30m
+
   test-android:
     executor:
       name: android/android-machine
@@ -178,7 +181,8 @@ jobs:
       resource-class: large
     steps:
       - checkout
-      - revenuecat/install-rubydocker-dependencies
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
       - android/accept-licenses
       - restore_cache:
           key: jars-{{ checksum "android/build.gradle" }}
@@ -189,26 +193,28 @@ jobs:
 
   make-github-release:
     docker:
-      - image: cimg/ruby:2.7.2
+      - image: cimg/ruby:3.1.2
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - revenuecat/install-rubydocker-dependencies
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
       - run:
           name: Make GitHub release for current version
           command: bundle exec fastlane github_release_current
   
   dependency-update:
     docker:
-      - image: cimg/ruby:2.7.2
+      - image: cimg/ruby:3.1.2
     steps:
       - checkout
       - attach_workspace:
           at: .
       - setup-git-credentials
       - trust-github-key
-      - revenuecat/install-rubydocker-dependencies
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
       - run:
           name: Update dependencies to latest versions
           command: bundle exec fastlane open_pr_upgrading_dependencies
@@ -222,7 +228,8 @@ jobs:
       - checkout
       - setup-git-credentials
       - trust-github-key
-      - revenuecat/install-rubydocker-dependencies
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
       - run: 
           name: Tag branch
           command: bundle exec fastlane tag_current_branch
@@ -234,7 +241,8 @@ jobs:
       - checkout
       - setup-git-credentials
       - trust-github-key
-      - revenuecat/install-rubydocker-dependencies
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
       - run:
           name: Automatically bump release and create release PR
           command: bundle exec fastlane automatic_bump github_rate_limit:10
@@ -246,7 +254,8 @@ jobs:
       - checkout
       - setup-git-credentials
       - trust-github-key
-      - revenuecat/install-rubydocker-dependencies
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
       - run:
           name: Kick off Flutter automatic dependency update
           command: bundle exec fastlane bump_hybrid_dependencies repo_name:purchases-flutter
@@ -296,6 +305,13 @@ workflows:
           requires:
             - deploy-ios
             - deploy-android
+      - push-pods:
+          <<: *release-tags
+          # Xcode 14 not supported until https://github.com/CocoaPods/CocoaPods/issues/11558 is fixed.
+          # This runs as its own job until https://github.com/CocoaPods/CocoaPods/issues/11621 is fixed.
+          xcode_version: '13.4.1'
+          requires:
+            - make-github-release
       - trigger-dependent-updates:
           <<: *release-tags
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ aliases:
     parameters:
       xcode_version:
         type: string
-        default: '14.3.0'
+        default: 14.3.0
     working_directory: ~/ios
     shell: /bin/bash --login -o pipefail
   release-tags: &release-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,9 @@ commands:
               ssh-keyscan $ip; \
               done 2>/dev/null >> ~/.ssh/known_hosts
 
-  run-ios-tests:
+jobs:
+  test-ios:
+    <<: *base-ios-job
     steps:
       - checkout
       - run:
@@ -78,12 +80,6 @@ commands:
       - store_artifacts:
           path: ios/PurchasesHybridCommon/test_output
           destination: scan-output
-
-jobs:
-  test-ios:
-    <<: *base-ios-job
-    steps:
-      - run-ios-tests
 
   integration-test-ios:
     <<: *base-ios-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,11 @@
 # For a detailed guide to building and testing on iOS, read the docs:
 # https://circleci.com/docs/2.0/testing-ios/
 
+orbs:
+  android: circleci/android@1.0.3
+  revenuecat: revenuecat/sdks-common-config@2.2.0
+  macos: circleci/macos@2.0.1
+
 version: 2.1
 
 aliases:
@@ -26,11 +31,6 @@ aliases:
         ignore: /.*/
       branches:
         only: /^release\/.*/
-
-orbs:
-  android: circleci/android@1.0.3
-  revenuecat: revenuecat/sdks-common-config@2.2.0
-  macos: circleci/macos@2.0.1
 
 parameters:
   action:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -312,9 +312,8 @@ lane :bump_hybrid_dependencies do |options|
 end
 
 platform :ios do
-  desc "Release to CocoaPods, and create GitHub release"
-  lane :release do |options|
-    version_number = current_version_number
+  desc "Release to CocoaPods"
+  lane :push_pods do |options|
     push_pods
   end
 


### PR DESCRIPTION
Pushing to cocoapods keeps failing until they fix https://github.com/CocoaPods/CocoaPods/issues/11621

We should make pushing to pods its own job so it doesn't break the release process

This PR also cleans up the config.yaml a bit by updating to the latest version of the orb