### PR TITLE
Fix tests by removing mocking of currency formatters which weren't ne…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,7 +75,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.annotation:annotation:1.6.0'
+    implementation 'androidx.annotation:annotation:1.3.0'
 
     latestDependenciesApi "com.revenuecat.purchases:purchases:$purchases_version"
     latestDependenciesApi "com.revenuecat.purchases:purchases-core-common:$purchases_version"

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -55,6 +55,7 @@ import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
@@ -423,7 +424,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(null, params.isPersonalizedPrice)
+            assertNull(params.isPersonalizedPrice)
 
             capturedPurchaseCallback.captured.onCompleted(mockPurchase, mockk(relaxed = true))
         }
@@ -482,7 +483,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(null, params.isPersonalizedPrice)
+            assertNull(params.isPersonalizedPrice)
 
             capturedPurchaseCallback.captured.onCompleted(mockPurchase, mockk(relaxed = true))
         }
@@ -543,7 +544,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(null, params.isPersonalizedPrice)
+            assertNull(params.isPersonalizedPrice)
 
             val presentedOfferingIdentifier = getPresentedOfferingId(params)
             assertEquals(expectedOfferingIdentifier, presentedOfferingIdentifier)
@@ -608,7 +609,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(null, params.isPersonalizedPrice)
+            assertNull(params.isPersonalizedPrice)
 
             capturedPurchaseCallback.captured.onCompleted(mockPurchase, mockk(relaxed = true))
         }
@@ -689,7 +690,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(null, params.isPersonalizedPrice)
+            assertNull(params.isPersonalizedPrice)
 
             capturedPurchaseCallback.captured.onCompleted(mockPurchase, mockk(relaxed = true))
         }
@@ -814,7 +815,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(null, params.isPersonalizedPrice)
+            assertNull(params.isPersonalizedPrice)
 
             capturedPurchaseCallback.captured.onCompleted(mockPurchase, mockk(relaxed = true))
         }
@@ -940,7 +941,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(null, params.isPersonalizedPrice)
+            assertNull(params.isPersonalizedPrice)
 
             capturedPurchaseCallback.captured.onCompleted(mockPurchase, mockk(relaxed = true))
         }
@@ -1009,7 +1010,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(null, params.isPersonalizedPrice)
+            assertNull(params.isPersonalizedPrice)
 
             val presentedOfferingIdentifier = getPresentedOfferingId(params)
             assertEquals(expectedOfferingIdentifier, presentedOfferingIdentifier)

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -423,7 +423,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(false, params.isPersonalizedPrice)
+            assertEquals(null, params.isPersonalizedPrice)
 
             capturedPurchaseCallback.captured.onCompleted(mockPurchase, mockk(relaxed = true))
         }
@@ -482,7 +482,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(false, params.isPersonalizedPrice)
+            assertEquals(null, params.isPersonalizedPrice)
 
             capturedPurchaseCallback.captured.onCompleted(mockPurchase, mockk(relaxed = true))
         }
@@ -543,7 +543,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(false, params.isPersonalizedPrice)
+            assertEquals(null, params.isPersonalizedPrice)
 
             val presentedOfferingIdentifier = getPresentedOfferingId(params)
             assertEquals(expectedOfferingIdentifier, presentedOfferingIdentifier)
@@ -608,7 +608,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(false, params.isPersonalizedPrice)
+            assertEquals(null, params.isPersonalizedPrice)
 
             capturedPurchaseCallback.captured.onCompleted(mockPurchase, mockk(relaxed = true))
         }
@@ -689,7 +689,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(false, params.isPersonalizedPrice)
+            assertEquals(null, params.isPersonalizedPrice)
 
             capturedPurchaseCallback.captured.onCompleted(mockPurchase, mockk(relaxed = true))
         }
@@ -814,7 +814,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(false, params.isPersonalizedPrice)
+            assertEquals(null, params.isPersonalizedPrice)
 
             capturedPurchaseCallback.captured.onCompleted(mockPurchase, mockk(relaxed = true))
         }
@@ -940,7 +940,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(false, params.isPersonalizedPrice)
+            assertEquals(null, params.isPersonalizedPrice)
 
             capturedPurchaseCallback.captured.onCompleted(mockPurchase, mockk(relaxed = true))
         }
@@ -1009,7 +1009,7 @@ internal class CommonKtTests {
             mockPurchases.purchase(any<PurchaseParams>(), capture(capturedPurchaseCallback))
         } answers {
             val params = it.invocation.args.first() as PurchaseParams
-            assertEquals(false, params.isPersonalizedPrice)
+            assertEquals(null, params.isPersonalizedPrice)
 
             val presentedOfferingIdentifier = getPresentedOfferingId(params)
             assertEquals(expectedOfferingIdentifier, presentedOfferingIdentifier)

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/MockUtils.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/MockUtils.kt
@@ -18,14 +18,3 @@ fun mockLogError() {
         )
     } returns 0
 }
-
-fun mockCurrencyFormatter(price: Long, priceString: String) {
-    mockkStatic(NumberFormat::class)
-    mockkStatic(Currency::class)
-    val mockkNumberFormat = mockk<NumberFormat>()
-    val mockkCurrency = mockk<Currency>()
-    every { NumberFormat.getCurrencyInstance() } returns mockkNumberFormat
-    every { Currency.getInstance("USD") } returns mockkCurrency
-    every { mockkNumberFormat.currency = any() } just Runs
-    every { mockkNumberFormat.format(price) } returns priceString
-}

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductIntroPriceMapperTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductIntroPriceMapperTests.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.hybridcommon.mappers
 
-import com.revenuecat.purchases.hybridcommon.mockCurrencyFormatter
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.StoreProduct
 import io.mockk.every
@@ -26,7 +25,6 @@ internal class StoreProductIntroPriceMapperTests {
     inner class MappingFreeTrial {
         @Test
         fun `of 7 days, the map has the correct intro price values`() {
-            mockCurrencyFormatter(0, "$0.00")
             every { mockStoreProduct.freeTrialPeriod } returns Period(7, Period.Unit.DAY, "P7D")
             every { mockStoreProduct.freeTrialCycles } returns 1
             received = mockStoreProduct.mapIntroPrice()
@@ -43,7 +41,6 @@ internal class StoreProductIntroPriceMapperTests {
 
         @Test
         fun `of 1 month, the map has the correct intro price values`() {
-            mockCurrencyFormatter(0, "$0.00")
             every { mockStoreProduct.freeTrialPeriod } returns Period(1, Period.Unit.MONTH, "P1M")
             every { mockStoreProduct.freeTrialCycles } returns 1
             received = mockStoreProduct.mapIntroPrice()
@@ -60,7 +57,6 @@ internal class StoreProductIntroPriceMapperTests {
 
         @Test
         fun `of 0 days, the map has the correct intro price values`() {
-            mockCurrencyFormatter(0, "$0.00")
             every { mockStoreProduct.freeTrialPeriod } returns Period(0, Period.Unit.DAY, "P0D")
             every { mockStoreProduct.freeTrialCycles } returns 1
             received = mockStoreProduct.mapIntroPrice()


### PR DESCRIPTION
## Motivation

Fix failing Android tests

## Description

- Remove mocking of currency formatters (which weren't being used anymroe) which were causing some Java reflection issues
- Fixed tests for `isPersonalizePrice` there were failed due to Android `6.4.0` upgrade