### PR TITLE
`MockStoreProduct`: fixed `Sendable` warnings

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Offering+HybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Offering+HybridAdditionsTests.swift
@@ -68,11 +68,15 @@ class OfferingInfoHybridAdditionsTests: QuickSpec {
     }
 }
 
-private final class MockStoreProduct: StoreProductType, Sendable {
+// These are `enum`s, but for some reason Swift doesn't make them implicitly Sendable.
+extension StoreProduct.ProductCategory: @unchecked Sendable {}
+extension StoreProduct.ProductType: @unchecked Sendable {}
 
-    var productCategory: RevenueCat.StoreProduct.ProductCategory = .subscription
+private struct MockStoreProduct: StoreProductType {
 
-    var productType: RevenueCat.StoreProduct.ProductType = .autoRenewableSubscription
+    var productCategory: StoreProduct.ProductCategory = .subscription
+
+    var productType: StoreProduct.ProductType = .autoRenewableSubscription
 
     var localizedDescription: String = ""
 


### PR DESCRIPTION
Fixes
> Stored property 'productCategory' of 'Sendable'-conforming class 'MockStoreProduct' is mutable

We can make it a `struct` since it's a `protocol`, solving the mutability issue by making it a value type.
