### PR TITLE
Add isPrepaid to subscription option mapper

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -196,6 +196,7 @@ private fun SubscriptionOption.mapSubscriptionOption(storeProduct: StoreProduct)
         "tags" to tags,
         "isBasePlan" to isBasePlan,
         "billingPeriod" to billingPeriod?.mapPeriod(),
+        "isPrepaid" to isPrepaid,
         "fullPricePhase" to fullPricePhase?.mapPricingPhase(),
         "freePhase" to freePhase?.mapPricingPhase(),
         "introPhase" to introPhase?.mapPricingPhase(),

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapperTests.kt
@@ -160,6 +160,9 @@ internal class StoreProductMapperTest {
             type = ProductType.SUBS
         ).map().let {
             assertThat(it["productType"]).isEqualTo("AUTO_RENEWABLE_SUBSCRIPTION")
+
+            val defaultOption = it["defaultOption"] as Map<String, Any>
+            assertThat(defaultOption["isPrepaid"]).isEqualTo(false)
         }
         stubStoreProduct(
             productId = exptectedProductId,
@@ -176,18 +179,27 @@ internal class StoreProductMapperTest {
             )
         ).map().let {
             assertThat(it["productType"]).isEqualTo("PREPAID_SUBSCRIPTION")
+
+            val defaultOption = it["defaultOption"] as Map<String, Any>
+            assertThat(defaultOption["isPrepaid"]).isEqualTo(true)
         }
         stubStoreProduct(
             productId = exptectedProductId,
             type = ProductType.INAPP
         ).map().let {
             assertThat(it["productType"]).isEqualTo("CONSUMABLE")
+
+            val defaultOption = it["defaultOption"] as Map<String, Any>
+            assertThat(defaultOption["isPrepaid"]).isEqualTo(false)
         }
         stubStoreProduct(
             productId = exptectedProductId,
             type = ProductType.UNKNOWN
         ).map().let {
             assertThat(it["productType"]).isEqualTo("UNKNOWN")
+
+            val defaultOption = it["defaultOption"] as Map<String, Any>
+            assertThat(defaultOption["isPrepaid"]).isEqualTo(false)
         }
     }
 


### PR DESCRIPTION
## Description

Add `isPrepaid` to subscription option mapper for hybrids to use