### PR TITLE
CI: wait until pods have been pushed to trigger dependent updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,7 +320,7 @@ workflows:
       - trigger-dependent-updates:
           <<: *release-tags
           requires:
-            - make-github-release
+            - push-pods
   
   weekly-run-workflow:
     when:


### PR DESCRIPTION
We were doing it in parallel which could cause dependent's bump PRs to fail if pods take longer to be pushed.

<img width="1038" alt="Screenshot 2023-06-27 at 21 10 33" src="https://github.com/RevenueCat/purchases-hybrid-common/assets/1014118/c7303199-67c4-4738-9c85-62a02d13fb3a">
