### PR TITLE
Fix free trial and intro price to derive from defaultOption

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -15,12 +15,12 @@ val StoreProduct.priceString: String
 val StoreProduct.priceCurrencyCode: String
     get() = this.price.currencyCode
 val StoreProduct.freeTrialPeriod: Period?
-    get() = this.subscriptionOptions?.freeTrial?.freePhase?.billingPeriod
+    get() = this.defaultOption?.freePhase?.billingPeriod
 val StoreProduct.freeTrialCycles: Int?
-    get() = this.subscriptionOptions?.freeTrial?.freePhase?.billingCycleCount
+    get() = this.defaultOption?.freePhase?.billingCycleCount
 
 private val StoreProduct.introductoryPhase: PricingPhase?
-    get() = this.subscriptionOptions?.introOffer?.introPhase
+    get() = this.defaultOption?.introPhase
 val StoreProduct.introductoryPrice: String?
     get() = this.introductoryPhase?.price?.formatted
 val StoreProduct.introductoryPricePeriod: Period?

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductIntroPriceMapperTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductIntroPriceMapperTests.kt
@@ -28,7 +28,7 @@ internal class StoreProductIntroPriceMapperTests {
     inner class MappingFreeTrial {
         @Test
         fun `of 7 days, the map has the correct intro price values`() {
-            every { mockStoreProduct.subscriptionOptions?.freeTrial?.freePhase } returns PricingPhase(
+            every { mockStoreProduct.defaultOption?.freePhase } returns PricingPhase(
                 price = Price("$0.00", 0, "USD"),
                 billingCycleCount = 1,
                 billingPeriod = Period(7, Period.Unit.DAY, "P7D"),
@@ -48,7 +48,7 @@ internal class StoreProductIntroPriceMapperTests {
 
         @Test
         fun `of 1 month, the map has the correct intro price values`() {
-            every { mockStoreProduct.subscriptionOptions?.freeTrial?.freePhase } returns PricingPhase(
+            every { mockStoreProduct.defaultOption?.freePhase } returns PricingPhase(
                 price = Price("$0.00", 0, "USD"),
                 billingCycleCount = 1,
                 billingPeriod = Period(1, Period.Unit.MONTH, "P1M"),
@@ -68,7 +68,7 @@ internal class StoreProductIntroPriceMapperTests {
 
         @Test
         fun `of 0 days, the map has the correct intro price values`() {
-            every { mockStoreProduct.subscriptionOptions?.freeTrial?.freePhase } returns PricingPhase(
+            every { mockStoreProduct.defaultOption?.freePhase } returns PricingPhase(
                 price = Price("$0.00", 0, "USD"),
                 billingCycleCount = 1,
                 billingPeriod = Period(0, Period.Unit.DAY, "P0D"),


### PR DESCRIPTION
## Motiviation

Noticed when answering a question about `introPrice` that it wasn't using the free trial and intro price from `defaultOption`. It was using the first free trial and intro price that it found in all the subscription options.

## Description

Uses `defaultOption` when determing:
- `freeTrialPeriod`
- `freeTrialCycles`
- `introductoryPrice`
- `introductoryPricePeriod`
- `introductoryPriceAmountMicros`
- `introductoryPriceCycles`
