### PR TITLE
`.composite-enable`: fixed file reference

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -2,6 +2,6 @@ rootProject.name = 'purchases-hybrid-common'
 
 // Run enableLocalBuild task to enable building purchases-android from your local copy
 if (file(".composite-enable").exists()) {
-    String path = new File(".composite-enable").text
+    String path = file(".composite-enable").text
     includeBuild (path)
 }


### PR DESCRIPTION
We were using 2 different ways of referencing this file: `file()` and `new File`.

When using an absolute path, the first `file().exists()` was returning `true`, but `new File` was failing to find it.
