### PR TITLE
`Trusted Entitlements`: add support for setting `VerificationMode`

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -517,7 +517,7 @@ fun configure(
     }
     if (verificationMode != null) {
         try {
-            builder.verificationModeAndDiagnostics(EntitlementVerificationMode.valueOf(verificationMode))
+            builder.entitlementVerificationMode(EntitlementVerificationMode.valueOf(verificationMode))
         } catch (e: IllegalArgumentException) {
             warnLog("Attempted to configure with unknown verification mode: $verificationMode.")
         }

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.DangerousSettings
+import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchaseParams
@@ -500,6 +501,7 @@ fun configure(
     store: Store = Store.PLAY_STORE,
     dangerousSettings: DangerousSettings = DangerousSettings(autoSyncPurchases = true),
     shouldShowInAppMessagesAutomatically: Boolean? = null,
+    verificationMode: String? = null,
 ) {
     Purchases.platformInfo = platformInfo
     val builder =
@@ -513,6 +515,14 @@ fun configure(
     if (shouldShowInAppMessagesAutomatically != null) {
         builder.showInAppMessagesAutomatically(shouldShowInAppMessagesAutomatically)
     }
+    if (verificationMode != null) {
+        try {
+            builder.verificationModeAndDiagnostics(EntitlementVerificationMode.valueOf(verificationMode))
+        } catch (e: IllegalArgumentException) {
+            warnLog("Attempted to configure with unknown verification mode: $verificationMode.")
+        }
+    }
+
     Purchases.configure(builder.build())
 }
 

--- a/android/src/test/java/apitests/java/CommonApiTests.java
+++ b/android/src/test/java/apitests/java/CommonApiTests.java
@@ -13,7 +13,6 @@ import com.revenuecat.purchases.hybridcommon.ErrorContainer;
 import com.revenuecat.purchases.hybridcommon.OnResult;
 import com.revenuecat.purchases.hybridcommon.OnResultAny;
 import com.revenuecat.purchases.hybridcommon.OnResultList;
-import com.revenuecat.purchases.models.GoogleProrationMode;
 import com.revenuecat.purchases.models.InAppMessageType;
 
 import java.util.List;
@@ -187,7 +186,9 @@ class CommonApiTests {
                                 PlatformInfo platformInfo,
                                 Store store,
                                 DangerousSettings dangerousSettings,
-                                Boolean shouldShowInAppMessagesAutomatically) {
+                                Boolean shouldShowInAppMessagesAutomatically,
+                                String verificationMode
+    ) {
         CommonKt.configure(context, apiKey, appUserId, observerMode, platformInfo);
         CommonKt.configure(context, apiKey, appUserId, observerMode, platformInfo, store);
         CommonKt.configure(context, apiKey, appUserId, observerMode, platformInfo, store, dangerousSettings);
@@ -200,6 +201,16 @@ class CommonApiTests {
                 store,
                 dangerousSettings,
                 shouldShowInAppMessagesAutomatically);
+        CommonKt.configure(
+                context,
+                apiKey,
+                appUserId,
+                observerMode,
+                platformInfo,
+                store,
+                dangerousSettings,
+                shouldShowInAppMessagesAutomatically,
+                verificationMode);
     }
 
     private void checkGetPromotionalOffer() {

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
@@ -216,6 +216,7 @@ private class CommonApiTests {
         store: Store,
         dangerousSettings: DangerousSettings,
         shouldShowInAppMessagesAutomatically: Boolean?,
+        verificationMode: String?,
     ) {
         configure(context, apiKey, appUserID, observerMode, platformInfo)
         configure(context, apiKey, appUserID, observerMode, platformInfo, store, dangerousSettings)
@@ -228,6 +229,17 @@ private class CommonApiTests {
             store,
             dangerousSettings,
             shouldShowInAppMessagesAutomatically,
+        )
+        configure(
+            context,
+            apiKey,
+            appUserID,
+            observerMode,
+            platformInfo,
+            store,
+            dangerousSettings,
+            shouldShowInAppMessagesAutomatically,
+            verificationMode,
         )
     }
 

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/ConfiguringUnitTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/ConfiguringUnitTests.kt
@@ -2,15 +2,19 @@ package com.revenuecat.purchases.hybridcommon
 
 import android.app.Application
 import android.content.Context
+import android.util.Log
 import com.revenuecat.purchases.DangerousSettings
+import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.PlatformInfo
+import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
@@ -35,6 +39,8 @@ internal class ConfiguringUnitTests {
         every {
             Purchases.configure(configuration = capture(purchasesConfigurationSlot))
         } returns mockPurchases
+
+        mockLogs()
     }
 
     @Test
@@ -123,9 +129,8 @@ internal class ConfiguringUnitTests {
                 platformInfo = expectedPlatformInfo,
                 store = Store.PLAY_STORE,
         )
-        verify(exactly = 1) {
-            Purchases.platformInfo = expectedPlatformInfo
-        }
+
+        Purchases.platformInfo = expectedPlatformInfo
     }
 
     @Test
@@ -138,9 +143,7 @@ internal class ConfiguringUnitTests {
                 platformInfo = expectedPlatformInfo,
                 verificationMode = null
         )
-        verify(exactly = 1) {
-            // TODO
-        }
+        assertEquals(EntitlementVerificationMode.DISABLED, purchasesConfigurationSlot.captured.verificationMode)
     }
 
     @Test
@@ -153,9 +156,7 @@ internal class ConfiguringUnitTests {
                 platformInfo = expectedPlatformInfo,
                 verificationMode = "DISABLED"
         )
-        verify(exactly = 1) {
-            // TODO
-        }
+        assertEquals(EntitlementVerificationMode.DISABLED, purchasesConfigurationSlot.captured.verificationMode)
     }
 
     @Test
@@ -168,9 +169,7 @@ internal class ConfiguringUnitTests {
                 platformInfo = expectedPlatformInfo,
                 verificationMode = "INFORMATIONAL"
         )
-        verify(exactly = 1) {
-            // TODO
-        }
+        assertEquals(EntitlementVerificationMode.INFORMATIONAL, purchasesConfigurationSlot.captured.verificationMode)
     }
 
     @Test
@@ -183,9 +182,8 @@ internal class ConfiguringUnitTests {
                 platformInfo = expectedPlatformInfo,
                 verificationMode = "ENFORCED"
         )
-        verify(exactly = 1) {
-            // TODO
-        }
+        // Enforced is not available yet
+        assertEquals(EntitlementVerificationMode.DISABLED, purchasesConfigurationSlot.captured.verificationMode)
     }
 
     @Test

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/ConfiguringUnitTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/ConfiguringUnitTests.kt
@@ -116,15 +116,75 @@ internal class ConfiguringUnitTests {
     @Test
     fun `calling configure with a platform info, should configure the Android SDK with that platform info`() {
         configure(
-            context = mockContext,
-            apiKey = "api_key",
-            appUserID = "appUserID",
-            observerMode = false,
-            platformInfo = expectedPlatformInfo,
-            store = Store.PLAY_STORE,
+                context = mockContext,
+                apiKey = "api_key",
+                appUserID = "appUserID",
+                observerMode = false,
+                platformInfo = expectedPlatformInfo,
+                store = Store.PLAY_STORE,
         )
         verify(exactly = 1) {
             Purchases.platformInfo = expectedPlatformInfo
+        }
+    }
+
+    @Test
+    fun `calling configure with no verification mode`() {
+        configure(
+                context = mockContext,
+                apiKey = "api_key",
+                appUserID = "appUserID",
+                observerMode = false,
+                platformInfo = expectedPlatformInfo,
+                verificationMode = null
+        )
+        verify(exactly = 1) {
+            // TODO
+        }
+    }
+
+    @Test
+    fun `calling configure with verification mode disabled`() {
+        configure(
+                context = mockContext,
+                apiKey = "api_key",
+                appUserID = "appUserID",
+                observerMode = false,
+                platformInfo = expectedPlatformInfo,
+                verificationMode = "DISABLED"
+        )
+        verify(exactly = 1) {
+            // TODO
+        }
+    }
+
+    @Test
+    fun `calling configure with verification mode informational`() {
+        configure(
+                context = mockContext,
+                apiKey = "api_key",
+                appUserID = "appUserID",
+                observerMode = false,
+                platformInfo = expectedPlatformInfo,
+                verificationMode = "INFORMATIONAL"
+        )
+        verify(exactly = 1) {
+            // TODO
+        }
+    }
+
+    @Test
+    fun `calling configure with verification mode enforced`() {
+        configure(
+                context = mockContext,
+                apiKey = "api_key",
+                appUserID = "appUserID",
+                observerMode = false,
+                platformInfo = expectedPlatformInfo,
+                verificationMode = "ENFORCED"
+        )
+        verify(exactly = 1) {
+            // TODO
         }
     }
 

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/ConfiguringUnitTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/ConfiguringUnitTests.kt
@@ -2,21 +2,17 @@ package com.revenuecat.purchases.hybridcommon
 
 import android.app.Application
 import android.content.Context
-import android.util.Log
 import com.revenuecat.purchases.DangerousSettings
 import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.PlatformInfo
-import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.mockkStatic
 import io.mockk.slot
-import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -122,12 +118,12 @@ internal class ConfiguringUnitTests {
     @Test
     fun `calling configure with a platform info, should configure the Android SDK with that platform info`() {
         configure(
-                context = mockContext,
-                apiKey = "api_key",
-                appUserID = "appUserID",
-                observerMode = false,
-                platformInfo = expectedPlatformInfo,
-                store = Store.PLAY_STORE,
+            context = mockContext,
+            apiKey = "api_key",
+            appUserID = "appUserID",
+            observerMode = false,
+            platformInfo = expectedPlatformInfo,
+            store = Store.PLAY_STORE,
         )
 
         Purchases.platformInfo = expectedPlatformInfo
@@ -136,12 +132,12 @@ internal class ConfiguringUnitTests {
     @Test
     fun `calling configure with no verification mode`() {
         configure(
-                context = mockContext,
-                apiKey = "api_key",
-                appUserID = "appUserID",
-                observerMode = false,
-                platformInfo = expectedPlatformInfo,
-                verificationMode = null
+            context = mockContext,
+            apiKey = "api_key",
+            appUserID = "appUserID",
+            observerMode = false,
+            platformInfo = expectedPlatformInfo,
+            verificationMode = null,
         )
         assertEquals(EntitlementVerificationMode.DISABLED, purchasesConfigurationSlot.captured.verificationMode)
     }
@@ -149,12 +145,12 @@ internal class ConfiguringUnitTests {
     @Test
     fun `calling configure with verification mode disabled`() {
         configure(
-                context = mockContext,
-                apiKey = "api_key",
-                appUserID = "appUserID",
-                observerMode = false,
-                platformInfo = expectedPlatformInfo,
-                verificationMode = "DISABLED"
+            context = mockContext,
+            apiKey = "api_key",
+            appUserID = "appUserID",
+            observerMode = false,
+            platformInfo = expectedPlatformInfo,
+            verificationMode = "DISABLED",
         )
         assertEquals(EntitlementVerificationMode.DISABLED, purchasesConfigurationSlot.captured.verificationMode)
     }
@@ -162,12 +158,12 @@ internal class ConfiguringUnitTests {
     @Test
     fun `calling configure with verification mode informational`() {
         configure(
-                context = mockContext,
-                apiKey = "api_key",
-                appUserID = "appUserID",
-                observerMode = false,
-                platformInfo = expectedPlatformInfo,
-                verificationMode = "INFORMATIONAL"
+            context = mockContext,
+            apiKey = "api_key",
+            appUserID = "appUserID",
+            observerMode = false,
+            platformInfo = expectedPlatformInfo,
+            verificationMode = "INFORMATIONAL",
         )
         assertEquals(EntitlementVerificationMode.INFORMATIONAL, purchasesConfigurationSlot.captured.verificationMode)
     }
@@ -175,12 +171,12 @@ internal class ConfiguringUnitTests {
     @Test
     fun `calling configure with verification mode enforced`() {
         configure(
-                context = mockContext,
-                apiKey = "api_key",
-                appUserID = "appUserID",
-                observerMode = false,
-                platformInfo = expectedPlatformInfo,
-                verificationMode = "ENFORCED"
+            context = mockContext,
+            apiKey = "api_key",
+            appUserID = "appUserID",
+            observerMode = false,
+            platformInfo = expectedPlatformInfo,
+            verificationMode = "ENFORCED",
         )
         // Enforced is not available yet
         assertEquals(EntitlementVerificationMode.DISABLED, purchasesConfigurationSlot.captured.verificationMode)

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/ConfiguringUnitTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/ConfiguringUnitTests.kt
@@ -126,7 +126,7 @@ internal class ConfiguringUnitTests {
             store = Store.PLAY_STORE,
         )
 
-        Purchases.platformInfo = expectedPlatformInfo
+        assertEquals(expectedPlatformInfo, Purchases.platformInfo)
     }
 
     @Test

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/MockUtils.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/MockUtils.kt
@@ -4,12 +4,12 @@ import android.util.Log
 import io.mockk.every
 import io.mockk.mockkStatic
 
-fun mockLogError() {
+fun mockLogs() {
     mockkStatic(Log::class)
-    every {
-        Log.e(
-            any(),
-            any(),
-        )
-    } returns 0
+    every { Log.v(any(), any()) } returns 0
+    every { Log.d(any(), any()) } returns 0
+    every { Log.i(any(), any()) } returns 0
+    every { Log.w(any(), any<String>()) } returns 0
+    every { Log.w(any(), any<Throwable>()) } returns 0
+    every { Log.e(any(), any()) } returns 0
 }

--- a/android/src/test/java/com/revenuecat/purchases/hybridcommon/PurchasesPeriodTests.kt
+++ b/android/src/test/java/com/revenuecat/purchases/hybridcommon/PurchasesPeriodTests.kt
@@ -8,7 +8,7 @@ internal class PurchasesPeriodTests {
 
     @Test
     fun `when parsing an invalid PurchasesPeriod, there is no exception`() {
-        mockLogError()
+        mockLogs()
 
         val period = PurchasesPeriod.parse("365")
         assertThat(period).isNull()

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCPurchases+HybridAdditionsAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCPurchases+HybridAdditionsAPITest.m
@@ -26,7 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                  platformFlavorVersion:@""
                                               usesStoreKit2IfAvailable:YES
                                                      dangerousSettings:nil
-                                  shouldShowInAppMessagesAutomatically:NO];
+                                  shouldShowInAppMessagesAutomatically:NO
+                                                      verificationMode:@""];
 }
 
 @end

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		35F6FD602673FE5600ABCB53 /* ErrorContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F6FD5F2673FE5600ABCB53 /* ErrorContainerTests.swift */; };
 		37E357D5014169A093450AD5 /* MockPurchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E351F858AE15D5BD2EAA5A /* MockPurchases.swift */; };
 		3F7F287D27E208F39745436C /* Pods_ObjCAPITester.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FAA49047A2AE8963CF73C94 /* Pods_ObjCAPITester.framework */; };
+		4FBD2DA72A4B7D8300C8A0FB /* EntitlementVerificationMode+HybridAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FBD2DA62A4B7D8300C8A0FB /* EntitlementVerificationMode+HybridAdditions.swift */; };
 		579EF61C286B761C002263AD /* PurchasesHybridCommon.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 57FFDE47286B72750089A57B /* PurchasesHybridCommon.storekit */; };
 		57AD0D7A28733B0C000932FF /* NonSubscriptionTransaction+HybridAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AD0D7928733B0C000932FF /* NonSubscriptionTransaction+HybridAdditions.swift */; };
 		57D6691E28DD19D900622DE6 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 57D6691D28DD19D900622DE6 /* SnapshotTesting */; };
@@ -133,6 +134,7 @@
 		460EB988CBB68111D4CF19A2 /* Pods-PurchasesHybridCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommon.debug.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommon/Pods-PurchasesHybridCommon.debug.xcconfig"; sourceTree = "<group>"; };
 		4E8CDB8D703EA998D72761BB /* Pods-PurchasesHybridCommonTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommonTests.debug.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommonTests/Pods-PurchasesHybridCommonTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4FAA49047A2AE8963CF73C94 /* Pods_ObjCAPITester.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ObjCAPITester.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4FBD2DA62A4B7D8300C8A0FB /* EntitlementVerificationMode+HybridAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "EntitlementVerificationMode+HybridAdditions.swift"; sourceTree = "<group>"; };
 		517430C4E8FC91A379B7BFE0 /* Pods-PurchasesHybridCommon-PurchasesHybridCommonIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommon-PurchasesHybridCommonIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommon-PurchasesHybridCommonIntegrationTests/Pods-PurchasesHybridCommon-PurchasesHybridCommonIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		57920F7A286B9B78000461A9 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		57AD0D7928733B0C000932FF /* NonSubscriptionTransaction+HybridAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NonSubscriptionTransaction+HybridAdditions.swift"; sourceTree = "<group>"; };
@@ -290,6 +292,7 @@
 				57AD0D7928733B0C000932FF /* NonSubscriptionTransaction+HybridAdditions.swift */,
 				2D4FDFE62807436200863298 /* StoreTransaction+HybridAdditions.swift */,
 				2D4FDFEA28074C3800863298 /* EntitlementInfos+HybridAdditions.swift */,
+				4FBD2DA62A4B7D8300C8A0FB /* EntitlementVerificationMode+HybridAdditions.swift */,
 				2D4FDFEC28074EB900863298 /* ErrorContainer.swift */,
 				2D900D902807574D00676D73 /* Offering+HybridAdditions.swift */,
 				2D900D942807580000676D73 /* Package+HybridAdditions.swift */,
@@ -724,6 +727,7 @@
 				2DD3D18E2810AF5A00A19EC6 /* CustomerInfo+HybridAdditions.swift in Sources */,
 				2DD3D1882810AF5A00A19EC6 /* StoreProductDiscount+HybridAdditions.swift in Sources */,
 				2DD3D1902810AF5A00A19EC6 /* StoreProduct+HybridAdditions.swift in Sources */,
+				4FBD2DA72A4B7D8300C8A0FB /* EntitlementVerificationMode+HybridAdditions.swift in Sources */,
 				2DD3D1872810AF5A00A19EC6 /* ErrorContainer.swift in Sources */,
 				2DD3D18F2810AF5A00A19EC6 /* EntitlementInfo+HybridAdditions.swift in Sources */,
 				2DD3D1922810AF5A00A19EC6 /* PromotionalOffer+HybridAdditions.swift in Sources */,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementVerificationMode+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementVerificationMode+HybridAdditions.swift
@@ -1,0 +1,34 @@
+//
+//  EntitlementVerificationMode+HybridAdditions.swift
+//  PurchasesHybridCommon
+//
+//  Created by Nacho Soto on 6/27/23.
+//
+
+import RevenueCat
+
+extension Configuration.EntitlementVerificationMode {
+
+    var name: String {
+        switch self {
+        case .disabled: return "DISABLED"
+        case .informational: return "INFORMATIONAL"
+        case .enforced: return "ENFORCED"
+        }
+    }
+
+    init?(name: String) {
+        if let mode = Self.modesByName[name] {
+            self = mode
+        } else {
+            return nil
+        }
+    }
+
+    private static let modesByName: [String: Self] = Dictionary(uniqueKeysWithValues: [
+        Self.disabled,
+        Self.informational,
+        Self.enforced
+    ].map { ($0.name, $0) })
+
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementVerificationMode+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementVerificationMode+HybridAdditions.swift
@@ -28,7 +28,8 @@ extension Configuration.EntitlementVerificationMode {
     private static let modesByName: [String: Self] = Dictionary(uniqueKeysWithValues: [
         Self.disabled,
         Self.informational,
-        Self.enforced
+        // Disabled temporarily since enforced is not available yet.
+        // Self.enforced
     ].map { ($0.name, $0) })
 
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
@@ -12,7 +12,7 @@ import RevenueCat
 @objc public extension Purchases {
 
     @objc(configureWithAPIKey:appUserID:observerMode:userDefaultsSuiteName:platformFlavor:platformFlavorVersion:
-            usesStoreKit2IfAvailable:dangerousSettings:shouldShowInAppMessagesAutomatically:)
+            usesStoreKit2IfAvailable:dangerousSettings:shouldShowInAppMessagesAutomatically:verificationMode:)
     static func configure(apiKey: String,
                           appUserID: String?,
                           observerMode: Bool,
@@ -21,7 +21,8 @@ import RevenueCat
                           platformFlavorVersion: String?,
                           usesStoreKit2IfAvailable: Bool = false,
                           dangerousSettings: DangerousSettings?,
-                          shouldShowInAppMessagesAutomatically: Bool = true) -> Purchases {
+                          shouldShowInAppMessagesAutomatically: Bool = true,
+                          verificationMode: String? = nil) -> Purchases {
         var userDefaults: UserDefaults?
         if let userDefaultsSuiteName = userDefaultsSuiteName {
             userDefaults = UserDefaults(suiteName: userDefaultsSuiteName)
@@ -50,6 +51,16 @@ import RevenueCat
         }
         configurationBuilder = configurationBuilder.with(showStoreMessagesAutomatically:
                                                             shouldShowInAppMessagesAutomatically)
+
+        if let verificationMode {
+            if let mode = Configuration.EntitlementVerificationMode(name: verificationMode) {
+                if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+                    configurationBuilder = configurationBuilder.with(entitlementVerificationMode: mode)
+                }
+            } else {
+                NSLog("Attempted to configure with unknown verification mode: '\(verificationMode)'")
+            }
+        }
 
         let purchases = self.configure(with: configurationBuilder.build())
         CommonFunctionality.sharedInstance = purchases

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridAdditionsTests.swift
@@ -21,8 +21,7 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         observerMode: false,
                                         userDefaultsSuiteName: nil,
                                         platformFlavor: "hybrid-platform",
-                                        platformFlavorVersion: "1.2.3",
-                                        dangerousSettings: nil)
+                                        platformFlavorVersion: "1.2.3")
                 }.notTo(raiseException())
             }
             it("initializes without raising exceptions if a suite name is passed") {
@@ -32,8 +31,43 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         observerMode: false,
                                         userDefaultsSuiteName: "test",
                                         platformFlavor: "hybrid-platform",
+                                        platformFlavorVersion: "1.2.3")
+                }.notTo(raiseException())
+            }
+        }
+        context("configure with verification mode") {
+            it("disabled") {
+                expect {
+                    Purchases.configure(apiKey: "api key",
+                                        appUserID: nil,
+                                        observerMode: false,
+                                        userDefaultsSuiteName: "test",
+                                        platformFlavor: "hybrid-platform",
                                         platformFlavorVersion: "1.2.3",
-                                        dangerousSettings: nil)
+                                        verificationMode: "DISABLED")
+                }.notTo(raiseException())
+            }
+
+            it("informational") {
+                expect {
+                    Purchases.configure(apiKey: "api key",
+                                        appUserID: nil,
+                                        observerMode: false,
+                                        userDefaultsSuiteName: "test",
+                                        platformFlavor: "hybrid-platform",
+                                        platformFlavorVersion: "1.2.3",
+                                        verificationMode: "INFORMATIONAL")
+                }.notTo(raiseException())
+            }
+            it("enforced") {
+                expect {
+                    Purchases.configure(apiKey: "api key",
+                                        appUserID: nil,
+                                        observerMode: false,
+                                        userDefaultsSuiteName: "test",
+                                        platformFlavor: "hybrid-platform",
+                                        platformFlavorVersion: "1.2.3",
+                                        verificationMode: "ENFORCED")
                 }.notTo(raiseException())
             }
         }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridAdditionsTests.swift
@@ -21,7 +21,8 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         observerMode: false,
                                         userDefaultsSuiteName: nil,
                                         platformFlavor: "hybrid-platform",
-                                        platformFlavorVersion: "1.2.3")
+                                        platformFlavorVersion: "1.2.3",
+                                        dangerousSettings: nil)
                 }.notTo(raiseException())
             }
             it("initializes without raising exceptions if a suite name is passed") {
@@ -31,7 +32,8 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         observerMode: false,
                                         userDefaultsSuiteName: "test",
                                         platformFlavor: "hybrid-platform",
-                                        platformFlavorVersion: "1.2.3")
+                                        platformFlavorVersion: "1.2.3",
+                                        dangerousSettings: nil)
                 }.notTo(raiseException())
             }
         }
@@ -44,6 +46,7 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         userDefaultsSuiteName: "test",
                                         platformFlavor: "hybrid-platform",
                                         platformFlavorVersion: "1.2.3",
+                                        dangerousSettings: nil,
                                         verificationMode: "DISABLED")
                 }.notTo(raiseException())
             }
@@ -56,6 +59,7 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         userDefaultsSuiteName: "test",
                                         platformFlavor: "hybrid-platform",
                                         platformFlavorVersion: "1.2.3",
+                                        dangerousSettings: nil,
                                         verificationMode: "INFORMATIONAL")
                 }.notTo(raiseException())
             }
@@ -67,6 +71,7 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         userDefaultsSuiteName: "test",
                                         platformFlavor: "hybrid-platform",
                                         platformFlavorVersion: "1.2.3",
+                                        dangerousSettings: nil,
                                         verificationMode: "ENFORCED")
                 }.notTo(raiseException())
             }

--- a/typescript/apitesters/enums.ts
+++ b/typescript/apitesters/enums.ts
@@ -7,6 +7,7 @@ import {
   PRORATION_MODE,
   IN_APP_MESSAGE_TYPE
 } from '../dist';
+import { ENTITLEMENT_VERIFICATION_MODE } from '../src';
 
 function checkPurchaseType(type: PURCHASE_TYPE): boolean {
   switch (type) {
@@ -101,6 +102,15 @@ function checkInAppMessages(messageType: IN_APP_MESSAGE_TYPE): boolean {
     case IN_APP_MESSAGE_TYPE.PRICE_INCREASE_CONSENT:
       return true;
     case IN_APP_MESSAGE_TYPE.GENERIC:
+      return true;
+  }
+}
+
+function checkVerificationMode(verificationMode: ENTITLEMENT_VERIFICATION_MODE): boolean {
+  switch (verificationMode) {
+    case ENTITLEMENT_VERIFICATION_MODE.DISABLED:
+      return true;
+    case ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL:
       return true;
   }
 }

--- a/typescript/src/enums.ts
+++ b/typescript/src/enums.ts
@@ -94,3 +94,28 @@ export enum IN_APP_MESSAGE_TYPE {
    */
   GENERIC = 2
 }
+
+/**
+ * Enum of entitlement verification modes.
+ */
+export enum ENTITLEMENT_VERIFICATION_MODE {
+  /**
+   * The SDK will not perform any entitlement verification.
+   */
+  DISABLED = "DISABLED",
+
+  /**
+     * Enable entitlement verification.
+     *
+     * If verification fails, this will be indicated with [VerificationResult.FAILED] in
+     * the [EntitlementInfos.verification] and [EntitlementInfo.verification] properties but parsing will not fail
+     * (i.e. Entitlements will still be granted).
+     *
+     * This can be useful if you want to handle verification failures to display an error/warning to the user
+     * or to track this situation but still grant access.
+     */
+  INFORMATIONAL = "INFORMATIONAL",
+
+  // Add ENFORCED mode once we're ready to ship it.
+  // ENFORCED = "ENFORCED"
+}

--- a/typescript/src/purchasesConfiguration.ts
+++ b/typescript/src/purchasesConfiguration.ts
@@ -1,3 +1,5 @@
+import { ENTITLEMENT_VERIFICATION_MODE } from "./enums";
+
 /**
  * Holds parameters to initialize the SDK.
  */
@@ -45,4 +47,10 @@ export interface PurchasesConfiguration {
    * check: https://rev.cat/storekit-message and https://rev.cat/googleplayinappmessaging
    */
   shouldShowInAppMessagesAutomatically?: boolean;
+
+  /**
+   * Verification strictness levels for [EntitlementInfo].
+   * See https://rev.cat/trusted-entitlements for more info.
+   */
+  entitlementVerificationInfo?: ENTITLEMENT_VERIFICATION_MODE;
 }


### PR DESCRIPTION
Depends on https://github.com/RevenueCat/purchases-ios/pull/2621 and https://github.com/RevenueCat/purchases-android/pull/1105.