### PR TITLE
Improvements typescript interfaces

### DIFF
--- a/typescript/apitesters/customerInfo.ts
+++ b/typescript/apitesters/customerInfo.ts
@@ -38,13 +38,19 @@ function checkEntitlementInfo(info: PurchasesEntitlementInfo) {
   const willRenew: boolean = info.willRenew;
   const periodType: string = info.periodType;
   const latestPurchaseDate: string = info.latestPurchaseDate;
+  const latestPurchaseDateMillis: number = info.latestPurchaseDateMillis;
   const originalPurchaseDate: string = info.originalPurchaseDate;
+  const originalPurchaseDateMillis: number = info.originalPurchaseDateMillis;
   const expirationDate: string | null = info.expirationDate;
+  const expirationDateMillis: number | null = info.expirationDateMillis;
   const store: string = info.store;
   const productIdentifier: string = info.productIdentifier;
   const isSandbox: boolean = info.isSandbox;
   const unsubscribeDetectedAt: string | null = info.unsubscribeDetectedAt;
+  const unsubscribeDetectedAtMillis: number | null = info.unsubscribeDetectedAtMillis;
   const billingIssueDetectedAt: string | null = info.billingIssueDetectedAt;
+  const billingIssueDetectedAtMillis: number | null = info.billingIssueDetectedAtMillis;
+  const ownershipType: "FAMILY_SHARED" | "PURCHASED" | "UNKNOWN" = info.ownershipType;
 }
 
 function checkTransaction(transaction: PurchasesStoreTransaction) {

--- a/typescript/apitesters/offerings.ts
+++ b/typescript/apitesters/offerings.ts
@@ -56,7 +56,7 @@ function checkPackage(pack: PurchasesPackage) {
 function checkOffering(offering: PurchasesOffering) {
   const identifier: string = offering.identifier;
   const serverDescription: string = offering.serverDescription;
-  const metadata: Map<string, any> = offering.metadata;
+  const metadata: { [key: string]: unknown } = offering.metadata;
   const availablePackages: PurchasesPackage[] = offering.availablePackages;
   const lifetime: PurchasesPackage | null = offering.lifetime;
   const annual: PurchasesPackage | null = offering.annual;

--- a/typescript/src/customerInfo.ts
+++ b/typescript/src/customerInfo.ts
@@ -2,6 +2,9 @@
  * The EntitlementInfo object gives you access to all of the information about the status of a user entitlement.
  */
 export interface PurchasesEntitlementInfo {
+    // "unsubscribeDetectedAtMillis": unsubscribeDetectedAt?.rc_millisecondsSince1970AsDouble() ?? NSNull(),
+    // "billingIssueDetectedAtMillis": billingIssueDetectedAt?.rc_millisecondsSince1970AsDouble() ?? NSNull(),
+    // "ownershipType": ownershipTypeString
     /**
      * The entitlement identifier configured in the RevenueCat dashboard
      */
@@ -19,18 +22,31 @@ export interface PurchasesEntitlementInfo {
      */
     readonly periodType: string;
     /**
-     * The latest purchase or renewal date for the entitlement.
+     * The latest purchase or renewal date for the entitlement in ISO8601 format.
      */
     readonly latestPurchaseDate: string;
     /**
-     * The first date this entitlement was purchased.
+     * The latest purchase or renewal date for the entitlement in milliseconds.
+     */
+    readonly latestPurchaseDateMillis: number;
+    /**
+     * The first date this entitlement was purchased in ISO8601 format.
      */
     readonly originalPurchaseDate: string;
     /**
-     * The expiration date for the entitlement, can be `null` for lifetime access. If the `periodType` is `trial`,
-     * this is the trial expiration date.
+     * The first date this entitlement was purchased in milliseconds.
+     */
+    readonly originalPurchaseDateMillis: number;
+    /**
+     * The expiration date for the entitlement in ISO8601, can be `null` for lifetime access. 
+     * If the `periodType` is `trial`, this is the trial expiration date.
      */
     readonly expirationDate: string | null;
+    /**
+     * The expiration date for the entitlement in milliseconds, can be `null` for lifetime access. 
+     * If the `periodType` is `trial`, this is the trial expiration date. 
+     */
+    readonly expirationDateMillis: number | null;
     /**
      * The store where this entitlement was unlocked from.
      */
@@ -44,17 +60,38 @@ export interface PurchasesEntitlementInfo {
      */
     readonly isSandbox: boolean;
     /**
-     * The date an unsubscribe was detected. Can be `null`.
+     * The date an unsubscribe was detected in ISO8601 format. Can be `null`.
      *
      * @note: Entitlement may still be active even if user has unsubscribed. Check the `isActive` property.
      */
     readonly unsubscribeDetectedAt: string | null;
     /**
-     * The date a billing issue was detected. Can be `null` if there is no billing issue or an issue has been resolved
+     * The date an unsubscribe was detected in milliseconds. Can be `null`.
+     *
+     * @note: Entitlement may still be active even if user has unsubscribed. Check the `isActive` property.
+     */
+    readonly unsubscribeDetectedAtMillis: number | null;
+    /**
+     * The date a billing issue was detected in ISO8601 format. Can be `null` if there is no billing issue or an 
+     * issue has been resolved
      *
      * @note: Entitlement may still be active even if there is a billing issue. Check the `isActive` property.
      */
     readonly billingIssueDetectedAt: string | null;
+    /**
+     * The date a billing issue was detected in milliseconds. Can be `null` if there is no billing issue or an 
+     * issue has been resolved
+     *
+     * @note: Entitlement may still be active even if there is a billing issue. Check the `isActive` property.
+     */
+    readonly billingIssueDetectedAtMillis: number | null;
+    /**
+     * Supported ownership types for an entitlement. 
+     * PURCHASED if the purchase was made directly by this user.
+     * FAMILY_SHARED if the purchase has been shared to this user by a family member.
+     * UNKNOWN if the purchase has no or an unknown ownership type.
+     */
+    readonly ownershipType: "FAMILY_SHARED" | "PURCHASED" | "UNKNOWN";
 }
 
 /**

--- a/typescript/src/customerInfo.ts
+++ b/typescript/src/customerInfo.ts
@@ -2,9 +2,6 @@
  * The EntitlementInfo object gives you access to all of the information about the status of a user entitlement.
  */
 export interface PurchasesEntitlementInfo {
-    // "unsubscribeDetectedAtMillis": unsubscribeDetectedAt?.rc_millisecondsSince1970AsDouble() ?? NSNull(),
-    // "billingIssueDetectedAtMillis": billingIssueDetectedAt?.rc_millisecondsSince1970AsDouble() ?? NSNull(),
-    // "ownershipType": ownershipTypeString
     /**
      * The entitlement identifier configured in the RevenueCat dashboard
      */

--- a/typescript/src/offerings.ts
+++ b/typescript/src/offerings.ts
@@ -242,10 +242,12 @@ export interface PurchasesOffering {
      */
     readonly serverDescription: string;
     /**
-     * Offering metadata defined in RevenueCat dashboard.
+     * Offering metadata defined in RevenueCat dashboard. To access values, you need
+     * to check the type beforehand. For example:
+     * const my_unknown_value: unknown = offering.metadata['my_key'];
+     * const my_string_value: string | undefined = typeof(my_unknown_value) === 'string' ? my_unknown_value : undefined;
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    readonly metadata: Map<string, any>;
+    readonly metadata: { [key: string]: unknown };
     /**
      * Array of `Package` objects available for purchase.
      */


### PR DESCRIPTION
This PR:
- Make `metadata` use correct type. https://github.com/RevenueCat/react-native-purchases/issues/700
- Add missing properties on `PurchasesEntitlementInfo` that are provided by PHC layer. https://github.com/RevenueCat/react-native-purchases/issues/708

Nothing is currently using the typescript package, but the plan is to move to use it in the RNP repo and the future capacitor plugin.

