### PR TITLE
Expose `CommonFunctionality.encode(customerInfo:)`

### DIFF
--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -107,6 +107,9 @@ NS_ASSUME_NONNULL_BEGIN
         [RCCommonFunctionality beginRefundRequestForActiveEntitlementCompletion:^(RCErrorContainer * _Nullable error) {
         }];
     }
+
+    RCCustomerInfo *info;
+    NSDictionary<NSString *, NSObject *> __unused *dictionary = [RCCommonFunctionality encodeCustomerInfo:info];
 }
 
 - (void)testDeprecatedAPI {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -611,3 +611,16 @@ private extension CommonFunctionality {
     }
 
 }
+
+// MARK: - Encoding
+
+@objc public extension CommonFunctionality {
+
+    // Note: see https://github.com/RevenueCat/purchases-hybrid-common/pull/485
+    // `CustomerInfo.dictionary` can't be made an `@objc public` method while supporting iOS < 13.0
+    @objc(encodeCustomerInfo:)
+    static func encode(customerInfo: CustomerInfo) -> [String: Any] {
+        return customerInfo.dictionary
+    }
+
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CustomerInfo+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CustomerInfo+HybridAdditions.swift
@@ -12,7 +12,6 @@ import RevenueCat
 internal extension CustomerInfo {
 
     var dictionary: [String: Any] {
-
         let sortedProductIdentifiers = allPurchasedProductIdentifiers.sorted()
 
         var allExpirations: [String: Any] = [:]

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/CustomerInfo+HybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/CustomerInfo+HybridAdditionsTests.swift
@@ -35,7 +35,7 @@ class CustomerInfoHybridAdditionsTests: QuickSpec {
 
                     let urlPath = "https://revenuecat.com"
 
-                    let dictionary = mockCustomerInfo.dictionary
+                    let dictionary = CommonFunctionality.encode(customerInfo: mockCustomerInfo)
                     expect(dictionary["managementURL"] as? String) == urlPath
                 }
                 it ("contains null when the management url doesn't exist") {
@@ -53,7 +53,7 @@ class CustomerInfoHybridAdditionsTests: QuickSpec {
                         """
                     )
 
-                    let dictionary = mockCustomerInfo.dictionary
+                    let dictionary = CommonFunctionality.encode(customerInfo: mockCustomerInfo)
                     expect(dictionary["managementURL"] as? NSNull) == NSNull()
                 }
             }
@@ -92,7 +92,7 @@ class CustomerInfoHybridAdditionsTests: QuickSpec {
                     let dateformatter = ISO8601DateFormatter()
                     let transactionDate = dateformatter.date(from: transactionDateString)!
 
-                    let dictionary = mockCustomerInfo.dictionary
+                    let dictionary = CommonFunctionality.encode(customerInfo: mockCustomerInfo)
                     let nonSubscriptionTransactions = try XCTUnwrap(dictionary["nonSubscriptionTransactions"] as? [Any])
                     expect(nonSubscriptionTransactions.count) == 1
 
@@ -102,8 +102,6 @@ class CustomerInfoHybridAdditionsTests: QuickSpec {
                     expect(transactionDictionary["productIdentifier"] as? String) == expectedProductID
                     expect(transactionDictionary["productId"] as? String) == expectedProductID
                     expect(transactionDictionary["purchaseDateMillis"] as? Double) == transactionDate.rc_millisecondsSince1970AsDouble()
-
-
                     expect(transactionDictionary["purchaseDate"] as? String) == dateformatter.string(from: transactionDate as Date)
                 }
                 it("is empty when there are no non subscription transactions") {
@@ -121,7 +119,7 @@ class CustomerInfoHybridAdditionsTests: QuickSpec {
                         """
                     )
 
-                    let dictionary = mockCustomerInfo.dictionary
+                    let dictionary = CommonFunctionality.encode(customerInfo: mockCustomerInfo)
                     let nonSubscriptionTransactions = dictionary["nonSubscriptionTransactions"] as? Array<Any>
                     expect(nonSubscriptionTransactions?.count) == 0
                 }


### PR DESCRIPTION
Follow up to #485.

Turns out we did need the ability to encode `CustomerInfo` for the `PurchasesDelegate` implementations in 2 of the hybrids.
