### PR TITLE
Use `esnext` module typescript compiler option instead of `commonjs`

### DIFF
--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -16,7 +16,7 @@
     "noUnusedParameters": true,
     "skipLibCheck": true,
     "target": "es5",
-    "module": "commonjs",
+    "module": "esnext",
     "lib": ["es6", "dom", "es2016", "esnext.asynciterable"],
     "declaration": true,
     "outDir": "./dist",


### PR DESCRIPTION
This changes the `module` typescript compiler option from `commonjs` to `esnext`. `@revenuecat/purchases-capacitor` already uses `esnext`. As for RNP, it still uses `commonjs` but I haven't seen any issues after doing this change and testing locally.
This is meant to deal with a problem with using enums from `purchases-typescript-internal` in `@revenuecat/purchases-capacitor`. Additionally, it should solve https://github.com/RevenueCat/purchases-capacitor/issues/98
