### PR TITLE
Support deploying separate ESNext typescript package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,18 @@ jobs:
           name: Deploy typescript interfaces NPM package
           command: bundle exec fastlane typescript deploy
 
+  deploy-typescript-esm:
+    docker:
+      - image: cimg/ruby:3.1.2-node
+    steps:
+      - checkout
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
+      - copy-npm-rc
+      - run:
+          name: Deploy typescript interfaces ESNext NPM package
+          command: bundle exec fastlane typescript deploy_esm
+
   make-github-release:
     docker:
       - image: cimg/ruby:3.1.2
@@ -357,12 +369,15 @@ workflows:
           <<: *release-tags
       - deploy-typescript:
           <<: *release-tags
+      - deploy-typescript-esm:
+          <<: *release-tags
       - make-github-release:
           <<: *release-tags
           requires:
             - deploy-ios
             - deploy-android
             - deploy-typescript
+            - deploy-typescript-esm
       - push-pods:
           <<: *release-tags
           requires:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -364,24 +364,46 @@ end
 platform :typescript do
   desc "Deploy npm package to npm.js"
   lane :deploy do |options|
-    version_number = current_version_number
-    is_prerelease = Gem::Version.new(version_number).prerelease?
+    build_and_publish_typescript_package
+  end
 
-    build_args = [
-      'yarn && yarn build'
-    ]
+  lane :deploy_esm do |options|
+    make_typescript_package_esm
+    build_and_publish_typescript_package
+  end
+end
 
-    publish_args = [
-      'npm',
-      'publish',
-      '--access public',
-      is_prerelease ? '--tag next' : nil
-    ].compact
+def make_typescript_package_esm
+  replace_text_in_files(
+    previous_text: "@revenuecat/purchases-typescript-internal",
+    new_text: "@revenuecat/purchases-typescript-internal-esm",
+    paths_of_files_to_update: ["typescript/package.json"]
+  )
+  replace_text_in_files(
+    previous_text: "commonjs",
+    new_text: "esnext",
+    paths_of_files_to_update: ["typescript/tsconfig.json"]
+  )
+end
 
-    Dir.chdir(File.expand_path('typescript', get_root_folder)) do
-      sh(build_args)
-      sh(publish_args)
-    end
+def build_and_publish_typescript_package
+  version_number = current_version_number
+  is_prerelease = Gem::Version.new(version_number).prerelease?
+
+  build_args = [
+    'yarn && yarn build'
+  ]
+
+  publish_args = [
+    'npm',
+    'publish',
+    '--access public',
+    is_prerelease ? '--tag next' : nil
+  ].compact
+
+  Dir.chdir(File.expand_path('typescript', get_root_folder)) do
+    sh(build_args)
+    sh(publish_args)
   end
 end
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -132,6 +132,14 @@ Upload and close a release
 
 Deploy npm package to npm.js
 
+### typescript deploy_esm
+
+```sh
+[bundle exec] fastlane typescript deploy_esm
+```
+
+
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.


### PR DESCRIPTION
Our `purchases-capacitor` plugin uses `esnext` instead of `commonjs` to compile the typescript code. This was causing some issues where some code wasn't found, and generating some warnings: https://github.com/RevenueCat/purchases-capacitor/issues/98

This PR adds another package, `@revenuecat/purchases-typescript-internal-esm` for our typescript shared code. This package will be compiled using `esnext` and will be used by `purchases-capacitor` to fix those issues. 

We did try to bundle both in a single package but that was causing other issues. This should fix the issue and avoid those complications