### PR TITLE
Add product type to typescript types

### DIFF
--- a/typescript/apitesters/offerings.ts
+++ b/typescript/apitesters/offerings.ts
@@ -24,7 +24,7 @@ function checkProduct(product: PurchasesStoreProduct) {
   const productCategory: PRODUCT_CATEGORY | null = product.productCategory;
   const productType: PRODUCT_TYPE = product.productType;
   const defaultOption: SubscriptionOption | null = product.defaultOption;
-  const subscriptionOptions: SubscriptionOption[] | null =  product.subscriptionOptions;
+  const subscriptionOptions: SubscriptionOption[] | null = product.subscriptionOptions;
   const presentedOfferingIdentifier: string | null = product.presentedOfferingIdentifier;
 }
 
@@ -127,43 +127,56 @@ function checkPrice(price: Price) {
 }
 
 function checkRecurrenceMode(mode: RECURRENCE_MODE) {
-  switch(mode) {
-    case RECURRENCE_MODE.INFINITE_RECURRING,
-    RECURRENCE_MODE.FINITE_RECURRING,
-    RECURRENCE_MODE.NON_RECURRING: {
-       break;
+  switch (mode) {
+    case RECURRENCE_MODE.INFINITE_RECURRING:
+    case RECURRENCE_MODE.FINITE_RECURRING:
+    case RECURRENCE_MODE.NON_RECURRING: {
+      break;
     }
-  };
+  }
 }
 
 function checkPeriodUnit(periodUnit: PERIOD_UNIT) {
-  switch(periodUnit) {
-    case PERIOD_UNIT.DAY,
-    PERIOD_UNIT.WEEK,
-    PERIOD_UNIT.MONTH,
-    PERIOD_UNIT.YEAR,
-    PERIOD_UNIT.UNKNOWN: {
-       break;
+  switch (periodUnit) {
+    case PERIOD_UNIT.DAY:
+    case PERIOD_UNIT.WEEK:
+    case PERIOD_UNIT.MONTH:
+    case PERIOD_UNIT.YEAR:
+    case PERIOD_UNIT.UNKNOWN: {
+      break;
     }
-  };
+  }
 }
 
 function checkOfferPaymentMode(offerPaymentMode: OFFER_PAYMENT_MODE) {
-  switch(offerPaymentMode) {
-    case OFFER_PAYMENT_MODE.FREE_TRIAL,
-    OFFER_PAYMENT_MODE.SINGLE_PAYMENT,
-    OFFER_PAYMENT_MODE.DISCOUNTED_RECURRING_PAYMENT: {
-       break;
+  switch (offerPaymentMode) {
+    case OFFER_PAYMENT_MODE.FREE_TRIAL:
+    case OFFER_PAYMENT_MODE.SINGLE_PAYMENT:
+    case OFFER_PAYMENT_MODE.DISCOUNTED_RECURRING_PAYMENT: {
+      break;
     }
-  };
+  }
 }
 
 function checkOfferProductCategory(productCategory: PRODUCT_CATEGORY) {
-  switch(productCategory) {
-    case PRODUCT_CATEGORY.NON_SUBSCRIPTION,
-    PRODUCT_CATEGORY.SUBSCRIPTION,
-    PRODUCT_CATEGORY.UNKNOWN: {
-       break;
+  switch (productCategory) {
+    case PRODUCT_CATEGORY.NON_SUBSCRIPTION:
+    case PRODUCT_CATEGORY.SUBSCRIPTION:
+    case PRODUCT_CATEGORY.UNKNOWN: {
+      break;
     }
-  };
+  }
+}
+
+function checkOfferProductType(productType: PRODUCT_TYPE) {
+  switch (productType) {
+    case PRODUCT_TYPE.CONSUMABLE:
+    case PRODUCT_TYPE.NON_CONSUMABLE:
+    case PRODUCT_TYPE.NON_RENEWABLE_SUBSCRIPTION:
+    case PRODUCT_TYPE.AUTO_RENEWABLE_SUBSCRIPTION:
+    case PRODUCT_TYPE.PREPAID_SUBSCRIPTION:
+    case PRODUCT_TYPE.UNKNOWN:
+      break;
+
+  }
 }

--- a/typescript/apitesters/offerings.ts
+++ b/typescript/apitesters/offerings.ts
@@ -8,7 +8,7 @@ import {
   PurchasesPackage, PurchasesPromotionalOffer,
   PurchasesStoreProduct, UpgradeInfo,
   SubscriptionOption, PricingPhase,
-  Price, Period, OFFER_PAYMENT_MODE, PERIOD_UNIT, PRODUCT_CATEGORY, RECURRENCE_MODE
+  Price, Period, OFFER_PAYMENT_MODE, PERIOD_UNIT, PRODUCT_CATEGORY, RECURRENCE_MODE, PRODUCT_TYPE
 } from "../dist";
 
 function checkProduct(product: PurchasesStoreProduct) {
@@ -22,6 +22,7 @@ function checkProduct(product: PurchasesStoreProduct) {
   const discounts: PurchasesStoreProductDiscount[] | null = product.discounts;
   const subscriptionPeriod: string | null = product.subscriptionPeriod;
   const productCategory: PRODUCT_CATEGORY | null = product.productCategory;
+  const productType: PRODUCT_TYPE = product.productType;
   const defaultOption: SubscriptionOption | null = product.defaultOption;
   const subscriptionOptions: SubscriptionOption[] | null =  product.subscriptionOptions;
   const presentedOfferingIdentifier: string | null = product.presentedOfferingIdentifier;
@@ -126,43 +127,43 @@ function checkPrice(price: Price) {
 }
 
 function checkRecurrenceMode(mode: RECURRENCE_MODE) {
-  switch(mode) { 
-    case RECURRENCE_MODE.INFINITE_RECURRING, 
-    RECURRENCE_MODE.FINITE_RECURRING, 
-    RECURRENCE_MODE.NON_RECURRING: { 
-       break; 
-    } 
+  switch(mode) {
+    case RECURRENCE_MODE.INFINITE_RECURRING,
+    RECURRENCE_MODE.FINITE_RECURRING,
+    RECURRENCE_MODE.NON_RECURRING: {
+       break;
+    }
   };
 }
 
 function checkPeriodUnit(periodUnit: PERIOD_UNIT) {
-  switch(periodUnit) { 
-    case PERIOD_UNIT.DAY, 
-    PERIOD_UNIT.WEEK, 
+  switch(periodUnit) {
+    case PERIOD_UNIT.DAY,
+    PERIOD_UNIT.WEEK,
     PERIOD_UNIT.MONTH,
     PERIOD_UNIT.YEAR,
-    PERIOD_UNIT.UNKNOWN: { 
-       break; 
-    } 
+    PERIOD_UNIT.UNKNOWN: {
+       break;
+    }
   };
 }
 
 function checkOfferPaymentMode(offerPaymentMode: OFFER_PAYMENT_MODE) {
-  switch(offerPaymentMode) { 
-    case OFFER_PAYMENT_MODE.FREE_TRIAL, 
-    OFFER_PAYMENT_MODE.SINGLE_PAYMENT, 
-    OFFER_PAYMENT_MODE.DISCOUNTED_RECURRING_PAYMENT: { 
-       break; 
-    } 
+  switch(offerPaymentMode) {
+    case OFFER_PAYMENT_MODE.FREE_TRIAL,
+    OFFER_PAYMENT_MODE.SINGLE_PAYMENT,
+    OFFER_PAYMENT_MODE.DISCOUNTED_RECURRING_PAYMENT: {
+       break;
+    }
   };
 }
 
 function checkOfferProductCategory(productCategory: PRODUCT_CATEGORY) {
-  switch(productCategory) { 
-    case PRODUCT_CATEGORY.NON_SUBSCRIPTION, 
-    PRODUCT_CATEGORY.SUBSCRIPTION, 
-    PRODUCT_CATEGORY.UNKNOWN: { 
-       break; 
-    } 
+  switch(productCategory) {
+    case PRODUCT_CATEGORY.NON_SUBSCRIPTION,
+    PRODUCT_CATEGORY.SUBSCRIPTION,
+    PRODUCT_CATEGORY.UNKNOWN: {
+       break;
+    }
   };
 }

--- a/typescript/src/offerings.ts
+++ b/typescript/src/offerings.ts
@@ -108,7 +108,7 @@ export interface PurchasesStoreProduct {
      */
     readonly productCategory: PRODUCT_CATEGORY | null;
     /**
-     * Product type.
+     * The specific type of subscription or one time purchase this product represents
      */
     readonly productType: PRODUCT_TYPE;
     /**
@@ -158,12 +158,12 @@ export enum PRODUCT_TYPE {
     CONSUMABLE = "CONSUMABLE",
 
     /**
-     * A non-consumable in-app purchase.
+     * A non-consumable in-app purchase. Only applies to Apple Store products.
      */
     NON_CONSUMABLE = "NON_CONSUMABLE",
 
     /**
-     * A non-renewing subscription.
+     * A non-renewing subscription. Only applies to Apple Store products.
      */
     NON_RENEWABLE_SUBSCRIPTION = "NON_RENEWABLE_SUBSCRIPTION",
 
@@ -173,12 +173,12 @@ export enum PRODUCT_TYPE {
     AUTO_RENEWABLE_SUBSCRIPTION = "AUTO_RENEWABLE_SUBSCRIPTION",
 
     /**
-     * A subscription that is pre-paid.
+     * A subscription that is pre-paid. Only applies to Google Play products.
      */
     PREPAID_SUBSCRIPTION = "PREPAID_SUBSCRIPTION",
 
     /**
-     * A type of product for unknowns.
+     * Unable to determine product type.
      */
     UNKNOWN = "UNKNOWN",
   }

--- a/typescript/src/offerings.ts
+++ b/typescript/src/offerings.ts
@@ -108,6 +108,10 @@ export interface PurchasesStoreProduct {
      */
     readonly productCategory: PRODUCT_CATEGORY | null;
     /**
+     * Product type.
+     */
+    readonly productType: PRODUCT_TYPE;
+    /**
      * Subscription period, specified in ISO 8601 format. For example,
      * P1W equates to one week, P1M equates to one month,
      * P3M equates to three months, P6M equates to six months,
@@ -135,11 +139,43 @@ export enum PRODUCT_CATEGORY {
      * A type of product for non-subscription.
      */
     NON_SUBSCRIPTION = "NON_SUBSCRIPTION",
-  
+
     /**
      * A type of product for subscriptions.
      */
     SUBSCRIPTION = "SUBSCRIPTION",
+
+    /**
+     * A type of product for unknowns.
+     */
+    UNKNOWN = "UNKNOWN",
+}
+
+export enum PRODUCT_TYPE {
+    /**
+     * A consumable in-app purchase.
+     */
+    CONSUMABLE = "CONSUMABLE",
+
+    /**
+     * A non-consumable in-app purchase.
+     */
+    NON_CONSUMABLE = "NON_CONSUMABLE",
+
+    /**
+     * A non-renewing subscription.
+     */
+    NON_RENEWABLE_SUBSCRIPTION = "NON_RENEWABLE_SUBSCRIPTION",
+
+    /**
+     * An auto-renewable subscription.
+     */
+    AUTO_RENEWABLE_SUBSCRIPTION = "AUTO_RENEWABLE_SUBSCRIPTION",
+
+    /**
+     * A subscription that is pre-paid.
+     */
+    PREPAID_SUBSCRIPTION = "PREPAID_SUBSCRIPTION",
 
     /**
      * A type of product for unknowns.
@@ -375,10 +411,10 @@ export enum PRORATION_MODE {
      * be charged at the same time.
      */
     DEFERRED = 4,
-     
+
     /**
-     * Replacement takes effect immediately, and the user is charged full price 
-     * of new plan and is given a full billing cycle of subscription, 
+     * Replacement takes effect immediately, and the user is charged full price
+     * of new plan and is given a full billing cycle of subscription,
      * plus remaining prorated time from the old plan.
      */
     IMMEDIATE_AND_CHARGE_FULL_PRICE = 5,
@@ -537,7 +573,7 @@ export interface Price {
 
     /**
      * Price in micro-units, where 1,000,000 micro-units equal one unit of the currency.
-     * 
+     *
      * For example, if price is "€7.99", price_amount_micros is 7,990,000. This value represents
      * the localized, rounded price for a particular currency.
      */
@@ -545,7 +581,7 @@ export interface Price {
 
     /**
      * Returns ISO 4217 currency code for price and original price.
-     * 
+     *
      * For example, if price is specified in British pounds sterling, price_currency_code is "GBP".
      * If currency code cannot be determined, currency symbol is returned.
      */


### PR DESCRIPTION
We are sending `productType` in the Kotlin and Swift side, but the property is missing from the types