### PR TITLE
fix proxyURL not crashing if invalid url is passed

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -41,11 +41,15 @@ import RevenueCat
         set {
             if let value = newValue {
                 var url: URL?
+                #if swift(>=5.9)
                 if #available(iOS 17.0, macCatalyst 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
                     url = URL(string: value, encodingInvalidCharacters: false)
                 } else {
                     url = URL(string: value)
                 }
+                #else
+                url = URL(string: value)
+                #endif
                 guard let proxyURL = url else {
                     fatalError("could not set the proxyURL, provided value is not a valid URL: \(value)")
                 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -40,7 +40,13 @@ import RevenueCat
         get { Purchases.proxyURL?.absoluteString }
         set {
             if let value = newValue {
-                guard let proxyURL = URL(string: value) else {
+                var url: URL?
+                if #available(iOS 17.0, macCatalyst 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
+                    url = URL(string: value, encodingInvalidCharacters: false)
+                } else {
+                    url = URL(string: value)
+                }
+                guard let proxyURL = url else {
                     fatalError("could not set the proxyURL, provided value is not a valid URL: \(value)")
                 }
                 Purchases.proxyURL = proxyURL


### PR DESCRIPTION
Fixes an issue where in iOS 17 onwards, passing in an invalid proxyURLString won't actually fail. 

https://twitter.com/developermaris/status/1701487361069031542?s=61&t=-F_XHhE9Npq5cORxmw3b8w