### PR TITLE
Add in app messages API support

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -489,6 +489,7 @@ fun showInAppMessagesIfNeeded(activity: Activity?, inAppMessageTypes: List<InApp
     }
 }
 
+@Suppress("LongParameterList")
 @JvmOverloads
 fun configure(
     context: Context,

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -25,6 +25,7 @@ import com.revenuecat.purchases.logInWith
 import com.revenuecat.purchases.logOutWith
 import com.revenuecat.purchases.models.BillingFeature
 import com.revenuecat.purchases.models.GoogleProrationMode
+import com.revenuecat.purchases.models.InAppMessageType
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.googleProduct
@@ -476,6 +477,19 @@ fun canMakePayments(
 }
 
 @JvmOverloads
+fun showInAppMessagesIfNeeded(activity: Activity?, inAppMessageTypes: List<InAppMessageType>? = null) {
+    if (activity == null) {
+        errorLog("showInAppMessages called with null activity")
+        return
+    }
+    if (inAppMessageTypes == null) {
+        Purchases.sharedInstance.showInAppMessagesIfNeeded(activity)
+    } else {
+        Purchases.sharedInstance.showInAppMessagesIfNeeded(activity, inAppMessageTypes)
+    }
+}
+
+@JvmOverloads
 fun configure(
     context: Context,
     apiKey: String,
@@ -484,6 +498,7 @@ fun configure(
     platformInfo: PlatformInfo,
     store: Store = Store.PLAY_STORE,
     dangerousSettings: DangerousSettings = DangerousSettings(autoSyncPurchases = true),
+    shouldShowInAppMessagesAutomatically: Boolean? = null,
 ) {
     Purchases.platformInfo = platformInfo
     val builder =
@@ -491,9 +506,14 @@ fun configure(
             .appUserID(appUserID)
             .store(store)
             .dangerousSettings(dangerousSettings)
-    if (observerMode != null) {
-        builder.observerMode(observerMode)
-    }
+            .apply {
+                if (observerMode != null) {
+                    observerMode(observerMode)
+                }
+                if (shouldShowInAppMessagesAutomatically != null) {
+                    showInAppMessagesAutomatically(shouldShowInAppMessagesAutomatically)
+                }
+            }
 
     Purchases.configure(builder.build())
 }
@@ -601,5 +621,11 @@ data class ErrorContainer(
 internal fun warnLog(message: String) {
     if (Purchases.logLevel <= LogLevel.WARN) {
         Log.w("PurchasesHybridCommon", message)
+    }
+}
+
+internal fun errorLog(message: String) {
+    if (Purchases.logLevel <= LogLevel.ERROR) {
+        Log.e("PurchasesHybridCommon", message)
     }
 }

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -507,15 +507,12 @@ fun configure(
             .appUserID(appUserID)
             .store(store)
             .dangerousSettings(dangerousSettings)
-            .apply {
-                if (observerMode != null) {
-                    observerMode(observerMode)
-                }
-                if (shouldShowInAppMessagesAutomatically != null) {
-                    showInAppMessagesAutomatically(shouldShowInAppMessagesAutomatically)
-                }
-            }
-
+    if (observerMode != null) {
+        builder.observerMode(observerMode)
+    }
+    if (shouldShowInAppMessagesAutomatically != null) {
+        builder.showInAppMessagesAutomatically(shouldShowInAppMessagesAutomatically)
+    }
     Purchases.configure(builder.build())
 }
 

--- a/android/src/test/java/apitests/java/CommonApiTests.java
+++ b/android/src/test/java/apitests/java/CommonApiTests.java
@@ -14,6 +14,7 @@ import com.revenuecat.purchases.hybridcommon.OnResult;
 import com.revenuecat.purchases.hybridcommon.OnResultAny;
 import com.revenuecat.purchases.hybridcommon.OnResultList;
 import com.revenuecat.purchases.models.GoogleProrationMode;
+import com.revenuecat.purchases.models.InAppMessageType;
 
 import java.util.List;
 import java.util.Map;
@@ -173,16 +174,32 @@ class CommonApiTests {
         CommonKt.canMakePayments(context, features, onResult);
     }
 
+    private void checkShowInAppMessagesIfNeeded(Activity activity, List<InAppMessageType> types) {
+        CommonKt.showInAppMessagesIfNeeded(activity);
+        CommonKt.showInAppMessagesIfNeeded(activity, types);
+        CommonKt.showInAppMessagesIfNeeded(activity, null);
+    }
+
     private void checkConfigure(Context context,
                                 String apiKey,
                                 String appUserId,
                                 Boolean observerMode,
                                 PlatformInfo platformInfo,
                                 Store store,
-                                DangerousSettings dangerousSettings) {
+                                DangerousSettings dangerousSettings,
+                                Boolean shouldShowInAppMessagesAutomatically) {
         CommonKt.configure(context, apiKey, appUserId, observerMode, platformInfo);
         CommonKt.configure(context, apiKey, appUserId, observerMode, platformInfo, store);
         CommonKt.configure(context, apiKey, appUserId, observerMode, platformInfo, store, dangerousSettings);
+        CommonKt.configure(
+                context,
+                apiKey,
+                appUserId,
+                observerMode,
+                platformInfo,
+                store,
+                dangerousSettings,
+                shouldShowInAppMessagesAutomatically);
     }
 
     private void checkGetPromotionalOffer() {

--- a/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
+++ b/android/src/test/java/apitests/kotlin/com/revenuecat/purchases/hybridcommon/CommonApiTests.kt
@@ -33,7 +33,9 @@ import com.revenuecat.purchases.hybridcommon.setLogHandler
 import com.revenuecat.purchases.hybridcommon.setLogHandlerWithOnResult
 import com.revenuecat.purchases.hybridcommon.setLogLevel
 import com.revenuecat.purchases.hybridcommon.setProxyURLString
+import com.revenuecat.purchases.hybridcommon.showInAppMessagesIfNeeded
 import com.revenuecat.purchases.hybridcommon.syncPurchases
+import com.revenuecat.purchases.models.InAppMessageType
 
 @Suppress("unused", "DEPRECATION", "LongParameterList", "UNUSED_VARIABLE")
 private class CommonApiTests {
@@ -199,6 +201,12 @@ private class CommonApiTests {
         canMakePayments(context, features, onResult)
     }
 
+    fun checkShowInAppMessagesIfNeeded(activity: Activity?) {
+        showInAppMessagesIfNeeded(activity)
+        showInAppMessagesIfNeeded(activity, listOf(InAppMessageType.BILLING_ISSUES))
+        showInAppMessagesIfNeeded(activity, null)
+    }
+
     fun checkConfigure(
         context: Context,
         apiKey: String,
@@ -207,9 +215,20 @@ private class CommonApiTests {
         platformInfo: PlatformInfo,
         store: Store,
         dangerousSettings: DangerousSettings,
+        shouldShowInAppMessagesAutomatically: Boolean?,
     ) {
         configure(context, apiKey, appUserID, observerMode, platformInfo)
         configure(context, apiKey, appUserID, observerMode, platformInfo, store, dangerousSettings)
+        configure(
+            context,
+            apiKey,
+            appUserID,
+            observerMode,
+            platformInfo,
+            store,
+            dangerousSettings,
+            shouldShowInAppMessagesAutomatically,
+        )
     }
 
     fun checkGetPromotionalOffer() {

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCPurchases+HybridAdditionsAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCPurchases+HybridAdditionsAPITest.m
@@ -25,7 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                         platformFlavor:nil
                                                  platformFlavorVersion:@""
                                               usesStoreKit2IfAvailable:YES
-                                                     dangerousSettings:nil];
+                                                     dangerousSettings:nil
+                                  shouldShowInAppMessagesAutomatically:NO];
 }
 
 @end

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -219,7 +219,10 @@ import RevenueCat
     @objc(showStoreMessagesForTypes:completion:)
     static func showStoreMessages(forRawValues rawValues: Set<NSNumber>,
                                   completion: @escaping () -> Void) {
-        Self.sharedInstance.showStoreMessages(forRawValues: rawValues, completion: completion)
+        let storeMessageTypes = rawValues.map { number in
+            StoreMessageType(rawValue: number.intValue)
+        }
+        Self.sharedInstance.showStoreMessages(for: Set(storeMessageTypes), completion: completion)
     }
 #endif
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -208,10 +208,8 @@ import RevenueCat
     @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @objc(showStoreMessagesCompletion:)
-    static func showStoreMessages(completion: @escaping (ErrorContainer?) -> Void) {
-        Self.sharedInstance.showStoreMessages { result in
-            Self.processShowStoreMessagesResultWithCompletion(showStoreMessagesResult: result, completion: completion)
-        }
+    static func showStoreMessages(completion: @escaping () -> Void) {
+        Self.sharedInstance.showStoreMessages(completion)
     }
 
     @available(iOS 16.4, *)
@@ -220,10 +218,8 @@ import RevenueCat
     @available(watchOS, unavailable)
     @objc(showStoreMessagesForTypes:completion:)
     static func showStoreMessages(forRawValues rawValues: Set<NSNumber>,
-                                  completion: @escaping (ErrorContainer?) -> Void) {
-        Self.sharedInstance.showStoreMessages(forRawValues: rawValues) { result in
-            Self.processShowStoreMessagesResultWithCompletion(showStoreMessagesResult: result, completion: completion)
-        }
+                                  completion: @escaping () -> Void) {
+        Self.sharedInstance.showStoreMessages(forRawValues: rawValues, completion: completion)
     }
 #endif
 
@@ -633,18 +629,6 @@ private extension CommonFunctionality {
             case .error:
                 completion(Self.refundRequestError(description: "Error during refund request."))
             }
-        case let .failure(error):
-            completion(ErrorContainer(error: error, extraPayload: [:]))
-        }
-    }
-
-    static func processShowStoreMessagesResultWithCompletion(
-        showStoreMessagesResult: Result<Void, PublicError>,
-        completion: @escaping (ErrorContainer?) -> Void
-    ) {
-        switch showStoreMessagesResult {
-        case let .success(_):
-            completion(nil)
         case let .failure(error):
             completion(ErrorContainer(error: error, extraPayload: [:]))
         }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -219,7 +219,7 @@ import RevenueCat
     @objc(showStoreMessagesForTypes:completion:)
     static func showStoreMessages(forRawValues rawValues: Set<NSNumber>,
                                   completion: @escaping () -> Void) {
-        let storeMessageTypes = rawValues.map { number in
+        let storeMessageTypes = rawValues.compactMap { number in
             StoreMessageType(rawValue: number.intValue)
         }
         Self.sharedInstance.showStoreMessages(for: Set(storeMessageTypes), completion: completion)

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -199,6 +199,36 @@ import RevenueCat
 
 }
 
+// MARK: In app messages
+@objc public extension CommonFunctionality {
+
+#if os(iOS)
+    @available(iOS 16.4, *)
+    @available(tvOS, unavailable)
+    @available(macOS, unavailable)
+    @available(watchOS, unavailable)
+    @objc(showStoreMessagesCompletion:)
+    static func showStoreMessages(completion: @escaping (ErrorContainer?) -> Void) {
+        Self.sharedInstance.showStoreMessages { result in
+            Self.processShowStoreMessagesResultWithCompletion(showStoreMessagesResult: result, completion: completion)
+        }
+    }
+
+    @available(iOS 16.4, *)
+    @available(tvOS, unavailable)
+    @available(macOS, unavailable)
+    @available(watchOS, unavailable)
+    @objc(showStoreMessagesForTypes:completion:)
+    static func showStoreMessages(forRawValues rawValues: Set<NSNumber>,
+                                  completion: @escaping (ErrorContainer?) -> Void) {
+        Self.sharedInstance.showStoreMessages(forRawValues: rawValues) { result in
+            Self.processShowStoreMessagesResultWithCompletion(showStoreMessagesResult: result, completion: completion)
+        }
+    }
+#endif
+
+}
+
 // MARK: purchasing and restoring
 @objc public extension CommonFunctionality {
 
@@ -603,6 +633,18 @@ private extension CommonFunctionality {
             case .error:
                 completion(Self.refundRequestError(description: "Error during refund request."))
             }
+        case let .failure(error):
+            completion(ErrorContainer(error: error, extraPayload: [:]))
+        }
+    }
+
+    static func processShowStoreMessagesResultWithCompletion(
+        showStoreMessagesResult: Result<Void, PublicError>,
+        completion: @escaping (ErrorContainer?) -> Void
+    ) {
+        switch showStoreMessagesResult {
+        case let .success(_):
+            completion(nil)
         case let .failure(error):
             completion(ErrorContainer(error: error, extraPayload: [:]))
         }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -202,17 +202,20 @@ import RevenueCat
 // MARK: In app messages
 @objc public extension CommonFunctionality {
 
-#if os(iOS)
-    @available(iOS 16.4, *)
+#if os(iOS) || targetEnvironment(macCatalyst) || VISION_OS
+    @available(iOS 16.0, *)
     @available(tvOS, unavailable)
     @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @objc(showStoreMessagesCompletion:)
     static func showStoreMessages(completion: @escaping () -> Void) {
-        Self.sharedInstance.showStoreMessages(completion)
+        _ = Task<Void, Never> {
+            await Self.sharedInstance.showStoreMessages(for: Set(StoreMessageType.allCases))
+            completion()
+        }
     }
 
-    @available(iOS 16.4, *)
+    @available(iOS 16.0, *)
     @available(tvOS, unavailable)
     @available(macOS, unavailable)
     @available(watchOS, unavailable)
@@ -222,7 +225,10 @@ import RevenueCat
         let storeMessageTypes = rawValues.compactMap { number in
             StoreMessageType(rawValue: number.intValue)
         }
-        Self.sharedInstance.showStoreMessages(for: Set(storeMessageTypes), completion: completion)
+        _ = Task<Void, Never> {
+            await Self.sharedInstance.showStoreMessages(for: Set(storeMessageTypes))
+            completion()
+        }
     }
 #endif
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
@@ -12,7 +12,7 @@ import RevenueCat
 @objc public extension Purchases {
 
     @objc(configureWithAPIKey:appUserID:observerMode:userDefaultsSuiteName:platformFlavor:platformFlavorVersion:
-            usesStoreKit2IfAvailable:dangerousSettings:shouldShowStoreMessagesAutomatically:)
+            usesStoreKit2IfAvailable:dangerousSettings:shouldShowInAppMessagesAutomatically:)
     static func configure(apiKey: String,
                           appUserID: String?,
                           observerMode: Bool,
@@ -21,7 +21,7 @@ import RevenueCat
                           platformFlavorVersion: String?,
                           usesStoreKit2IfAvailable: Bool = false,
                           dangerousSettings: DangerousSettings?,
-                          shouldShowStoreMessagesAutomatically: Bool? = nil) -> Purchases {
+                          shouldShowInAppMessagesAutomatically: Bool? = nil) -> Purchases {
         var userDefaults: UserDefaults?
         if let userDefaultsSuiteName = userDefaultsSuiteName {
             userDefaults = UserDefaults(suiteName: userDefaultsSuiteName)
@@ -48,9 +48,9 @@ import RevenueCat
             let platformInfo = Purchases.PlatformInfo(flavor: platformFlavor, version: platformFlavorVersion)
             configurationBuilder = configurationBuilder.with(platformInfo: platformInfo)
         }
-        if let shouldShowStoreMessagesAutomatically = shouldShowStoreMessagesAutomatically {
+        if let shouldShowInAppMessagesAutomatically = shouldShowInAppMessagesAutomatically {
             configurationBuilder = configurationBuilder.with(showStoreMessagesAutomatically:
-                                                                shouldShowStoreMessagesAutomatically)
+                                                                shouldShowInAppMessagesAutomatically)
         }
 
         let purchases = self.configure(with: configurationBuilder.build())

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
@@ -21,7 +21,7 @@ import RevenueCat
                           platformFlavorVersion: String?,
                           usesStoreKit2IfAvailable: Bool = false,
                           dangerousSettings: DangerousSettings?,
-                          shouldShowInAppMessagesAutomatically: Bool? = nil) -> Purchases {
+                          shouldShowInAppMessagesAutomatically: Bool = true) -> Purchases {
         var userDefaults: UserDefaults?
         if let userDefaultsSuiteName = userDefaultsSuiteName {
             userDefaults = UserDefaults(suiteName: userDefaultsSuiteName)
@@ -48,10 +48,8 @@ import RevenueCat
             let platformInfo = Purchases.PlatformInfo(flavor: platformFlavor, version: platformFlavorVersion)
             configurationBuilder = configurationBuilder.with(platformInfo: platformInfo)
         }
-        if let shouldShowInAppMessagesAutomatically = shouldShowInAppMessagesAutomatically {
-            configurationBuilder = configurationBuilder.with(showStoreMessagesAutomatically:
-                                                                shouldShowInAppMessagesAutomatically)
-        }
+        configurationBuilder = configurationBuilder.with(showStoreMessagesAutomatically:
+                                                            shouldShowInAppMessagesAutomatically)
 
         let purchases = self.configure(with: configurationBuilder.build())
         CommonFunctionality.sharedInstance = purchases

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
@@ -12,7 +12,7 @@ import RevenueCat
 @objc public extension Purchases {
 
     @objc(configureWithAPIKey:appUserID:observerMode:userDefaultsSuiteName:platformFlavor:platformFlavorVersion:
-            usesStoreKit2IfAvailable:dangerousSettings:)
+            usesStoreKit2IfAvailable:dangerousSettings:shouldShowStoreMessagesAutomatically:)
     static func configure(apiKey: String,
                           appUserID: String?,
                           observerMode: Bool,
@@ -20,7 +20,8 @@ import RevenueCat
                           platformFlavor: String?,
                           platformFlavorVersion: String?,
                           usesStoreKit2IfAvailable: Bool = false,
-                          dangerousSettings: DangerousSettings?) -> Purchases {
+                          dangerousSettings: DangerousSettings?,
+                          shouldShowStoreMessagesAutomatically: Bool? = nil) -> Purchases {
         var userDefaults: UserDefaults?
         if let userDefaultsSuiteName = userDefaultsSuiteName {
             userDefaults = UserDefaults(suiteName: userDefaultsSuiteName)
@@ -46,6 +47,10 @@ import RevenueCat
         if let platformFlavor = platformFlavor, let platformFlavorVersion = platformFlavorVersion {
             let platformInfo = Purchases.PlatformInfo(flavor: platformFlavor, version: platformFlavorVersion)
             configurationBuilder = configurationBuilder.with(platformInfo: platformInfo)
+        }
+        if let shouldShowStoreMessagesAutomatically = shouldShowStoreMessagesAutomatically {
+            configurationBuilder = configurationBuilder.with(showStoreMessagesAutomatically:
+                                                                shouldShowStoreMessagesAutomatically)
         }
 
         let purchases = self.configure(with: configurationBuilder.build())

--- a/typescript/apitesters/enums.ts
+++ b/typescript/apitesters/enums.ts
@@ -4,7 +4,8 @@ import {
   PACKAGE_TYPE,
   REFUND_REQUEST_STATUS,
   INTRO_ELIGIBILITY_STATUS,
-  PRORATION_MODE
+  PRORATION_MODE,
+  IN_APP_MESSAGE_TYPE
 } from '../dist';
 
 function checkPurchaseType(type: PURCHASE_TYPE): boolean {
@@ -91,6 +92,17 @@ function checkRefundRequestStatus(status: REFUND_REQUEST_STATUS): boolean {
     case REFUND_REQUEST_STATUS.USER_CANCELLED:
       return true;
     case REFUND_REQUEST_STATUS.ERROR:
+      return true;
+  }
+}
+
+function checkInAppMessages(messageType: IN_APP_MESSAGE_TYPE): boolean {
+  switch (messageType) {
+    case IN_APP_MESSAGE_TYPE.BILLING_ISSUE:
+      return true;
+    case IN_APP_MESSAGE_TYPE.PRICE_INCREASE_CONSENT:
+      return true;
+    case IN_APP_MESSAGE_TYPE.GENERIC:
       return true;
   }
 }

--- a/typescript/src/enums.ts
+++ b/typescript/src/enums.ts
@@ -80,16 +80,16 @@ export enum IN_APP_MESSAGE_TYPE {
   /**
    * In-app messages to indicate there has been a billing issue charging the user.
    */
-  BILLING_ISSUE,
+  BILLING_ISSUE = 0,
 
   /**
    * iOS-only. This message will show if you increase the price of a subscription and 
    * the user needs to opt-in to the increase.
    */
-  PRICE_INCREASE_CONSENT,
+  PRICE_INCREASE_CONSENT = 1,
 
   /**
    * iOS-only. StoreKit generic messages.
    */
-  GENERIC
+  GENERIC = 2
 }

--- a/typescript/src/enums.ts
+++ b/typescript/src/enums.ts
@@ -77,6 +77,7 @@ export enum LOG_LEVEL {
  * method in Purchases.
  */
 export enum IN_APP_MESSAGE_TYPE {
+  // Make sure the enum values are in sync with those defined in iOS/Android
   /**
    * In-app messages to indicate there has been a billing issue charging the user.
    */

--- a/typescript/src/enums.ts
+++ b/typescript/src/enums.ts
@@ -69,3 +69,27 @@ export enum LOG_LEVEL {
   WARN = "WARN",
   ERROR = "ERROR"
 }
+
+/**
+ * Enum for in-app message types.
+ * This can be used if you disable automatic in-app message from showing automatically.
+ * Then, you can pass what type of messages you want to show in the `showInAppMessages`
+ * method in Purchases.
+ */
+export enum IN_APP_MESSAGE_TYPE {
+  /**
+   * In-app messages to indicate there has been a billing issue charging the user.
+   */
+  BILLING_ISSUE,
+
+  /**
+   * iOS-only. This message will show if you increase the price of a subscription and 
+   * the user needs to opt-in to the increase.
+   */
+  PRICE_INCREASE_CONSENT,
+
+  /**
+   * iOS-only. StoreKit generic messages.
+   */
+  GENERIC
+}

--- a/typescript/src/purchasesConfiguration.ts
+++ b/typescript/src/purchasesConfiguration.ts
@@ -44,5 +44,5 @@ export interface PurchasesConfiguration {
    * This allows to disable that behavior, so you can display those messages at your convenience. For more information,
    * check: https://rev.cat/storekit-message and https://rev.cat/googleplayinappmessaging
    */
-  shouldShowStoreMessages?: boolean;
+  shouldShowInAppMessagesAutomatically?: boolean;
 }

--- a/typescript/src/purchasesConfiguration.ts
+++ b/typescript/src/purchasesConfiguration.ts
@@ -38,4 +38,11 @@ export interface PurchasesConfiguration {
    * An optional boolean. Android only. Required to configure the plugin to be used in the Amazon Appstore.
    */
   useAmazon?: boolean;
+  /**
+   * Whether we should show store in-app messages automatically. Both Google Play and the App Store provide in-app
+   * messages for some situations like billing issues. By default, those messages will be shown automatically.
+   * This allows to disable that behavior, so you can display those messages at your convenience. For more information,
+   * check: https://rev.cat/storekit-message and https://rev.cat/googleplayinappmessaging
+   */
+  shouldShowStoreMessages?: boolean;
 }


### PR DESCRIPTION
This adds a new API to be used by the hybrids to support deferring in app messages so they don't show automatically and provides an API to display these messages on convenience.
