### PR TITLE
Add documentation for productType field in StoreProduct in typescript

### DIFF
--- a/typescript/src/offerings.ts
+++ b/typescript/src/offerings.ts
@@ -108,7 +108,8 @@ export interface PurchasesStoreProduct {
      */
     readonly productCategory: PRODUCT_CATEGORY | null;
     /**
-     * The specific type of subscription or one time purchase this product represents
+     * The specific type of subscription or one time purchase this product represents. 
+     * Important: In iOS, if using StoreKit 1, we cannot determine the type.
      */
     readonly productType: PRODUCT_TYPE;
     /**


### PR DESCRIPTION
We added the `productType` field to the typescript interfaces in #507. We didn't mention there that the `productType` can not be determined in iOS when using SK1. This adds a comment mentioning that.
