### PR TITLE
Add `product_plan_identifier` to `EntitlementInfo` in iOS

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementInfo+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementInfo+HybridAdditions.swift
@@ -25,7 +25,7 @@ internal extension EntitlementInfo {
             "expirationDateMillis": expirationDate?.rc_millisecondsSince1970AsDouble() ?? NSNull(),
             "store": storeString,
             "productIdentifier": productIdentifier,
-            "productPlanIdentifier": NSNull(), // Only used in Android
+            "productPlanIdentifier": productPlanIdentifier ?? NSNull(),
             "isSandbox": isSandbox,
             "unsubscribeDetectedAt": unsubscribeDetectedAt?.rc_formattedAsISO8601() ?? NSNull(),
             "unsubscribeDetectedAtMillis": unsubscribeDetectedAt?.rc_millisecondsSince1970AsDouble() ?? NSNull(),


### PR DESCRIPTION
This field was already added in Android but not in iOS, where it was always null. This field only applies to purchases done in Google play. 
