### PR TITLE
Fix deploy android circleci job

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,1 @@
+android/.sdkmanrc


### PR DESCRIPTION
As part of #552, we added sdkman to install the correct java version. However, the deploy job in CircleCI runs in the root folder, as opposed to the test/lint jobs, which run in the `android` folder, so it wasn't actually installing the correct java version because there was no `.sdkmanrc` file in the root folder and was causing the deploy job to fail, as seen in [PR 557](https://app.circleci.com/pipelines/github/RevenueCat/purchases-hybrid-common/2622/workflows/e6029d52-84ae-4114-b293-4fa576a900c3/jobs/10735) . 

This adds a symlink in the root folder to the `android` folder so we have the same sdkmanrc in both locations.

An alternative would be to switch folders during the deploy job, but I wanted to keep it in the root folder if possible, seemed cleaner to me. Lmk if you think otherwise.