### PR TITLE
Fix entitlement verification name typo

### DIFF
--- a/typescript/apitesters/purchasesConfiguration.ts
+++ b/typescript/apitesters/purchasesConfiguration.ts
@@ -1,0 +1,26 @@
+import { PurchasesConfiguration } from "../dist";
+import { ENTITLEMENT_VERIFICATION_MODE } from "../src";
+
+function checkPurchasesConfiguration(configuration: PurchasesConfiguration) {
+    const apiKey: string = configuration.apiKey;
+    const appUserID: string | null | undefined = configuration.appUserID;
+    const observerMode: boolean | undefined = configuration.observerMode;
+    const userDefaultsSuiteName: string | undefined = configuration.userDefaultsSuiteName;
+    const usesStoreKit2IfAvailable: boolean | undefined = configuration.usesStoreKit2IfAvailable;
+    const useAmazon: boolean | undefined = configuration.useAmazon;
+    const shouldShowInAppMessagesAutomatically: boolean | undefined = configuration.shouldShowInAppMessagesAutomatically;
+    const entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE | undefined = configuration.entitlementVerificationMode;
+    const configuration2: PurchasesConfiguration = {
+        apiKey: apiKey,
+        appUserID: appUserID,
+        observerMode: observerMode,
+        userDefaultsSuiteName: userDefaultsSuiteName,
+        usesStoreKit2IfAvailable: usesStoreKit2IfAvailable,
+        useAmazon: useAmazon,
+        shouldShowInAppMessagesAutomatically: shouldShowInAppMessagesAutomatically,
+        entitlementVerificationMode: entitlementVerificationMode
+    } 
+    const configuration3: PurchasesConfiguration = {
+        apiKey: apiKey
+    } 
+}

--- a/typescript/src/purchasesConfiguration.ts
+++ b/typescript/src/purchasesConfiguration.ts
@@ -52,5 +52,5 @@ export interface PurchasesConfiguration {
    * Verification strictness levels for [EntitlementInfo].
    * See https://rev.cat/trusted-entitlements for more info.
    */
-  entitlementVerificationInfo?: ENTITLEMENT_VERIFICATION_MODE;
+  entitlementVerificationMode?: ENTITLEMENT_VERIFICATION_MODE;
 }


### PR DESCRIPTION
We set the wrong name in the typescript interface. Also adds API tests for purchases configuration to try to catch this more easily in the future.