### PR TITLE
Paywalls: Expose delegate in PaywallProxy to receive events

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
@@ -61,7 +61,6 @@ extension PaywallProxy: PaywallViewControllerDelegate {
     public func paywallViewController(_ controller: PaywallViewController,
                                       didFinishPurchasingWith customerInfo: CustomerInfo) {
         self.delegate?.paywallViewController?(controller, didFinishPurchasingWith: customerInfo)
-        controller.dismiss(animated: true)
     }
 
     public func paywallViewController(_ controller: PaywallViewController,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
@@ -73,6 +73,10 @@ extension PaywallProxy: PaywallViewControllerDelegate {
                                       didFinishRestoringWith customerInfo: CustomerInfo) {
         self.delegate?.paywallViewController?(controller, didFinishRestoringWith: customerInfo)
     }
+
+    public func paywallViewControllerWasDismissed(_ controller: PaywallViewController) {
+        self.delegate?.paywallViewControllerWasDismissed?(controller)
+    }
 }
 
 #endif

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
@@ -67,8 +67,6 @@ extension PaywallProxy: PaywallViewControllerDelegate {
     public func paywallViewController(_ controller: PaywallViewController,
                                       didFinishPurchasingWith customerInfo: CustomerInfo,
                                       transaction: StoreTransaction?) {
-        // We are not dismissing the controller here since it's already performed in the other delegate method.
-        // Currently in the native sdk, both methods are called, and we don't want to dismiss the controller twice.
         self.delegate?.paywallViewController?(controller, didFinishPurchasingWith: customerInfo, transaction: transaction)
     }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
@@ -67,6 +67,8 @@ extension PaywallProxy: PaywallViewControllerDelegate {
     public func paywallViewController(_ controller: PaywallViewController,
                                       didFinishPurchasingWith customerInfo: CustomerInfo,
                                       transaction: StoreTransaction?) {
+        // We are not dismissing the controller here since it's already performed in the other delegate method.
+        // Currently in the native sdk, both methods are called, and we don't want to dismiss the controller twice.
         self.delegate?.paywallViewController?(controller, didFinishPurchasingWith: customerInfo, transaction: transaction)
     }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
@@ -17,6 +17,9 @@ import UIKit
 @available(iOS 15.0, *)
 @objcMembers public class PaywallProxy: NSObject {
 
+    /// See ``PaywallViewControllerDelegate`` for receiving events.
+    public weak var delegate: PaywallViewControllerDelegate?
+
     @objc
     public func createPaywallView() -> UIViewController {
         return UIHostingController(rootView: PaywallView())
@@ -57,9 +60,20 @@ extension PaywallProxy: PaywallViewControllerDelegate {
 
     public func paywallViewController(_ controller: PaywallViewController,
                                       didFinishPurchasingWith customerInfo: CustomerInfo) {
+        self.delegate?.paywallViewController?(controller, didFinishPurchasingWith: customerInfo)
         controller.dismiss(animated: true)
     }
 
+    public func paywallViewController(_ controller: PaywallViewController,
+                                      didFinishPurchasingWith customerInfo: CustomerInfo,
+                                      transaction: StoreTransaction?) {
+        self.delegate?.paywallViewController?(controller, didFinishPurchasingWith: customerInfo, transaction: transaction)
+    }
+
+    public func paywallViewController(_ controller: PaywallViewController,
+                                      didFinishRestoringWith customerInfo: CustomerInfo) {
+        self.delegate?.paywallViewController?(controller, didFinishRestoringWith: customerInfo)
+    }
 }
 
 #endif


### PR DESCRIPTION
This allows to set a `PaywallViewControllerDelegate` to the `PaywallProxy` to allow to receive purchase events in the hybrids. This is a first step to fix: https://github.com/RevenueCat/purchases-flutter/issues/886

### TODO
- [x] Expose a delegate method that gets called when the PaywallViewController gets dismissed.