### PR TITLE
Merge dependency-update workflows and fix automatic-release being triggered when executing action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,17 +412,13 @@ workflows:
           requires:
             - make-github-release
   
-  weekly-run-workflow:
+  dependency-update:
     when:
-      and:
-        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - equal: [ "update-native-dependencies", << pipeline.schedule.name >> ]
-    jobs:
-      - dependency-update 
-
-  trigger-dependency-update:
-    when:
-      equal: [ dependency-update, << pipeline.parameters.action >> ]
+      or:
+        - and:
+            - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+            - equal: [ "update-native-dependencies", << pipeline.schedule.name >> ]
+        - equal: [ dependency-update, << pipeline.parameters.action >> ]
     jobs:
       - dependency-update
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,8 +435,11 @@ workflows:
 
   automatic-release:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - not:
+            equal: [ dependency-update, << pipeline.parameters.action >> ]
     jobs:
       - release:
           filters:


### PR DESCRIPTION
I noticed `automatic-release` was getting triggered after executing the `dependency-update` action manually in CircleCI.

I also noticed `weekly-run-workflow` and `dependency-update` could be merged by merging their starting conditions