### PR TITLE
Add PaywallFragmentViewModel to share data with caller fragment/activity

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallFragment.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallFragment.kt
@@ -5,7 +5,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
-import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResultHandler

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallFragment.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallFragment.kt
@@ -2,16 +2,41 @@ package com.revenuecat.purchases.hybridcommon
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.ViewModelProvider
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResultHandler
 
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
-internal class PaywallFragment(
-    private val requiredEntitlementIdentifier: String?,
-) : Fragment(), PaywallResultHandler {
+internal class PaywallFragment : Fragment(), PaywallResultHandler {
+    companion object {
+        private const val requiredEntitlementIdentifierKey = "requiredEntitlementIdentifier"
+        const val tag: String = "revenuecat-paywall-fragment"
+
+        @JvmStatic
+        fun newInstance(
+            activity: FragmentActivity,
+            requiredEntitlementIdentifier: String? = null,
+            paywallResultListener: PaywallResultListener? = null,
+        ): PaywallFragment {
+            val paywallFragmentViewModel = ViewModelProvider(activity)[PaywallFragmentViewModel::class.java]
+            paywallFragmentViewModel.paywallResultListener = paywallResultListener
+            return PaywallFragment().apply {
+                arguments = Bundle().apply {
+                    putString(requiredEntitlementIdentifierKey, requiredEntitlementIdentifier)
+                }
+            }
+        }
+    }
+
     private lateinit var launcher: PaywallActivityLauncher
+    private lateinit var viewModel: PaywallFragmentViewModel
+
+    private val requiredEntitlementIdentifier: String?
+        get() = arguments?.getString(requiredEntitlementIdentifierKey)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -20,15 +45,14 @@ internal class PaywallFragment(
             this,
             this,
         )
+        viewModel = ViewModelProvider(requireActivity())[PaywallFragmentViewModel::class.java]
 
         requiredEntitlementIdentifier?.let {
             launcher.launchIfNeeded(requiredEntitlementIdentifier = it)
         } ?: launcher.launch()
     }
 
-    companion object {
-        const val tag: String = "revenuecat-paywall-fragment"
+    override fun onActivityResult(result: PaywallResult) {
+        viewModel.paywallResultListener?.onPaywallResult(result)
     }
-
-    override fun onActivityResult(result: PaywallResult) = Unit
 }

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallFragmentViewModel.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallFragmentViewModel.kt
@@ -1,0 +1,7 @@
+package com.revenuecat.purchases.hybridcommon
+
+import androidx.lifecycle.ViewModel
+
+class PaywallFragmentViewModel : ViewModel() {
+    var paywallResultListener: PaywallResultListener? = null
+}

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallFragmentViewModel.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallFragmentViewModel.kt
@@ -2,6 +2,6 @@ package com.revenuecat.purchases.hybridcommon
 
 import androidx.lifecycle.ViewModel
 
-class PaywallFragmentViewModel : ViewModel() {
+internal class PaywallFragmentViewModel : ViewModel() {
     var paywallResultListener: PaywallResultListener? = null
 }

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallHelpers.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallHelpers.kt
@@ -15,7 +15,7 @@ fun presentPaywallFromFragment(
             PaywallFragment.newInstance(
                 fragment,
                 requiredEntitlementIdentifier,
-                paywallResultListener
+                paywallResultListener,
             ),
             PaywallFragment.tag,
         )

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallHelpers.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallHelpers.kt
@@ -6,10 +6,18 @@ import androidx.fragment.app.FragmentActivity
 fun presentPaywallFromFragment(
     fragment: FragmentActivity,
     requiredEntitlementIdentifier: String? = null,
+    paywallResultListener: PaywallResultListener? = null,
 ) {
     fragment
         .supportFragmentManager
         .beginTransaction()
-        .add(PaywallFragment(requiredEntitlementIdentifier), PaywallFragment.tag)
+        .add(
+            PaywallFragment.newInstance(
+                fragment,
+                requiredEntitlementIdentifier,
+                paywallResultListener
+            ),
+            PaywallFragment.tag,
+        )
         .commit()
 }

--- a/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallResultListener.kt
+++ b/android/src/main/java/com/revenuecat/purchases/hybridcommon/PaywallResultListener.kt
@@ -1,0 +1,9 @@
+package com.revenuecat.purchases.hybridcommon
+
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult
+
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+interface PaywallResultListener {
+    fun onPaywallResult(paywallResult: PaywallResult)
+}


### PR DESCRIPTION
This is an attempt to be able to have some sort of completion listener from the calling fragment/activity. The idea is to use a shared view model, which doesn't need to be exposed, to share data using the underlying activity. The flow would be:
- The calling activity/fragment would pass us a new `PaywallResultListener` to listen to the result of the paywall
- Internally, we create a `PaywallFragmentViewModel` using the underlying activity and set that listener there
- Then, in the `PaywallFragment` itself, we also get the same instance of the `PaywallFragmentViewModel`, giving us access to the same result listener.

Note that I haven't exposed a `PaywallListener` directly. The reason for that is that we're using a different activity for the paywall, so we can't use the underlying activity to communicate with that (we would need the underlying application context). This would require making the Paywall activity as a fragment instead of an activity in purchases-android.
