### PR TITLE
Trim version file contents

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -408,7 +408,7 @@ def build_and_publish_typescript_package
 end
 
 def current_version_number
-  File.read("../.version")
+  File.read("../.version").strip
 end
 
 def push_pods


### PR DESCRIPTION
While working in paywalls, we had issues because there was an extra line break at the end of the `.version` file, which caused the text substitution to not work correctly (it expected the existing text to have a line break as well). This trims the contents of that file so we don't have that issue moving forward.

This already exists in all our other SDKs