### PR TITLE
Remove core-ktx dependency

### DIFF
--- a/android/api-tests/build.gradle.kts
+++ b/android/api-tests/build.gradle.kts
@@ -46,6 +46,5 @@ android {
 dependencies {
     implementation(project(":hybridcommon"))
     implementation(project(":hybridcommon-ui"))
-    implementation(libs.core.ktx)
     testImplementation(libs.junit)
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ assertj-core = "3.22.0"
 fragmentKtx = "1.6.2"
 junit-jupiter = "5.8.2"
 kotlin = "1.7.21"
-core-ktx = "1.12.0"
 junit = "4.13.2"
 mockk = "1.12.8"
 purchases = "7.2.9"
@@ -14,7 +13,6 @@ mavenPublish = "0.22.0"
 
 [libraries]
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj-core" }
-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragmentKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }

--- a/android/hybridcommon-ui/build.gradle.kts
+++ b/android/hybridcommon-ui/build.gradle.kts
@@ -42,7 +42,6 @@ android {
 }
 
 dependencies {
-    implementation(libs.core.ktx)
     implementation(libs.fragment.ktx)
     api(libs.purchases)
     api(libs.purchases.ui)

--- a/android/hybridcommon/build.gradle.kts
+++ b/android/hybridcommon/build.gradle.kts
@@ -46,7 +46,6 @@ android {
 }
 
 dependencies {
-    implementation(libs.core.ktx)
     api(libs.purchases)
     api(libs.purchases.amazon)
     testImplementation(libs.kotlin.test)


### PR DESCRIPTION
This dependency was added by Android Studio's wizard and I didn't check whether it was needed (it wasn't). It actually caused a breaking change, since this dependency requires apps to target Android 34. For some reason I didn't encounter this when I was testing in flutter using `includeBuild` but was able to repro after publishing 8.1.3-beta.5. I tested this again by publishing to maven local and can confirm the fix now.