### PR TITLE
Fix dismiss button not showing in Android when not specified

### DIFF
--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
@@ -45,7 +45,15 @@ internal class PaywallFragment : Fragment(), PaywallResultHandler {
         get() = arguments?.getString(requiredEntitlementIdentifierKey)
 
     private val shouldDisplayDismissButton: Boolean?
-        get() = arguments?.getBoolean(shouldDisplayDismissButtonKey)
+        get() {
+            return arguments?.let {
+                if (it.containsKey(shouldDisplayDismissButtonKey)) {
+                    it.getBoolean(shouldDisplayDismissButtonKey)
+                } else {
+                    null
+                }
+            }
+        }
 
     private val offeringIdentifier: String?
         get() = arguments?.getString(offeringIdentifierKey)


### PR DESCRIPTION
If the `shouldDisplayDismissButtonKey` was missing, the button wasn't being displayed