### PR TITLE
Don't trigger updates on dependents on non-stable releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,13 @@ aliases:
       tags:
         ignore:
           - /^.*-SNAPSHOT/
-          - latest
-          - /^.*-amazon*/
+      branches:
+        ignore: /.*/
+  stable-release-tags: &stable-release-tags
+    filters:
+      tags:
+        ignore:
+          - /^.*-*/
       branches:
         ignore: /.*/
   release-branches: &release-branches
@@ -267,7 +272,7 @@ jobs:
       - run:
           name: Make GitHub release for current version
           command: bundle exec fastlane github_release_current
-  
+
   dependency-update:
     docker:
       - image: cimg/ruby:3.1.2
@@ -282,7 +287,7 @@ jobs:
       - run:
           name: Update dependencies to latest versions
           command: bundle exec fastlane open_pr_upgrading_dependencies
-  
+
   tag-release-branch:
     docker:
       - image: cimg/ruby:3.1.2
@@ -294,7 +299,7 @@ jobs:
       - trust-github-key
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
-      - run: 
+      - run:
           name: Tag branch
           command: bundle exec fastlane tag_current_branch
 
@@ -422,10 +427,10 @@ workflows:
             - deploy-typescript
             - deploy-typescript-esm
       - trigger-dependent-updates:
-          <<: *release-tags
+          <<: *stable-release-tags
           requires:
             - make-github-release
-  
+
   dependency-update:
     when:
       or:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -273,10 +273,6 @@ end
 
 desc "Run automatic bump in other repos"
 lane :bump_hybrid_dependencies do |options|
-  if current_version_prerelease?
-    UI.error("Hybrids won't update automatically for PHC prerelase versions")
-    next
-  end
   version_number_for_bump = current_version_number
   repo_name = options[:repo_name]
 
@@ -395,7 +391,8 @@ def make_typescript_package_esm
 end
 
 def build_and_publish_typescript_package
-  is_prerelease = current_version_prerelease?
+  version_number = current_version_number
+  is_prerelease = Gem::Version.new(version_number).prerelease?
 
   build_args = [
     'yarn && yarn build'
@@ -412,10 +409,6 @@ def build_and_publish_typescript_package
     sh(build_args)
     sh(publish_args)
   end
-end
-
-def current_version_prerelease?
-  Gem::Version.new(current_version_number).prerelease?
 end
 
 def current_version_number


### PR DESCRIPTION
Only trigger dependent updates on stable releases