### PR TITLE
Fix paywall result not being returned

### DIFF
--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
@@ -82,32 +82,38 @@ internal class PaywallFragment : Fragment(), PaywallResultHandler {
     private fun launchPaywallIfNeeded(requiredEntitlementIdentifier: String) {
         val displayDismissButton = shouldDisplayDismissButton
         val offering = offeringIdentifier
+        val paywallDisplayCallback = object : PaywallDisplayCallback {
+            override fun onPaywallDisplayResult(wasDisplayed: Boolean) {
+                if (!wasDisplayed) {
+                    viewModel.paywallResultListener?.onPaywallResult(notPresentedPaywallResult)
+                }
+            }
+        }
 
         if (displayDismissButton != null && offering != null) {
             launcher.launchIfNeeded(
                 requiredEntitlementIdentifier = requiredEntitlementIdentifier,
                 shouldDisplayDismissButton = displayDismissButton,
                 offeringIdentifier = offering,
-                paywallDisplayCallback = object : PaywallDisplayCallback {
-                    override fun onPaywallDisplayResult(wasDisplayed: Boolean) {
-                        if (!wasDisplayed) {
-                            viewModel.paywallResultListener?.onPaywallResult(notPresentedPaywallResult)
-                        }
-                    }
-                },
+                paywallDisplayCallback = paywallDisplayCallback,
             )
         } else if (displayDismissButton != null) {
             launcher.launchIfNeeded(
                 requiredEntitlementIdentifier = requiredEntitlementIdentifier,
                 shouldDisplayDismissButton = displayDismissButton,
+                paywallDisplayCallback = paywallDisplayCallback,
             )
         } else if (offering != null) {
             launcher.launchIfNeeded(
                 requiredEntitlementIdentifier = requiredEntitlementIdentifier,
                 offeringIdentifier = offering,
+                paywallDisplayCallback = paywallDisplayCallback,
             )
         } else {
-            launcher.launchIfNeeded(requiredEntitlementIdentifier = requiredEntitlementIdentifier)
+            launcher.launchIfNeeded(
+                requiredEntitlementIdentifier = requiredEntitlementIdentifier,
+                paywallDisplayCallback = paywallDisplayCallback,
+            )
         }
     }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
@@ -133,7 +133,8 @@ import UIKit
                 let shouldDisplay = !customerInfo.entitlements.active.keys.contains(requiredEntitlementIdentifier)
                 if shouldDisplay {
                     self.privatePresentPaywall(displayCloseButton: displayCloseButton,
-                                        offering: offering)
+                                               offering: offering,
+                                               paywallResultHandler: paywallResultHandler)
                 } else {
                     paywallResultHandler?(PaywallResult.notPresented.name)
                 }


### PR DESCRIPTION
I didn't test all ways of presenting a paywall conditionally in #628. This makes sure we return `NOT_PRESENTED` in all cases where appropriate in android. 

In iOS we were also missing to return a value in `presentPaywallIfNeeded`.
