### PR TITLE
Update fastlane internal plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 0ddee10ab18fe2b1ceade8c7c3eddd842840c1c2
+  revision: e6ba24780086c2863a59204a200f2280deea66f6
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 


### PR DESCRIPTION
After splitting the android library into 2 in #604, the job to trigger updates in the hybrids was broken. This was updated in the fastlane plugin but we need to update the reference.