### PR TITLE
Fix `stable-release-tags` filter in config.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ aliases:
     filters:
       tags:
         ignore:
-          - /^.*-*/
+          - /^.*-.*$/
       branches:
         ignore: /.*/
   release-branches: &release-branches


### PR DESCRIPTION
The `trigger-dependent-updates` job was not triggering due to this broken filter introduced in https://github.com/RevenueCat/purchases-hybrid-common/pull/638/files

This new regex requires at least one hyphen