### PR TITLE
`CircleCI`: change jobs to use Apple Silicon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ aliases:
     parameters:
       xcode_version:
         type: string
-        default: 14.3.0
+        default: 15.2.0
     working_directory: ~/ios
     shell: /bin/bash --login -o pipefail
   release-tags: &release-tags
@@ -391,8 +391,7 @@ workflows:
           xcode_version: '14.3.0'
       - test-ios-17:
           xcode_version: '15.2.0'
-      - check-pods:
-          xcode_version: '15.2.0'
+      - check-pods
       - integration-test-ios
       - test-android
       - detekt-android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ version: 2.1
 
 aliases:
   base-ios-job: &base-ios-job
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     macos:
       xcode: << parameters.xcode_version >>
     parameters:
@@ -135,7 +135,7 @@ jobs:
           working_directory: ios/PurchasesHybridCommon
           environment:
             SCAN_SCHEME: PurchasesHybridCommon
-            SCAN_DEVICE: iPhone 15 (17.0.1)
+            SCAN_DEVICE: iPhone 15 (17.2)
       - store_test_results:
           path: ios/PurchasesHybridCommon/test_output
       - store_artifacts:
@@ -390,9 +390,9 @@ workflows:
       - test-ios-16:
           xcode_version: '14.3.0'
       - test-ios-17:
-          xcode_version: '15.0.0'
+          xcode_version: '15.2.0'
       - check-pods:
-          xcode_version: '14.3.0'
+          xcode_version: '15.2.0'
       - integration-test-ios
       - test-android
       - detekt-android


### PR DESCRIPTION
See also https://github.com/RevenueCat/purchases-ios/pull/3140.

This also updates Xcode 15.0 to 15.2.
