### PR TITLE
Fix getting `rootViewController`

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
@@ -177,7 +177,7 @@ import UIKit
             .first { $0.activationState == .foregroundActive }
 
         guard let windowScene = scene as? UIWindowScene else { return nil }
-        return windowScene.windows.first?.rootViewController
+        return windowScene.keyWindow?.rootViewController
     }
 
 }


### PR DESCRIPTION
As suggested by @MarkVillacampa I changed `windows.first` with `keyWindow`. This was returning null in React Native, which broke the `presentPaywall` and `presentPaywallIfNeeded` functions in 7.16.0

The regression was introduced in #656 