### PR TITLE
Update Android orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,7 @@ jobs:
     executor:
       name: android/android-machine
       resource-class: large
+      tag: default
     working_directory: ~/purchases-hybrid-common/android
     shell: /bin/bash --login -o pipefail
     steps:
@@ -204,6 +205,7 @@ jobs:
     executor:
       name: android/android-machine
       resource-class: large
+      tag: default
     working_directory: ~/purchases-hybrid-common/android
     steps:
       - checkout:
@@ -223,6 +225,7 @@ jobs:
     executor:
       name: android/android-machine
       resource-class: large
+      tag: default
     steps:
       - checkout
       - install-sdkman

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 # https://circleci.com/docs/2.0/testing-ios/
 
 orbs:
-  android: circleci/android@1.0.3
+  android: circleci/android@2.4.0
   revenuecat: revenuecat/sdks-common-config@3.0.0
   macos: circleci/macos@2.0.1
   node: circleci/node@5.1.0


### PR DESCRIPTION
We were using a very old android image (from 2021) which is actually getting deprecated. Updating the version of the orb uses so we use the `default` tag, which automatically gets updated every 3 months with the latest stuff.

<img width="737" alt="Screenshot 2024-01-22 at 14 56 12" src="https://github.com/RevenueCat/purchases-hybrid-common/assets/664544/772310e9-d7e0-4670-a92c-c08a79cd64e2">

https://discuss.circleci.com/t/android-image-deprecations-and-eol-for-2024/50180
