### PR TITLE
`Paywalls`: add methods for presenting paywalls with an offering identifier (Android)

### DIFF
--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
@@ -26,24 +26,7 @@ internal class PaywallFragment : Fragment(), PaywallResultHandler {
             requiredEntitlementIdentifier: String? = null,
             paywallResultListener: PaywallResultListener? = null,
             shouldDisplayDismissButton: Boolean? = null,
-            offering: Offering? = null,
-        ): PaywallFragment {
-            return newInstance(
-                activity,
-                requiredEntitlementIdentifier,
-                paywallResultListener,
-                shouldDisplayDismissButton,
-                offering?.identifier,
-            )
-        }
-
-        @JvmStatic
-        fun newInstance(
-            activity: FragmentActivity,
-            requiredEntitlementIdentifier: String? = null,
-            paywallResultListener: PaywallResultListener? = null,
-            shouldDisplayDismissButton: Boolean? = null,
-            offeringIdentifier: String? = null,
+            paywallSource: PaywallSource,
         ): PaywallFragment {
             val paywallFragmentViewModel = ViewModelProvider(activity)[PaywallFragmentViewModel::class.java]
             paywallFragmentViewModel.paywallResultListener = paywallResultListener
@@ -51,7 +34,11 @@ internal class PaywallFragment : Fragment(), PaywallResultHandler {
                 arguments = Bundle().apply {
                     putString(requiredEntitlementIdentifierKey, requiredEntitlementIdentifier)
                     shouldDisplayDismissButton?.let { putBoolean(shouldDisplayDismissButtonKey, it) }
-                    offeringIdentifier?.let { putString(offeringIdentifierKey, it) }
+                    when (paywallSource) {
+                        is PaywallSource.Offering -> putString(offeringIdentifierKey, paywallSource.value.identifier)
+                        is PaywallSource.OfferingIdentifier -> putString(offeringIdentifierKey, paywallSource.value)
+                        is PaywallSource.DefaultOffering -> Unit
+                    }
                 }
             }
         }

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
@@ -28,13 +28,30 @@ internal class PaywallFragment : Fragment(), PaywallResultHandler {
             shouldDisplayDismissButton: Boolean? = null,
             offering: Offering? = null,
         ): PaywallFragment {
+            return newInstance(
+                activity,
+                requiredEntitlementIdentifier,
+                paywallResultListener,
+                shouldDisplayDismissButton,
+                offering?.identifier,
+            )
+        }
+
+        @JvmStatic
+        fun newInstance(
+            activity: FragmentActivity,
+            requiredEntitlementIdentifier: String? = null,
+            paywallResultListener: PaywallResultListener? = null,
+            shouldDisplayDismissButton: Boolean? = null,
+            offeringIdentifier: String? = null,
+        ): PaywallFragment {
             val paywallFragmentViewModel = ViewModelProvider(activity)[PaywallFragmentViewModel::class.java]
             paywallFragmentViewModel.paywallResultListener = paywallResultListener
             return PaywallFragment().apply {
                 arguments = Bundle().apply {
                     putString(requiredEntitlementIdentifierKey, requiredEntitlementIdentifier)
                     shouldDisplayDismissButton?.let { putBoolean(shouldDisplayDismissButtonKey, it) }
-                    offering?.let { putString(offeringIdentifierKey, it.identifier) }
+                    offeringIdentifier?.let { putString(offeringIdentifierKey, it) }
                 }
             }
         }

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallHelpers.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallHelpers.kt
@@ -24,7 +24,7 @@ fun presentPaywallFromFragment(
             requiredEntitlementIdentifier = requiredEntitlementIdentifier,
             paywallResultListener = paywallResultListener,
             shouldDisplayDismissButton = shouldDisplayDismissButton,
-            offering = offering,
+            paywallSource = offering?.let { PaywallSource.Offering(it) } ?: PaywallSource.DefaultOffering,
         ),
     )
 }
@@ -38,23 +38,13 @@ fun presentPaywallFromFragment(
             .supportFragmentManager
             .beginTransaction()
             .add(
-                if (offeringIdentifier != null) {
-                    PaywallFragment.newInstance(
-                        fragment,
-                        requiredEntitlementIdentifier,
-                        paywallResultListener,
-                        shouldDisplayDismissButton,
-                        offeringIdentifier,
-                    )
-                } else {
-                    PaywallFragment.newInstance(
-                        fragment,
-                        requiredEntitlementIdentifier,
-                        paywallResultListener,
-                        shouldDisplayDismissButton,
-                        offering,
-                    )
-                },
+                PaywallFragment.newInstance(
+                    fragment,
+                    requiredEntitlementIdentifier,
+                    paywallResultListener,
+                    shouldDisplayDismissButton,
+                    paywallSource,
+                ),
                 PaywallFragment.tag,
             )
             .commit()
@@ -62,9 +52,8 @@ fun presentPaywallFromFragment(
 }
 
 data class PresentPaywallOptions(
+    val paywallSource: PaywallSource = PaywallSource.DefaultOffering,
     val requiredEntitlementIdentifier: String? = null,
     val paywallResultListener: PaywallResultListener? = null,
     val shouldDisplayDismissButton: Boolean? = null,
-    val offering: Offering? = null,
-    val offeringIdentifier: String? = null,
 )

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallHelpers.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallHelpers.kt
@@ -8,7 +8,7 @@ import com.revenuecat.purchases.Offering
     message = "Use presentPaywallFromFragment with Options instead",
     replaceWith = ReplaceWith(
         expression = "presentPaywallFromFragment(fragment, options)",
-        imports = ["com.revenuecat.purchases.hybridcommon.ui.presentPaywallFromFragment"]
+        imports = ["com.revenuecat.purchases.hybridcommon.ui.presentPaywallFromFragment"],
     ),
 )
 fun presentPaywallFromFragment(
@@ -25,7 +25,7 @@ fun presentPaywallFromFragment(
             paywallResultListener = paywallResultListener,
             shouldDisplayDismissButton = shouldDisplayDismissButton,
             offering = offering,
-        )
+        ),
     )
 }
 

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallHelpers.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallHelpers.kt
@@ -4,6 +4,13 @@ import androidx.fragment.app.FragmentActivity
 import com.revenuecat.purchases.Offering
 
 @JvmOverloads
+@Deprecated(
+    message = "Use presentPaywallFromFragment with Options instead",
+    replaceWith = ReplaceWith(
+        expression = "presentPaywallFromFragment(fragment, options)",
+        imports = ["com.revenuecat.purchases.hybridcommon.ui.presentPaywallFromFragment"]
+    ),
+)
 fun presentPaywallFromFragment(
     fragment: FragmentActivity,
     requiredEntitlementIdentifier: String? = null,
@@ -11,18 +18,54 @@ fun presentPaywallFromFragment(
     shouldDisplayDismissButton: Boolean? = null,
     offering: Offering? = null,
 ) {
-    fragment
-        .supportFragmentManager
-        .beginTransaction()
-        .add(
-            PaywallFragment.newInstance(
-                fragment,
-                requiredEntitlementIdentifier,
-                paywallResultListener,
-                shouldDisplayDismissButton,
-                offering,
-            ),
-            PaywallFragment.tag,
+    presentPaywallFromFragment(
+        fragment,
+        PresentPaywallOptions(
+            requiredEntitlementIdentifier = requiredEntitlementIdentifier,
+            paywallResultListener = paywallResultListener,
+            shouldDisplayDismissButton = shouldDisplayDismissButton,
+            offering = offering,
         )
-        .commit()
+    )
 }
+
+@JvmOverloads
+fun presentPaywallFromFragment(
+    fragment: FragmentActivity,
+    options: PresentPaywallOptions,
+) {
+    with(options) {
+        fragment
+            .supportFragmentManager
+            .beginTransaction()
+            .add(
+                if (offeringIdentifier != null) {
+                    PaywallFragment.newInstance(
+                        fragment,
+                        requiredEntitlementIdentifier,
+                        paywallResultListener,
+                        shouldDisplayDismissButton,
+                        offeringIdentifier,
+                    )
+                } else {
+                    PaywallFragment.newInstance(
+                        fragment,
+                        requiredEntitlementIdentifier,
+                        paywallResultListener,
+                        shouldDisplayDismissButton,
+                        offering,
+                    )
+                },
+                PaywallFragment.tag,
+            )
+            .commit()
+    }
+}
+
+data class PresentPaywallOptions(
+    val requiredEntitlementIdentifier: String? = null,
+    val paywallResultListener: PaywallResultListener? = null,
+    val shouldDisplayDismissButton: Boolean? = null,
+    val offering: Offering? = null,
+    val offeringIdentifier: String? = null,
+)

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallHelpers.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallHelpers.kt
@@ -29,7 +29,6 @@ fun presentPaywallFromFragment(
     )
 }
 
-@JvmOverloads
 fun presentPaywallFromFragment(
     fragment: FragmentActivity,
     options: PresentPaywallOptions,

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallSource.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallSource.kt
@@ -1,0 +1,9 @@
+package com.revenuecat.purchases.hybridcommon.ui
+
+import com.revenuecat.purchases.Offering as PurchasesOffering
+
+sealed class PaywallSource {
+    class Offering(val value: PurchasesOffering) : PaywallSource()
+    object DefaultOffering : PaywallSource()
+    class OfferingIdentifier(val value: String) : PaywallSource()
+}


### PR DESCRIPTION
Added `newInstance` function that accepts an `offeringIdentifier` instead of an `Offering`