### PR TITLE
`Paywalls`: add methods for presenting paywalls with an offering identifier (iOS)

### DIFF
--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCPaywallProxyAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCPaywallProxyAPITest.m
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 @import PurchasesHybridCommon;
+@import RevenueCat;
+@import UIKit;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,11 +21,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testAPI {
     if (@available(iOS 15.0, *)) {
+        RCOffering *offering;
+
         PaywallProxy *proxy = [PaywallProxy new];
         [proxy presentPaywall];
         [proxy presentPaywallWithDisplayCloseButton:true];
         [proxy presentPaywallWithPaywallResultHandler:^(NSString *result) {}];
         [proxy presentPaywallWithDisplayCloseButton:true paywallResultHandler:^(NSString *result) {}];
+        [proxy presentPaywallWithOffering:offering displayCloseButton:true paywallResultHandler:^(NSString *result) {}];
+        [proxy presentPaywallWithOfferingIdentifier:@"offering" 
+                                 displayCloseButton:true
+                               paywallResultHandler:^(NSString *result) {}];
+
         [proxy presentPaywallIfNeededWithRequiredEntitlementIdentifier:@""];
         [proxy presentPaywallIfNeededWithRequiredEntitlementIdentifier:@"" displayCloseButton:YES];
         [proxy presentPaywallIfNeededWithRequiredEntitlementIdentifier:@""
@@ -31,6 +40,15 @@ NS_ASSUME_NONNULL_BEGIN
         [proxy presentPaywallIfNeededWithRequiredEntitlementIdentifier:@""
                                                     displayCloseButton:true
                                                   paywallResultHandler:^(NSString *result) {}];
+        [proxy presentPaywallIfNeededWithRequiredEntitlementIdentifier:@""
+                                                    offeringIdentifier:@"offering"
+                                                    displayCloseButton:true
+                                                  paywallResultHandler:^(NSString *result) {}];
+
+        __unused UIViewController *view1 = [proxy createPaywallView];
+        __unused UIViewController *view2 = [proxy createPaywallViewWithOfferingIdentifier:@"offering"];
+        __unused UIViewController *footer1 = [proxy createFooterPaywallView];
+        __unused UIViewController *footer2 = [proxy createFooterPaywallViewWithOfferingIdentifier:@"offering"];
     }
 }
 

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCPaywallProxyAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCPaywallProxyAPITest.m
@@ -45,10 +45,10 @@ NS_ASSUME_NONNULL_BEGIN
                                                     displayCloseButton:true
                                                   paywallResultHandler:^(NSString *result) {}];
 
-        __unused UIViewController *view1 = [proxy createPaywallView];
-        __unused UIViewController *view2 = [proxy createPaywallViewWithOfferingIdentifier:@"offering"];
-        __unused UIViewController *footer1 = [proxy createFooterPaywallView];
-        __unused UIViewController *footer2 = [proxy createFooterPaywallViewWithOfferingIdentifier:@"offering"];
+        __unused RCPaywallViewController *view1 = [proxy createPaywallView];
+        __unused RCPaywallViewController *view2 = [proxy createPaywallViewWithOfferingIdentifier:@"offering"];
+        __unused RCPaywallFooterViewController *footer1 = [proxy createFooterPaywallView];
+        __unused RCPaywallFooterViewController *footer2 = [proxy createFooterPaywallViewWithOfferingIdentifier:@"offering"];
     }
 }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
@@ -24,17 +24,17 @@ import UIKit
                                                      result: PaywallResult)] = [:]
 
     @objc
-    public func createPaywallView() -> UIViewController {
+    public func createPaywallView() -> PaywallViewController {
         return PaywallViewController()
     }
 
     @objc
-    public func createPaywallView(offeringIdentifier: String) -> UIViewController {
+    public func createPaywallView(offeringIdentifier: String) -> PaywallViewController {
         return PaywallViewController(offeringIdentifier: offeringIdentifier)
     }
 
     @objc
-    public func createFooterPaywallView() -> UIViewController {
+    public func createFooterPaywallView() -> PaywallFooterViewController {
         let controller = PaywallFooterViewController()
         controller.delegate = self
 
@@ -42,7 +42,7 @@ import UIKit
     }
 
     @objc
-    public func createFooterPaywallView(offeringIdentifier: String) -> UIViewController {
+    public func createFooterPaywallView(offeringIdentifier: String) -> PaywallFooterViewController {
         let controller = PaywallFooterViewController(offeringIdentifier: offeringIdentifier)
         controller.delegate = self
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/PaywallProxy.swift
@@ -25,7 +25,12 @@ import UIKit
 
     @objc
     public func createPaywallView() -> UIViewController {
-        return UIHostingController(rootView: PaywallView())
+        return PaywallViewController()
+    }
+
+    @objc
+    public func createPaywallView(offeringIdentifier: String) -> UIViewController {
+        return PaywallViewController(offeringIdentifier: offeringIdentifier)
     }
 
     @objc
@@ -36,46 +41,28 @@ import UIKit
         return controller
     }
 
-    @available(*, deprecated, message: "Use presentPaywall with paywallResultHandler instead")
     @objc
-    public func presentPaywall() {
-        self.privatePresentPaywall(displayCloseButton: nil, offering: nil)
-    }
+    public func createFooterPaywallView(offeringIdentifier: String) -> UIViewController {
+        let controller = PaywallFooterViewController(offeringIdentifier: offeringIdentifier)
+        controller.delegate = self
 
-    @available(*, deprecated, message: "Use presentPaywall with paywallResultHandler instead")
-    @objc
-    public func presentPaywall(displayCloseButton: Bool) {
-        self.privatePresentPaywall(displayCloseButton: displayCloseButton, offering: nil)
-    }
-
-    @available(*, deprecated, message: "Use presentPaywall with paywallResultHandler instead")
-    @objc
-    public func presentPaywall(offering: Offering) {
-        self.privatePresentPaywall(displayCloseButton: nil, offering: offering)
-    }
-
-    @available(*, deprecated, message: "Use presentPaywall with paywallResultHandler instead")
-    @objc
-    public func presentPaywall(offering: Offering, displayCloseButton: Bool) {
-        self.privatePresentPaywall(displayCloseButton: displayCloseButton, offering: offering)
+        return controller
     }
 
     @objc
     public func presentPaywall(paywallResultHandler: @escaping (String) -> Void) {
-        self.privatePresentPaywall(displayCloseButton: nil, offering: nil, paywallResultHandler: paywallResultHandler)
+        self.privatePresentPaywall(paywallResultHandler: paywallResultHandler)
     }
 
     @objc
     public func presentPaywall(displayCloseButton: Bool, paywallResultHandler: @escaping (String) -> Void) {
         self.privatePresentPaywall(displayCloseButton: displayCloseButton,
-                                   offering: nil,
                                    paywallResultHandler: paywallResultHandler)
     }
 
     @objc
     public func presentPaywall(offering: Offering, paywallResultHandler: @escaping (String) -> Void) {
-        self.privatePresentPaywall(displayCloseButton: nil,
-                                   offering: offering,
+        self.privatePresentPaywall(content: .offering(offering),
                                    paywallResultHandler: paywallResultHandler)
     }
 
@@ -84,35 +71,23 @@ import UIKit
                                displayCloseButton: Bool,
                                paywallResultHandler: @escaping (String) -> Void) {
         self.privatePresentPaywall(displayCloseButton: displayCloseButton,
-                                   offering: offering,
+                                   content: .offering(offering),
                                    paywallResultHandler: paywallResultHandler)
     }
 
-    @available(*, deprecated, message: "Use presentPaywallIfNeeded with paywallResultHandler instead")
     @objc
-    public func presentPaywallIfNeeded(requiredEntitlementIdentifier: String) {
-        self.privatePresentPaywallIfNeeded(requiredEntitlementIdentifier: requiredEntitlementIdentifier,
-                                           displayCloseButton: nil,
-                                           offering: nil,
-                                           paywallResultHandler: nil)
-    }
-
-    @available(*, deprecated, message: "Use presentPaywallIfNeeded with paywallResultHandler instead")
-    @objc
-    public func presentPaywallIfNeeded(requiredEntitlementIdentifier: String, 
-                                       displayCloseButton: Bool) {
-        self.privatePresentPaywallIfNeeded(requiredEntitlementIdentifier: requiredEntitlementIdentifier,
-                                           displayCloseButton: displayCloseButton,
-                                           offering: nil,
-                                           paywallResultHandler: nil)
+    public func presentPaywall(offeringIdentifier: String,
+                               displayCloseButton: Bool,
+                               paywallResultHandler: @escaping (String) -> Void) {
+        self.privatePresentPaywall(displayCloseButton: displayCloseButton,
+                                   content: .offeringIdentifier(offeringIdentifier),
+                                   paywallResultHandler: paywallResultHandler)
     }
 
     @objc
     public func presentPaywallIfNeeded(requiredEntitlementIdentifier: String,
                                        paywallResultHandler: @escaping (String) -> Void) {
         self.privatePresentPaywallIfNeeded(requiredEntitlementIdentifier: requiredEntitlementIdentifier,
-                                           displayCloseButton: nil,
-                                           offering: nil,
                                            paywallResultHandler: paywallResultHandler)
     }
 
@@ -122,13 +97,23 @@ import UIKit
                                        paywallResultHandler: @escaping (String) -> Void) {
         self.privatePresentPaywallIfNeeded(requiredEntitlementIdentifier: requiredEntitlementIdentifier,
                                            displayCloseButton: displayCloseButton,
-                                           offering: nil,
+                                           paywallResultHandler: paywallResultHandler)
+    }
+
+    @objc
+    public func presentPaywallIfNeeded(requiredEntitlementIdentifier: String,
+                                       offeringIdentifier: String,
+                                       displayCloseButton: Bool,
+                                       paywallResultHandler: @escaping (String) -> Void) {
+        self.privatePresentPaywallIfNeeded(requiredEntitlementIdentifier: requiredEntitlementIdentifier,
+                                           displayCloseButton: displayCloseButton,
+                                           content: .offeringIdentifier(offeringIdentifier),
                                            paywallResultHandler: paywallResultHandler)
     }
 
     private func privatePresentPaywallIfNeeded(requiredEntitlementIdentifier: String,
-                                               displayCloseButton: Bool?,
-                                               offering: Offering?,
+                                               displayCloseButton: Bool = false,
+                                               content: Content = .defaultOffering,
                                                paywallResultHandler: ((String) -> Void)? = nil) {
         _ = Task { @MainActor in
             do {
@@ -136,7 +121,7 @@ import UIKit
                 let shouldDisplay = !customerInfo.entitlements.active.keys.contains(requiredEntitlementIdentifier)
                 if shouldDisplay {
                     self.privatePresentPaywall(displayCloseButton: displayCloseButton,
-                                               offering: offering,
+                                               content: content,
                                                paywallResultHandler: paywallResultHandler)
                 } else {
                     paywallResultHandler?(PaywallResult.notPresented.name)
@@ -147,8 +132,8 @@ import UIKit
         }
     }
 
-    private func privatePresentPaywall(displayCloseButton: Bool?,
-                                       offering: Offering?,
+    private func privatePresentPaywall(displayCloseButton: Bool = false,
+                                       content: Content = .defaultOffering,
                                        paywallResultHandler: ((String) -> Void)? = nil) {
         guard let rootController = Self.rootViewController else {
             NSLog("Unable to find root UIViewController")
@@ -156,17 +141,22 @@ import UIKit
         }
 
         let controller: PaywallViewController
-        if let displayCloseButton = displayCloseButton {
+        switch content {
+        case let .offering(offering):
             controller = PaywallViewController(offering: offering, displayCloseButton: displayCloseButton)
-        } else {
-            controller = PaywallViewController()
+        case let .offeringIdentifier(identifier):
+            controller = PaywallViewController(offeringIdentifier: identifier, displayCloseButton: displayCloseButton)
+        case .defaultOffering:
+            controller = PaywallViewController(displayCloseButton: displayCloseButton)
         }
 
         controller.delegate = self
         controller.modalPresentationStyle = .pageSheet
+
         if let paywallResultHandler {
             self.resultByVC[controller] = (paywallResultHandler, .cancelled)
         }
+
         rootController.present(controller, animated: true)
     }
 
@@ -178,6 +168,14 @@ import UIKit
 
         guard let windowScene = scene as? UIWindowScene else { return nil }
         return windowScene.keyWindow?.rootViewController
+    }
+
+    private enum Content {
+
+        case offering(Offering)
+        case offeringIdentifier(String)
+        case defaultOffering
+
     }
 
 }
@@ -212,6 +210,53 @@ extension PaywallProxy: PaywallViewControllerDelegate {
     public func paywallViewController(_ controller: PaywallViewController, 
                                       didChangeSizeTo size: CGSize) {
         self.delegate?.paywallViewController?(controller, didChangeSizeTo: size)
+    }
+
+}
+
+// MARK: - Deprecations
+
+@available(iOS 15.0, *)
+extension PaywallProxy {
+
+    @available(*, deprecated, message: "Use presentPaywall with paywallResultHandler instead")
+    @objc
+    public func presentPaywall() {
+        self.privatePresentPaywall()
+    }
+
+    @available(*, deprecated, message: "Use presentPaywall with paywallResultHandler instead")
+    @objc
+    public func presentPaywall(displayCloseButton: Bool) {
+        self.privatePresentPaywall(displayCloseButton: displayCloseButton)
+    }
+
+    @available(*, deprecated, message: "Use presentPaywall with paywallResultHandler instead")
+    @objc
+    public func presentPaywall(offering: Offering) {
+        self.privatePresentPaywall(content: .offering(offering))
+    }
+
+    @available(*, deprecated, message: "Use presentPaywall with paywallResultHandler instead")
+    @objc
+    public func presentPaywall(offering: Offering, displayCloseButton: Bool) {
+        self.privatePresentPaywall(displayCloseButton: displayCloseButton, content: .offering(offering))
+    }
+
+    @available(*, deprecated, message: "Use presentPaywallIfNeeded with paywallResultHandler instead")
+    @objc
+    public func presentPaywallIfNeeded(requiredEntitlementIdentifier: String) {
+        self.privatePresentPaywallIfNeeded(requiredEntitlementIdentifier: requiredEntitlementIdentifier,
+                                           paywallResultHandler: nil)
+    }
+
+    @available(*, deprecated, message: "Use presentPaywallIfNeeded with paywallResultHandler instead")
+    @objc
+    public func presentPaywallIfNeeded(requiredEntitlementIdentifier: String,
+                                       displayCloseButton: Bool) {
+        self.privatePresentPaywallIfNeeded(requiredEntitlementIdentifier: requiredEntitlementIdentifier,
+                                           displayCloseButton: displayCloseButton,
+                                           paywallResultHandler: nil)
     }
 
 }


### PR DESCRIPTION
Depends on https://github.com/RevenueCat/purchases-ios/pull/3587.

Reopened #666.