### PR TITLE
`CircleCI`: don't skip major bumps

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -70,10 +70,7 @@ lane :automatic_bump do |options|
     UI.message('Skipping automatic bump since the next version doesn\'t include public facing changes')
     next
   end
-  if type_of_bump == :major
-    UI.message('Skipping automatic bump since the next version is a major release')
-    next
-  end
+  
   bump(options)
 end
 


### PR DESCRIPTION
As discussed internally, we want to make it easy to create major version bumps.
