### PR TITLE
`CommonFunctionality`: `purchase` methods also return `StoreTransaction`

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanPurchasePackage.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanPurchasePackage.1.json
@@ -51,5 +51,11 @@
     ],
     "originalApplicationVersion" : "1.0"
   },
-  "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro"
+  "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+  "transaction" : {
+    "productId" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+    "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+    "revenueCatId" : "0",
+    "transactionIdentifier" : "0"
+  }
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanPurchaseProduct.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanPurchaseProduct.1.json
@@ -51,5 +51,11 @@
     ],
     "originalApplicationVersion" : "1.0"
   },
-  "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro"
+  "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+  "transaction" : {
+    "productId" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+    "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+    "revenueCatId" : "0",
+    "transactionIdentifier" : "0"
+  }
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanPurchasePackage.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanPurchasePackage.1.json
@@ -51,5 +51,11 @@
     ],
     "originalApplicationVersion" : "1.0"
   },
-  "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro"
+  "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+  "transaction" : {
+    "productId" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+    "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+    "revenueCatId" : "0",
+    "transactionIdentifier" : "0"
+  }
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanPurchaseProduct.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanPurchaseProduct.1.json
@@ -51,5 +51,11 @@
     ],
     "originalApplicationVersion" : "1.0"
   },
-  "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro"
+  "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+  "transaction" : {
+    "productId" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+    "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+    "revenueCatId" : "0",
+    "transactionIdentifier" : "0"
+  }
 }


### PR DESCRIPTION
This will be used by some hybrids, like for https://github.com/RevenueCat/react-native-purchases/issues/659.