### PR TITLE
Create PaywallListenerWrapper and expose mappers

### DIFF
--- a/android/hybridcommon-ui/build.gradle.kts
+++ b/android/hybridcommon-ui/build.gradle.kts
@@ -43,6 +43,7 @@ android {
 
 dependencies {
     implementation(libs.fragment.ktx)
+    implementation(project(":hybridcommon"))
     api(libs.purchases)
     api(libs.purchases.ui)
     testImplementation(libs.junit)

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallListenerWrapper.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallListenerWrapper.kt
@@ -1,0 +1,42 @@
+package com.revenuecat.purchases.hybridcommon.ui
+
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.hybridcommon.mappers.map
+import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
+
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+abstract class PaywallListenerWrapper : PaywallListener {
+
+    override fun onPurchaseStarted(rcPackage: Package) {
+        this.onPurchaseStarted(rcPackage.map())
+    }
+
+    override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
+        this.onPurchaseCompleted(
+            customerInfo = customerInfo.map(),
+            storeTransaction = storeTransaction.map(),
+        )
+    }
+
+    override fun onPurchaseError(error: PurchasesError) {
+        this.onPurchaseError(error = error.map().info)
+    }
+
+    override fun onRestoreCompleted(customerInfo: CustomerInfo) {
+        this.onRestoreCompleted(customerInfo = customerInfo.map())
+    }
+
+    override fun onRestoreError(error: PurchasesError) {
+        this.onRestoreError(error = error.map().info)
+    }
+
+    abstract fun onPurchaseStarted(rcPackage: Map<String, Any?>)
+    abstract fun onPurchaseCompleted(customerInfo: Map<String, Any?>, storeTransaction: Map<String, Any?>)
+    abstract fun onPurchaseError(error: Map<String, Any?>)
+    abstract fun onRestoreCompleted(customerInfo: Map<String, Any?>)
+    abstract fun onRestoreError(error: Map<String, Any?>)
+}

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -605,22 +605,6 @@ private fun getPurchaseCompletedFunction(onResult: OnResult): (StoreTransaction?
     }
 }
 
-@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-internal fun PurchasesError.map(
-    extra: Map<String, Any?> = mapOf(),
-): ErrorContainer =
-    ErrorContainer(
-        code.code,
-        message,
-        mapOf(
-            "code" to code.code,
-            "message" to message,
-            "readableErrorCode" to code.name,
-            "readable_error_code" to code.name,
-            "underlyingErrorMessage" to (underlyingErrorMessage ?: ""),
-        ) + extra,
-    )
-
 data class ErrorContainer(
     val code: Int,
     val message: String,

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/OfferingsMapper.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/OfferingsMapper.kt
@@ -15,20 +15,20 @@ private fun Offering.map(): Map<String, Any?> =
         "identifier" to identifier,
         "serverDescription" to serverDescription,
         "metadata" to metadata,
-        "availablePackages" to availablePackages.map { it.map(identifier) },
-        "lifetime" to lifetime?.map(identifier),
-        "annual" to annual?.map(identifier),
-        "sixMonth" to sixMonth?.map(identifier),
-        "threeMonth" to threeMonth?.map(identifier),
-        "twoMonth" to twoMonth?.map(identifier),
-        "monthly" to monthly?.map(identifier),
-        "weekly" to weekly?.map(identifier),
+        "availablePackages" to availablePackages.map { it.map() },
+        "lifetime" to lifetime?.map(),
+        "annual" to annual?.map(),
+        "sixMonth" to sixMonth?.map(),
+        "threeMonth" to threeMonth?.map(),
+        "twoMonth" to twoMonth?.map(),
+        "monthly" to monthly?.map(),
+        "weekly" to weekly?.map(),
     )
 
-private fun Package.map(offeringIdentifier: String): Map<String, Any?> =
+fun Package.map(): Map<String, Any?> =
     mapOf(
         "identifier" to identifier,
         "packageType" to packageType.name,
         "product" to product.map(),
-        "offeringIdentifier" to offeringIdentifier,
+        "offeringIdentifier" to offering,
     )

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/PurchasesError.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/PurchasesError.kt
@@ -1,0 +1,19 @@
+package com.revenuecat.purchases.hybridcommon.mappers
+
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.hybridcommon.ErrorContainer
+
+fun PurchasesError.map(
+    extra: Map<String, Any?> = mapOf(),
+): ErrorContainer =
+    ErrorContainer(
+        code.code,
+        message,
+        mapOf(
+            "code" to code.code,
+            "message" to message,
+            "readableErrorCode" to code.name,
+            "readable_error_code" to code.name,
+            "underlyingErrorMessage" to (underlyingErrorMessage ?: ""),
+        ) + extra,
+    )

--- a/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/MappersTests.kt
+++ b/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/MappersTests.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.hybridcommon
 
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.hybridcommon.mappers.map
 import com.revenuecat.purchases.hybridcommon.mappers.toMillis
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
This is needed so the hybrids can have their own `PaywallListener` in their own formats, for example `WriteableMap` in React Native