### PR TITLE
Bump android to 6.9.6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     ext.assertj_version = '3.22.0'
     ext.mockk_version = '1.12.8'
     ext.gradle_maven_publish = '0.22.0'
-    ext.purchases_version = '6.9.5'
+    ext.purchases_version = '6.9.6'
     ext.detekt_version = '1.23.0'
 
     repositories {


### PR DESCRIPTION
This will bump android to 6.9.6, to include the fixes for `DEFERRED` mode not working when using an oldProductId in the format: `productId:basePlanId`. This will be used to create a hotfix in the hybrids.
