### PR TITLE
Add lanes to trigger dependency updates and bump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ eval_gemfile("fastlane/Pluginfile")
 
 gem "cocoapods", "~> 1.15"
 gem 'danger'
+gem 'rest-client'
 gem "lefthook", "~> 1.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,7 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     highline (2.0.3)
+    http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     httpclient (2.8.3)
@@ -251,6 +252,9 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     lefthook (1.6.1)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0206)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.22.1)
@@ -278,6 +282,11 @@ GEM
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (3.1.2)
     rexml (3.2.6)
     rouge (2.0.7)
@@ -335,6 +344,7 @@ DEPENDENCIES
   fastlane-plugin-revenuecat_internal!
   fastlane-plugin-versioning_android
   lefthook (~> 1.6)
+  rest-client
 
 BUNDLED WITH
    2.4.6

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -91,6 +91,16 @@ lane :github_release do |options|
   )
 end
 
+desc "Trigger update dependencies to latest GitHub releases"
+lane :trigger_update_dependencies do
+    trigger_action(action: "dependency-update")
+end
+
+desc "Trigger bump"
+lane :trigger_bump do
+    trigger_action(action: "bump")
+end
+
 desc "Update dependencies to latest GitHub releases and opens a PR"
 lane :open_pr_upgrading_dependencies do |options|
   ensure_git_status_clean
@@ -202,6 +212,32 @@ lane :tag_current_branch do |options|
 
   add_git_tag(tag: version_number)
   push_git_tags(tag: version_number)
+end
+
+private_lane :trigger_action do |options|
+    require 'rest-client'
+
+    # Prompt branch
+    default_branch = git_branch
+    branch = UI.input("Branch (defaults to #{default_branch}): ")
+    branch = default_branch if branch == ""
+
+    # Get CircleCI token
+    circle_token = ENV["CIRCLE_TOKEN"]
+    UI.user_error! "Please set the CIRCLE_TOKEN environment variable" unless circle_token
+
+    # Make request
+    headers = {"Circle-Token": circle_token, "Content-Type": "application/json", "Accept": "application/json"}
+    data = {parameters: {:action => options[:action]}, branch: branch}
+    url = "https://circleci.com/api/v2/project/github/RevenueCat/#{repo_name}/pipeline"
+
+    resp = RestClient.post url, data.to_json, headers
+
+    # Print workflow url
+    number = JSON.parse(resp.body)["number"]
+    workflow_url = "https://app.circleci.com/pipelines/github/RevenueCat/#{repo_name}/#{number}"
+
+    UI.important "Workflow: #{workflow_url}"
 end
 
 desc "Update purchases-ios dependency version"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -45,6 +45,22 @@ Make GitHub release for current version
 
 Make GitHub release for specific version
 
+### trigger_update_dependencies
+
+```sh
+[bundle exec] fastlane trigger_update_dependencies
+```
+
+Trigger update dependencies to latest GitHub releases
+
+### trigger_bump
+
+```sh
+[bundle exec] fastlane trigger_bump
+```
+
+Trigger bump
+
 ### open_pr_upgrading_dependencies
 
 ```sh


### PR DESCRIPTION
Created two lanes, one that triggers a dependency update and one that creates a bump. Inspired by https://github.com/RevenueCat/purchases-ios/blob/b99c8a6f6392038f26c68240a87c50519f053316/fastlane/Fastfile#L458