### PR TITLE
[WIP] Release 10.0.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,7 @@
 In `ios/PurchasesHybridCommon/Podfile` replace:
 
 ```
-  pod 'RevenueCat', '4.37.0'
+  pod 'RevenueCat', '5.0.0-beta.3'
 ```
 
 with:

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -15,12 +15,12 @@ Pod::Spec.new do |s|
 
   s.framework      = 'StoreKit'
 
-  s.dependency 'RevenueCat', '4.40.0'
+  s.dependency 'RevenueCat', '5.0.0-beta.3'
   s.swift_version = '5.7'
 
-  s.ios.deployment_target = '11.0'
-  s.osx.deployment_target = '10.13'
-  s.tvos.deployment_target = '11.0'
+  s.ios.deployment_target = '13.0'
+  s.osx.deployment_target = '10.15'
+  s.tvos.deployment_target = '13.0'
   s.visionos.deployment_target = '1.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }

--- a/PurchasesHybridCommonUI.podspec
+++ b/PurchasesHybridCommonUI.podspec
@@ -16,13 +16,13 @@ Pod::Spec.new do |s|
   s.framework      = 'StoreKit'
   s.framework      = 'SwiftUI'
 
-  s.dependency 'RevenueCatUI', '4.40.0'
+  s.dependency 'RevenueCatUI', '5.0.0-beta.3'
   s.dependency 'PurchasesHybridCommon', s.version.to_s
   s.swift_version = '5.7'
 
-  s.ios.deployment_target = '11.0'
-  s.osx.deployment_target = '10.13'
-  s.tvos.deployment_target = '11.0'
+  s.ios.deployment_target = '13.0'
+  s.osx.deployment_target = '10.15'
+  s.tvos.deployment_target = '13.0'
   s.visionos.deployment_target = '1.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCPurchases+HybridAdditionsAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCPurchases+HybridAdditionsAPITest.m
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                  userDefaultsSuiteName:nil
                                                         platformFlavor:nil
                                                  platformFlavorVersion:@""
-                                              usesStoreKit2IfAvailable:YES
+                                                       storeKitVersion:@""
                                                      dangerousSettings:nil
                                   shouldShowInAppMessagesAutomatically:NO
                                                       verificationMode:@""];
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                   userDefaultsSuiteName:nil
                                                          platformFlavor:nil
                                                   platformFlavorVersion:@""
-                                               usesStoreKit2IfAvailable:YES
+                                                        storeKitVersion:@""
                                                       dangerousSettings:nil
                                    shouldShowInAppMessagesAutomatically:NO];
 }

--- a/ios/PurchasesHybridCommon/Podfile
+++ b/ios/PurchasesHybridCommon/Podfile
@@ -1,10 +1,10 @@
 # Uncomment the next line to define a global platform for your project
 
 target 'PurchasesHybridCommon' do
-  platform :ios, '11.0'
+  platform :ios, '13.0'
   use_frameworks!
 
-  pod 'RevenueCat', '4.40.0'
+  pod 'RevenueCat', '5.0.0-beta.3'
 
   target 'PurchasesHybridCommonTests' do
     # Pods for testing
@@ -21,18 +21,18 @@ target 'PurchasesHybridCommon' do
 end
 
 target 'PurchasesHybridCommonUI' do
-  platform :ios, '11.0'
+  platform :ios, '13.0'
   use_frameworks!
 
-  pod 'RevenueCat', '4.40.0'
-  pod 'RevenueCatUI', '4.40.0'
+  pod 'RevenueCat', '5.0.0-beta.3'
+  pod 'RevenueCatUI', '5.0.0-beta.3'
 
 end
 
 target 'ObjCAPITester' do
-  platform :ios, '11.0'
+  platform :ios, '13.0'
   use_frameworks!
 
-  pod 'RevenueCat', '4.40.0'
-  pod 'RevenueCatUI', '4.40.0'
+  pod 'RevenueCat', '5.0.0-beta.3'
+  pod 'RevenueCatUI', '5.0.0-beta.3'
 end

--- a/ios/PurchasesHybridCommon/Podfile.lock
+++ b/ios/PurchasesHybridCommon/Podfile.lock
@@ -1,26 +1,15 @@
 PODS:
   - Nimble (10.0.0)
   - Quick (5.0.1)
-<<<<<<< HEAD
-  - RevenueCat (4.40.0)
-  - RevenueCatUI (4.40.0):
-    - RevenueCat (= 4.40.0)
-=======
   - RevenueCat (5.0.0-beta.3)
   - RevenueCatUI (5.0.0-beta.3):
     - RevenueCat (= 5.0.0-beta.3)
->>>>>>> f9ebfaa (Bump iOS SDK to 5.0.0-beta.3)
 
 DEPENDENCIES:
   - Nimble
   - Quick
-<<<<<<< HEAD
-  - RevenueCat (= 4.40.0)
-  - RevenueCatUI (= 4.40.0)
-=======
   - RevenueCat (= 5.0.0-beta.3)
   - RevenueCatUI (= 5.0.0-beta.3)
->>>>>>> f9ebfaa (Bump iOS SDK to 5.0.0-beta.3)
 
 SPEC REPOS:
   trunk:
@@ -32,16 +21,9 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
-<<<<<<< HEAD
-  RevenueCat: f33d2bb58e75afc68d3a8cf193971f008f553a2c
-  RevenueCatUI: f3c05c088452b96b9acc33f048459497b5615391
-
-PODFILE CHECKSUM: 4b67add96f8b3745ceda538d67c47f31f39f3886
-=======
   RevenueCat: 40e259013468caf616c49cd67a78e5754f123547
   RevenueCatUI: 7b9d1cc5ca8e5eabb92be8ee39c7c2352561041d
 
 PODFILE CHECKSUM: 11ffe426600ae69e83dbf1bbabf1c7afcc3244ca
->>>>>>> f9ebfaa (Bump iOS SDK to 5.0.0-beta.3)
 
 COCOAPODS: 1.15.2

--- a/ios/PurchasesHybridCommon/Podfile.lock
+++ b/ios/PurchasesHybridCommon/Podfile.lock
@@ -1,15 +1,26 @@
 PODS:
   - Nimble (10.0.0)
   - Quick (5.0.1)
+<<<<<<< HEAD
   - RevenueCat (4.40.0)
   - RevenueCatUI (4.40.0):
     - RevenueCat (= 4.40.0)
+=======
+  - RevenueCat (5.0.0-beta.3)
+  - RevenueCatUI (5.0.0-beta.3):
+    - RevenueCat (= 5.0.0-beta.3)
+>>>>>>> f9ebfaa (Bump iOS SDK to 5.0.0-beta.3)
 
 DEPENDENCIES:
   - Nimble
   - Quick
+<<<<<<< HEAD
   - RevenueCat (= 4.40.0)
   - RevenueCatUI (= 4.40.0)
+=======
+  - RevenueCat (= 5.0.0-beta.3)
+  - RevenueCatUI (= 5.0.0-beta.3)
+>>>>>>> f9ebfaa (Bump iOS SDK to 5.0.0-beta.3)
 
 SPEC REPOS:
   trunk:
@@ -21,9 +32,16 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
+<<<<<<< HEAD
   RevenueCat: f33d2bb58e75afc68d3a8cf193971f008f553a2c
   RevenueCatUI: f3c05c088452b96b9acc33f048459497b5615391
 
 PODFILE CHECKSUM: 4b67add96f8b3745ceda538d67c47f31f39f3886
+=======
+  RevenueCat: 40e259013468caf616c49cd67a78e5754f123547
+  RevenueCatUI: 7b9d1cc5ca8e5eabb92be8ee39c7c2352561041d
+
+PODFILE CHECKSUM: 11ffe426600ae69e83dbf1bbabf1c7afcc3244ca
+>>>>>>> f9ebfaa (Bump iOS SDK to 5.0.0-beta.3)
 
 COCOAPODS: 1.15.2

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		35F6FD602673FE5600ABCB53 /* ErrorContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F6FD5F2673FE5600ABCB53 /* ErrorContainerTests.swift */; };
 		37E357D5014169A093450AD5 /* MockPurchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E351F858AE15D5BD2EAA5A /* MockPurchases.swift */; };
 		3F7F287D27E208F39745436C /* Pods_ObjCAPITester.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FAA49047A2AE8963CF73C94 /* Pods_ObjCAPITester.framework */; };
+		4D322E642B83BC650004AF53 /* StoreKitVersion+HybridAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D322E632B83BC650004AF53 /* StoreKitVersion+HybridAdditions.swift */; };
+		4D6276F42B8A0AD30062E553 /* StoreKitVersion+HybridAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6276F32B8A0AD30062E553 /* StoreKitVersion+HybridAdditionsTests.swift */; };
 		4F7974562B5EDDEF003085E7 /* PaywallProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F72072B2AF310390017395F /* PaywallProxy.swift */; };
 		4F79745C2B5EDDEF003085E7 /* PaywallResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFF59942B46D1450022FD77 /* PaywallResult.swift */; };
 		4F79746A2B5EDF82003085E7 /* PurchasesHybridCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D54BF002437AD5800FF4EE4 /* PurchasesHybridCommon.framework */; };
@@ -158,6 +160,8 @@
 		35F6FD5F2673FE5600ABCB53 /* ErrorContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorContainerTests.swift; sourceTree = "<group>"; };
 		37E351F858AE15D5BD2EAA5A /* MockPurchases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockPurchases.swift; sourceTree = "<group>"; };
 		460EB988CBB68111D4CF19A2 /* Pods-PurchasesHybridCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommon.debug.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommon/Pods-PurchasesHybridCommon.debug.xcconfig"; sourceTree = "<group>"; };
+		4D322E632B83BC650004AF53 /* StoreKitVersion+HybridAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitVersion+HybridAdditions.swift"; sourceTree = "<group>"; };
+		4D6276F32B8A0AD30062E553 /* StoreKitVersion+HybridAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitVersion+HybridAdditionsTests.swift"; sourceTree = "<group>"; };
 		4E8CDB8D703EA998D72761BB /* Pods-PurchasesHybridCommonTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommonTests.debug.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommonTests/Pods-PurchasesHybridCommonTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4F72072B2AF310390017395F /* PaywallProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallProxy.swift; sourceTree = "<group>"; };
 		4F7974672B5EDDEF003085E7 /* PurchasesHybridCommonUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PurchasesHybridCommonUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -290,6 +294,7 @@
 				2D0D207F245797B900614E47 /* Date+HybridAdditionsTests.swift */,
 				2D44523D2491198A006AA26F /* CustomerInfo+HybridAdditionsTests.swift */,
 				2CC09B242A27E35B0047DA34 /* Offering+HybridAdditionsTests.swift */,
+				4D6276F32B8A0AD30062E553 /* StoreKitVersion+HybridAdditionsTests.swift */,
 				2D44524024916501006AA26F /* PurchasesHybridCommonTests.swift */,
 				35F6FD5F2673FE5600ABCB53 /* ErrorContainerTests.swift */,
 				2DD3D1842810A81F00A19EC6 /* XCTestCase+Expectations.swift */,
@@ -337,6 +342,7 @@
 				2D4FDFE428073A9300863298 /* EntitlementInfo+HybridAdditions.swift */,
 				57AD0D7928733B0C000932FF /* NonSubscriptionTransaction+HybridAdditions.swift */,
 				2D4FDFE62807436200863298 /* StoreTransaction+HybridAdditions.swift */,
+				4D322E632B83BC650004AF53 /* StoreKitVersion+HybridAdditions.swift */,
 				2D4FDFEA28074C3800863298 /* EntitlementInfos+HybridAdditions.swift */,
 				4FBD2DA62A4B7D8300C8A0FB /* EntitlementVerificationMode+HybridAdditions.swift */,
 				2D4FDFEC28074EB900863298 /* ErrorContainer.swift */,
@@ -848,6 +854,7 @@
 				2DD3D1902810AF5A00A19EC6 /* StoreProduct+HybridAdditions.swift in Sources */,
 				4FBD2DA72A4B7D8300C8A0FB /* EntitlementVerificationMode+HybridAdditions.swift in Sources */,
 				2DD3D1872810AF5A00A19EC6 /* ErrorContainer.swift in Sources */,
+				4D322E642B83BC650004AF53 /* StoreKitVersion+HybridAdditions.swift in Sources */,
 				2DD3D18F2810AF5A00A19EC6 /* EntitlementInfo+HybridAdditions.swift in Sources */,
 				2DD3D1922810AF5A00A19EC6 /* PromotionalOffer+HybridAdditions.swift in Sources */,
 				2DD3D1862810AF5A00A19EC6 /* Package+HybridAdditions.swift in Sources */,
@@ -887,6 +894,7 @@
 				2DC85B58246B2A7B003CD22E /* PurchasesHybridAdditionsTests.swift in Sources */,
 				FD31DE772841420000C0CA3A /* CustomerInfo+TestExtensions.swift in Sources */,
 				2D6E333C2450F7A60022A971 /* StoreProductDiscount+HybridAdditionsTests.swift in Sources */,
+				4D6276F42B8A0AD30062E553 /* StoreKitVersion+HybridAdditionsTests.swift in Sources */,
 				2D44523E2491198A006AA26F /* CustomerInfo+HybridAdditionsTests.swift in Sources */,
 				35F6FD602673FE5600ABCB53 /* ErrorContainerTests.swift in Sources */,
 				37E357D5014169A093450AD5 /* MockPurchases.swift in Sources */,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
@@ -1047,13 +1047,12 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 RevenueCat. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.ObjCAPITester;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1062,10 +1061,8 @@
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = "1,2,6";
-				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Debug;
 		};
@@ -1087,13 +1084,12 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 RevenueCat. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.ObjCAPITester;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1102,10 +1098,8 @@
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = "1,2,6";
-				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Release;
 		};
@@ -1118,20 +1112,16 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = PurchasesHybridCommonTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.PurchasesHybridCommonTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TVOS_DEPLOYMENT_TARGET = 11.2;
-				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Debug;
 		};
@@ -1144,20 +1134,16 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = PurchasesHybridCommonTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.PurchasesHybridCommonTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TVOS_DEPLOYMENT_TARGET = 11.2;
-				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Release;
 		};
@@ -1211,15 +1197,15 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
-				TVOS_DEPLOYMENT_TARGET = 11.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
@@ -1269,14 +1255,14 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
-				TVOS_DEPLOYMENT_TARGET = 11.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 				VALIDATE_PRODUCT = YES;
 				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 				XROS_DEPLOYMENT_TARGET = 1.0;

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -694,6 +694,13 @@ private extension CommonFunctionality {
         return ErrorContainer(error: error, extraPayload: extraPayload)
     }
 
+    static func transactionNotFoundError(description: String, userCancelled: Bool?) -> ErrorContainer {
+        let error = NSError(domain: ErrorCode.errorDomain,
+                            code: ErrorCode.unknownError.rawValue,
+                            userInfo: [NSLocalizedDescriptionKey: description])
+        return Self.createErrorContainer(error: error, userCancelled: userCancelled)
+    }
+
 }
 
 // MARK: - Encoding
@@ -725,7 +732,10 @@ private extension CommonFunctionality {
                     completion?(nil, ErrorContainer(error: error, extraPayload: [:]))
                 }
             } else {
-                completion?(nil, nil)
+                completion?(nil, transactionNotFoundError(
+                    description: "Couldn't find transaction for product ID '\(productID)'.",
+                    userCancelled: false
+                ))
             }
         }
     }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -41,7 +41,7 @@ import RevenueCat
         set {
             if let value = newValue {
                 let url: URL?
-                // Starting with iOS 17, URL(string:) returns a non-nil value from invalid URLs. 
+                // Starting with iOS 17, URL(string:) returns a non-nil value from invalid URLs.
                 // So we use a new method to get the old behavior.
                 // Since the new method isn't recognized by older Xcodes, we use Swift 5.9 as a proxy for Xcode 15+.
                 // https://developer.apple.com/documentation/xcode-release-notes/xcode-15_0-release-notes
@@ -266,17 +266,14 @@ import RevenueCat
             }
 
             if let signedDiscountTimestamp = signedDiscountTimestamp {
-                if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) {
-                    guard let promotionalOffer = self.promoOffersByTimestamp[signedDiscountTimestamp] else {
-                        completion(nil, productNotFoundError(description: "Couldn't find discount.", userCancelled: false))
-                        return
-                    }
-                    Self.sharedInstance.purchase(product: storeProduct,
-                                              promotionalOffer: promotionalOffer,
-                                              completion: hybridCompletion)
+                guard let promotionalOffer = self.promoOffersByTimestamp[signedDiscountTimestamp] else {
+                    completion(nil, productNotFoundError(description: "Couldn't find discount.", userCancelled: false))
                     return
                 }
-
+                Self.sharedInstance.purchase(product: storeProduct,
+                                            promotionalOffer: promotionalOffer,
+                                            completion: hybridCompletion)
+                return
             }
 
             Self.sharedInstance.purchase(product: storeProduct, completion: hybridCompletion)
@@ -301,17 +298,14 @@ import RevenueCat
             }
 
             if let signedDiscountTimestamp = signedDiscountTimestamp {
-                if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) {
-                    guard let promotionalOffer = self.promoOffersByTimestamp[signedDiscountTimestamp] else {
-                        completion(nil, productNotFoundError(description: "Couldn't find discount.", userCancelled: false))
-                        return
-                    }
-                    Self.sharedInstance.purchase(package: package,
-                                                 promotionalOffer: promotionalOffer,
-                                                 completion: hybridCompletion)
+                guard let promotionalOffer = self.promoOffersByTimestamp[signedDiscountTimestamp] else {
+                    completion(nil, productNotFoundError(description: "Couldn't find discount.", userCancelled: false))
                     return
                 }
-
+                Self.sharedInstance.purchase(package: package,
+                                                promotionalOffer: promotionalOffer,
+                                                completion: hybridCompletion)
+                return
             }
 
             Self.sharedInstance.purchase(package: package, completion: hybridCompletion)
@@ -461,13 +455,6 @@ import RevenueCat
     static func promotionalOffer(for productIdentifier: String,
                                  discountIdentifier: String?,
                                  completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) else {
-            completion(
-                nil,
-                Self.createErrorContainer(error: ErrorCode.unsupportedError)
-            )
-            return
-        }
 
         product(with: productIdentifier) { storeProduct in
             guard let storeProduct = storeProduct else {
@@ -664,7 +651,6 @@ private extension CommonFunctionality {
         }
     }
 
-    @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *)
     static func discount(with identifier: String?, for product: StoreProduct) -> StoreProductDiscount? {
         if identifier == nil {
             return product.discounts.first

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -708,3 +708,26 @@ private extension CommonFunctionality {
     }
 
 }
+
+// MARK: StoreKit 2 Observer Mode
+@objc public extension CommonFunctionality {
+
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+    @objc(handleObserverModeTransactionForProductID:completion:) 
+    static func handleObserverModeTransaction(productID: String, completion: (([String: Any]?, ErrorContainer?) -> Void)?) {
+        _ = Task<Void, Never> {
+            let result = await StoreKit.Transaction.latest(for: productID)
+            if let result = result {
+                do {
+                    let transaction = try await Self.sharedInstance.handleObserverModeTransaction(.success(result))
+                    completion?(transaction?.dictionary, nil)
+                } catch {
+                    completion?(nil, ErrorContainer(error: error, extraPayload: [:]))
+                }
+            } else {
+                completion?(nil, nil)
+            }
+        }
+    }
+
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementInfo+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementInfo+HybridAdditions.swift
@@ -13,11 +13,6 @@ internal extension EntitlementInfo {
 
     var dictionary: [String: Any] {
         let verificationResult: VerificationResult
-        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-            verificationResult = verification
-        } else {
-            verificationResult = .notRequested
-        }
         return [
             "identifier": identifier,
             "isActive": isActive,
@@ -38,7 +33,7 @@ internal extension EntitlementInfo {
             "billingIssueDetectedAt": billingIssueDetectedAt?.rc_formattedAsISO8601() ?? NSNull(),
             "billingIssueDetectedAtMillis": billingIssueDetectedAt?.rc_millisecondsSince1970AsDouble() ?? NSNull(),
             "ownershipType": ownershipTypeString,
-            "verification": verificationResult.name
+            "verification": verification.name
         ]
     }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementInfo+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementInfo+HybridAdditions.swift
@@ -12,7 +12,6 @@ import RevenueCat
 internal extension EntitlementInfo {
 
     var dictionary: [String: Any] {
-        let verificationResult: VerificationResult
         return [
             "identifier": identifier,
             "isActive": isActive,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementInfos+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementInfos+HybridAdditions.swift
@@ -12,16 +12,10 @@ import RevenueCat
 internal extension EntitlementInfos {
 
     var dictionary: [String: Any] {
-        let verificationResult: VerificationResult
-        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-            verificationResult = verification
-        } else {
-            verificationResult = .notRequested
-        }
         return [
             "all": all.mapValues { $0.dictionary },
             "active": active.mapValues { $0.dictionary },
-            "verification": verificationResult.name
+            "verification": verification.name
         ]
     }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/NSDate+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/NSDate+HybridAdditions.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-// note: This extension is only temporary, since we're
-// dropping iOS 11 in the upcoming major
 extension Date {
 
     func rc_formattedAsISO8601() -> String {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
@@ -35,7 +35,7 @@ import RevenueCat
         if let appUserID = appUserID {
             configurationBuilder = configurationBuilder.with(appUserID: appUserID)
         }
-        configurationBuilder = configurationBuilder.with(observerMode: observerMode)
+        configurationBuilder = configurationBuilder.with(observerMode: observerMode, storeKitVersion: usesStoreKit2IfAvailable ? .storeKit2 : .storeKit1)
         if let userDefaults = userDefaults {
             configurationBuilder = configurationBuilder.with(userDefaults: userDefaults)
         }
@@ -54,9 +54,7 @@ import RevenueCat
 
         if let verificationMode {
             if let mode = Configuration.EntitlementVerificationMode(name: verificationMode) {
-                if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-                    configurationBuilder = configurationBuilder.with(entitlementVerificationMode: mode)
-                }
+                configurationBuilder = configurationBuilder.with(entitlementVerificationMode: mode)
             } else {
                 NSLog("Attempted to configure with unknown verification mode: '\(verificationMode)'")
             }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/Purchases+HybridAdditions.swift
@@ -35,13 +35,16 @@ import RevenueCat
         if let appUserID = appUserID {
             configurationBuilder = configurationBuilder.with(appUserID: appUserID)
         }
-        configurationBuilder = configurationBuilder.with(observerMode: observerMode, storeKitVersion: usesStoreKit2IfAvailable ? .storeKit2 : .storeKit1)
+        configurationBuilder = configurationBuilder.with(
+            observerMode: observerMode, 
+            storeKitVersion: usesStoreKit2IfAvailable ? .storeKit2 : .storeKit1
+        )
         if let userDefaults = userDefaults {
             configurationBuilder = configurationBuilder.with(userDefaults: userDefaults)
         }
-        configurationBuilder = (configurationBuilder as ConfigurationBuilderDeprecatable)
-            // Allows silencing deprecation warning, so `pod lib lint` does not fail.
-            .with(usesStoreKit2IfAvailable: usesStoreKit2IfAvailable)
+        configurationBuilder = configurationBuilder.with(
+            storeKitVersion: usesStoreKit2IfAvailable ? .storeKit2 : .storeKit1
+        )
         if let dangerousSettings = dangerousSettings {
             configurationBuilder = configurationBuilder.with(dangerousSettings: dangerousSettings)
         }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreKitVersion+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreKitVersion+HybridAdditions.swift
@@ -1,0 +1,34 @@
+//
+//  StoreKitVersion+HybridAdditions.swift
+//  PurchasesHybridCommon
+//
+//  Created by mark on 19/2/24.
+//  Copyright © 2024 RevenueCat. All rights reserved.
+//
+
+import RevenueCat
+
+public extension StoreKitVersion {
+
+    var name: String {
+        switch self {
+        case .storeKit1: return "STOREKIT_1"
+        case .storeKit2: return "STOREKIT_2"
+        }
+    }
+
+    init?(name: String) {
+        if let mode = Self.modesByName[name] {
+            self = mode
+        } else {
+            return nil
+        }
+    }
+
+    private static let modesByName: [String: Self] = [
+        "DEFAULT": Self.default,
+        Self.storeKit1.name: Self.storeKit1,
+        Self.storeKit2.name: Self.storeKit2,
+    ]
+
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProduct+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProduct+HybridAdditions.swift
@@ -27,19 +27,14 @@ internal extension StoreProduct {
             "subscriptionPeriod": NSNull(),
         ]
 
-        if #available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *),
-           let introductoryDiscount = self.introductoryDiscount {
+        if let introductoryDiscount = self.introductoryDiscount {
             dictionary["introPrice"] = introductoryDiscount.rc_dictionary
         }
 
-        if #available(iOS 12.2, tvOS 12.2, macOS 10.14.4, *) {
-            dictionary["discounts"] = self.discounts.map { $0.rc_dictionary }
-        }
+        dictionary["discounts"] = self.discounts.map { $0.rc_dictionary }
 
-        if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *) {
-            if let subscriptionPeriod = self.subscriptionPeriod {
-                dictionary["subscriptionPeriod"] = StoreProduct.rc_normalized(subscriptionPeriod: subscriptionPeriod)
-            }
+        if let subscriptionPeriod = self.subscriptionPeriod {
+            dictionary["subscriptionPeriod"] = StoreProduct.rc_normalized(subscriptionPeriod: subscriptionPeriod)
         }
 
         return dictionary

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProductDiscount+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProductDiscount+HybridAdditions.swift
@@ -26,11 +26,9 @@ internal extension StoreProductDiscount {
             "periodNumberOfUnits": subscriptionPeriod.value,
             "cycles": numberOfPeriods
         ]
-        
-        if #available(iOS 12.2, tvOS 12.2, macOS 10.14.4, *) {
-            if offerIdentifier != nil {
-                dictionary["identifier"] = offerIdentifier
-            }
+
+        if offerIdentifier != nil {
+            dictionary["identifier"] = offerIdentifier
         }
         return dictionary
     }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class BaseIntegrationTests: XCTestCase {
 
-    class var storeKit2Setting: StoreKit2Setting {
+    class var storeKitVersion: StoreKitVersion {
         return .default
     }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
@@ -69,7 +69,7 @@ private extension BaseIntegrationTests {
             userDefaultsSuiteName: Constants.userDefaultsSuiteName,
             platformFlavor: nil,
             platformFlavorVersion: nil,
-            usesStoreKit2IfAvailable: Self.storeKitVersion == .storeKit2,
+            storeKitVersion: Self.storeKitVersion.name,
             dangerousSettings: self.dangerousSettings
         )
         Purchases.logLevel = .debug

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
@@ -69,7 +69,7 @@ private extension BaseIntegrationTests {
             userDefaultsSuiteName: Constants.userDefaultsSuiteName,
             platformFlavor: nil,
             platformFlavorVersion: nil,
-            usesStoreKit2IfAvailable: Self.storeKit2Setting == .enabledForCompatibleDevices,
+            usesStoreKit2IfAvailable: Self.storeKitVersion == .storeKit2,
             dangerousSettings: self.dangerousSettings
         )
         Purchases.logLevel = .debug

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
@@ -16,6 +16,10 @@ class BaseIntegrationTests: XCTestCase {
         return .default
     }
 
+    class var observerMode: Bool {
+        return false
+    }
+
     override func setUp() async throws {
         try await super.setUp()
 
@@ -65,7 +69,7 @@ private extension BaseIntegrationTests {
         _ = Purchases.configure(
             apiKey: Constants.apiKey,
             appUserID: nil,
-            observerMode: false,
+            observerMode: Self.observerMode,
             userDefaultsSuiteName: Constants.userDefaultsSuiteName,
             platformFlavor: nil,
             platformFlavorVersion: nil,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
 
-    override class var storeKit2Setting: StoreKit2Setting { return .enabledForCompatibleDevices }
+    override class var storeKitVersion: StoreKitVersion { return .storeKit2 }
 
 }
 
@@ -53,8 +53,8 @@ class StoreKit1IntegrationTests: BaseIntegrationTests {
         _ = try await CommonFunctionality.offerings()
     }
 
-    override class var storeKit2Setting: StoreKit2Setting {
-        return .disabled
+    override class var storeKitVersion: StoreKitVersion {
+        return .storeKit1
     }
 
     func testCanGetOfferings() async throws {
@@ -116,7 +116,7 @@ class StoreKit1IntegrationTests: BaseIntegrationTests {
     }
 
     func testTrialOrIntroductoryPriceEligibility() async throws {
-        if Self.storeKit2Setting == .disabled {
+        if Self.storeKitVersion == .storeKit1 {
             // SK1 implementation relies on the receipt being loaded already.
             // See `TrialOrIntroPriceEligibilityChecker.sk1CheckEligibility`
             _ = try await CommonFunctionality.restorePurchases()
@@ -129,7 +129,6 @@ class StoreKit1IntegrationTests: BaseIntegrationTests {
         await self.assertSnapshot(result)
     }
 
-    @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *)
     func testIneligibleForPromotionalOfferByDefault() async {
         do {
             _ = try await CommonFunctionality.promotionalOffer(
@@ -143,7 +142,6 @@ class StoreKit1IntegrationTests: BaseIntegrationTests {
         }
     }
 
-    @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *)
     func testPromotionalOffer() async throws {
         try await self.purchaseMonthlyOffering()
         try self.testSession.expireSubscription(productIdentifier: Self.productIdentifier)
@@ -157,7 +155,6 @@ class StoreKit1IntegrationTests: BaseIntegrationTests {
         await self.assertSnapshot(result)
     }
 
-    @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *)
     func testIneligibleForPromotionalError() async throws {
         do {
             _ = try await CommonFunctionality.promotionalOffer(
@@ -181,7 +178,7 @@ private extension StoreKit1IntegrationTests {
         file: StaticString = #file,
         line: UInt = #line
     ) {
-        let name = "\(Self.storeKit2Setting.testSuffix)-\(testName)"
+        let name = "SK\(Self.storeKitVersion.debugDescription)-\(testName)"
         SnapshotTesting.assertSnapshot(matching: value,
                                        as: .json,
                                        file: file,
@@ -235,17 +232,6 @@ private extension StoreKit1IntegrationTests {
             product: productIdentifier,
             signedDiscountTimestamp: nil
         )
-    }
-
-}
-
-private extension StoreKit2Setting {
-
-    var testSuffix: String {
-        switch self {
-        case .disabled, .enabledOnlyForOptimizations: return "SK1"
-        case .enabledForCompatibleDevices: return "SK2"
-        }
     }
 
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
@@ -25,7 +25,7 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit2IntegrationTests {
 
     override class var observerMode: Bool { true }
 
-    func testHandleObserverMoveTransaction() async throws {
+    func testHandleObserverModeTransaction() async throws {
         _ = try await Product.products(for: [Self.productIdentifier]).first?.purchase()
 
         let (dict, error) = try await withCheckedThrowingContinuation { continuation in
@@ -39,6 +39,15 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit2IntegrationTests {
         await self.assertSnapshot(unwrappedDict)
     }
 
+    func testHandleObserverModeTransactionMissingTransaction() async throws {
+        let (dict, error) = try await withCheckedThrowingContinuation { continuation in
+            CommonFunctionality.handleObserverModeTransaction(productID: "invalid_product_id") { (dict, error) in
+                continuation.resume(returning: (dict, error))
+            }
+        }
+        expect(error?.error).to(matchError(ErrorCode.unknownError))
+        expect(dict).to(beNil())
+    }
 }
 
 class StoreKit1IntegrationTests: BaseIntegrationTests {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/StoreKitIntegrationTests.swift
@@ -21,6 +21,26 @@ class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
 
 }
 
+class StoreKit2ObserverModeIntegrationTests: StoreKit2IntegrationTests {
+
+    override class var observerMode: Bool { true }
+
+    func testHandleObserverMoveTransaction() async throws {
+        _ = try await Product.products(for: [Self.productIdentifier]).first?.purchase()
+
+        let (dict, error) = try await withCheckedThrowingContinuation { continuation in
+            CommonFunctionality.handleObserverModeTransaction(productID: Self.productIdentifier) { (dict, error) in
+                continuation.resume(returning: (dict, error))
+            }
+        }
+        expect(error).to(beNil())
+        var unwrappedDict = try XCTUnwrap(dict)
+        removeDates(&unwrappedDict)
+        await self.assertSnapshot(unwrappedDict)
+    }
+
+}
+
 class StoreKit1IntegrationTests: BaseIntegrationTests {
 
     private var testSession: SKTestSession!

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanPurchasePackage.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanPurchasePackage.1.json
@@ -49,7 +49,7 @@
     "nonSubscriptionTransactions" : [
 
     ],
-    "originalApplicationVersion" : "1.0"
+    "originalApplicationVersion" : null
   },
   "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
   "transaction" : {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanPurchaseProduct.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanPurchaseProduct.1.json
@@ -49,7 +49,7 @@
     "nonSubscriptionTransactions" : [
 
     ],
-    "originalApplicationVersion" : "1.0"
+    "originalApplicationVersion" : null
   },
   "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
   "transaction" : {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testHandleObserverMoveTransaction.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testHandleObserverMoveTransaction.1.json
@@ -1,0 +1,6 @@
+{
+  "productId" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+  "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+  "revenueCatId" : "0",
+  "transactionIdentifier" : "0"
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testLogInAndLogOut.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testLogInAndLogOut.1.json
@@ -22,6 +22,8 @@
     "nonSubscriptionTransactions" : [
 
     ],
-    "originalApplicationVersion" : "1.0"
+    "originalApplicationVersion" : null,
+    "originalPurchaseDate" : null,
+    "originalPurchaseDateMillis" : null
   }
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
@@ -666,4 +666,11 @@ extension MockPurchases: PurchasesSwiftType {
         fatalError("Not mocked")
     }
 
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+    func handleObserverModeTransaction(
+        _ purchaseResult: Product.PurchaseResult
+    ) async throws -> RevenueCat.StoreTransaction? {
+        fatalError("Not mocked")
+    }
+
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
@@ -12,7 +12,7 @@ final class MockPurchases: PurchasesType {
     var cachedCustomerInfo: RevenueCat.CustomerInfo?
 
     var cachedOfferings: RevenueCat.Offerings?
-    
+
     var delegate: RevenueCat.PurchasesDelegate?
 
     init() {}
@@ -568,9 +568,8 @@ extension MockPurchases {
 
 }
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 extension MockPurchases: PurchasesSwiftType {
-    
+
     var customerInfoStream: AsyncStream<CustomerInfo> {
         fatalError("This method is not mocked")
     }
@@ -635,7 +634,6 @@ extension MockPurchases: PurchasesSwiftType {
         fatalError("Not mocked")
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func eligiblePromotionalOffers(forProduct product: StoreProduct) async -> [PromotionalOffer] {
         fatalError("This method is not mocked")
     }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridAdditionsTests.swift
@@ -22,6 +22,7 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         userDefaultsSuiteName: nil,
                                         platformFlavor: "hybrid-platform",
                                         platformFlavorVersion: "1.2.3",
+                                        storeKitVersion: "DEFAULT",
                                         dangerousSettings: nil)
                 }.notTo(raiseException())
             }
@@ -33,6 +34,7 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         userDefaultsSuiteName: "test",
                                         platformFlavor: "hybrid-platform",
                                         platformFlavorVersion: "1.2.3",
+                                        storeKitVersion: "DEFAULT",
                                         dangerousSettings: nil)
                 }.notTo(raiseException())
             }
@@ -45,7 +47,8 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         observerMode: false,
                                         userDefaultsSuiteName: "test",
                                         platformFlavor: "hybrid-platform",
-                                        platformFlavorVersion: "1.2.3",
+                                        platformFlavorVersion: "1.2.3", 
+                                        storeKitVersion: "DEFAULT",
                                         dangerousSettings: nil,
                                         verificationMode: "DISABLED")
                 }.notTo(raiseException())
@@ -59,6 +62,7 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         userDefaultsSuiteName: "test",
                                         platformFlavor: "hybrid-platform",
                                         platformFlavorVersion: "1.2.3",
+                                        storeKitVersion: "DEFAULT",
                                         dangerousSettings: nil,
                                         verificationMode: "INFORMATIONAL")
                 }.notTo(raiseException())
@@ -71,6 +75,7 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         userDefaultsSuiteName: "test",
                                         platformFlavor: "hybrid-platform",
                                         platformFlavorVersion: "1.2.3",
+                                        storeKitVersion: "DEFAULT",
                                         dangerousSettings: nil,
                                         verificationMode: "ENFORCED")
                 }.notTo(raiseException())
@@ -84,8 +89,51 @@ class PurchasesHybridAdditionsTests: QuickSpec {
                                         observerMode: false,
                                         userDefaultsSuiteName: "test",
                                         platformFlavor: "hybrid-platform",
-                                        platformFlavorVersion: "1.2.3",
+                                        platformFlavorVersion: "1.2.3", 
+                                        storeKitVersion: "DEFAULT",
                                         dangerousSettings: DangerousSettings(autoSyncPurchases: false))
+                }.notTo(raiseException())
+            }
+        }
+        context("configure with StoreKit version") {
+            it("DEFAULT") {
+                expect {
+                    Purchases.configure(apiKey: "api key",
+                                        appUserID: nil,
+                                        observerMode: false,
+                                        userDefaultsSuiteName: "test",
+                                        platformFlavor: "hybrid-platform",
+                                        platformFlavorVersion: "1.2.3",
+                                        storeKitVersion: "DEFAULT",
+                                        dangerousSettings: nil,
+                                        verificationMode: "DISABLED")
+                }.notTo(raiseException())
+            }
+
+            it("STOREKIT_2") {
+                expect {
+                    Purchases.configure(apiKey: "api key",
+                                        appUserID: nil,
+                                        observerMode: false,
+                                        userDefaultsSuiteName: "test",
+                                        platformFlavor: "hybrid-platform",
+                                        platformFlavorVersion: "1.2.3",
+                                        storeKitVersion: "STOREKIT_2",
+                                        dangerousSettings: nil,
+                                        verificationMode: "DISABLED")
+                }.notTo(raiseException())
+            }
+            it("STOREKIT_1") {
+                expect {
+                    Purchases.configure(apiKey: "api key",
+                                        appUserID: nil,
+                                        observerMode: false,
+                                        userDefaultsSuiteName: "test",
+                                        platformFlavor: "hybrid-platform",
+                                        platformFlavorVersion: "1.2.3",
+                                        storeKitVersion: "STOREKIT_1",
+                                        dangerousSettings: nil,
+                                        verificationMode: "DISABLED")
                 }.notTo(raiseException())
             }
         }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/StoreKitVersion+HybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/StoreKitVersion+HybridAdditionsTests.swift
@@ -1,0 +1,24 @@
+//
+//  StoreKitVersionHybridAdditionsTests.swift
+//  PurchasesHybridCommonTests
+//
+//  Created by Mark Villacampa on 23/2/24.
+//  Copyright © 2024 RevenueCat. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import PurchasesHybridCommon
+@testable import RevenueCat
+
+class StoreKitVersionHybridAdditionsTests: QuickSpec {
+
+    override func spec() {
+        context("StoreKitVersion") {
+            expect(StoreKitVersion(name: "DEFAULT")).to(equal(.storeKit2))
+            expect(StoreKitVersion(name: "STOREKIT_1")).to(equal(.storeKit1))
+            expect(StoreKitVersion(name: "STOREKIT_2")).to(equal(.storeKit2))
+            expect(StoreKitVersion(name: "FAIL")).to(beNil())
+        }
+    }
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/XCTestCase+Expectations.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/XCTestCase+Expectations.swift
@@ -66,7 +66,6 @@ extension XCTestCase {
 }
 
 /// Similar to `XCTUnrap` but it allows an `async` closure.
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 func XCTAsyncUnwrap<T>(
     _ expression: @autoclosure () async throws -> T?,
     _ message: @autoclosure () -> String = "",

--- a/typescript/apitesters/offerings.ts
+++ b/typescript/apitesters/offerings.ts
@@ -51,7 +51,7 @@ function checkDiscount(discount: PurchasesStoreProductDiscount) {
   const priceString: string = discount.priceString;
   const cycles: number = discount.cycles;
   const period: string = discount.period;
-  const periodUnit: string = discount.periodUnit;
+  const periodUnit: PERIOD_UNIT = discount.periodUnit;
   const periodNumberOfUnits: number = discount.periodNumberOfUnits;
 }
 
@@ -60,7 +60,7 @@ function checkIntroPrice(introPrice: PurchasesIntroPrice) {
   const priceString: string = introPrice.priceString;
   const cycles: number = introPrice.cycles;
   const period: string = introPrice.period;
-  const periodUnit: string = introPrice.periodUnit;
+  const periodUnit: PERIOD_UNIT = introPrice.periodUnit;
   const periodNumberOfUnits: number = introPrice.periodNumberOfUnits;
 }
 

--- a/typescript/apitesters/purchasesConfiguration.ts
+++ b/typescript/apitesters/purchasesConfiguration.ts
@@ -1,12 +1,12 @@
 import { PurchasesConfiguration } from "../dist";
-import { ENTITLEMENT_VERIFICATION_MODE } from "../src";
+import { ENTITLEMENT_VERIFICATION_MODE, STOREKIT_VERSION } from "../src";
 
 function checkPurchasesConfiguration(configuration: PurchasesConfiguration) {
     const apiKey: string = configuration.apiKey;
     const appUserID: string | null | undefined = configuration.appUserID;
     const observerMode: boolean | undefined = configuration.observerMode;
     const userDefaultsSuiteName: string | undefined = configuration.userDefaultsSuiteName;
-    const usesStoreKit2IfAvailable: boolean | undefined = configuration.usesStoreKit2IfAvailable;
+    const storeKitVersion: STOREKIT_VERSION | undefined = configuration.storeKitVersion;
     const useAmazon: boolean | undefined = configuration.useAmazon;
     const shouldShowInAppMessagesAutomatically: boolean | undefined = configuration.shouldShowInAppMessagesAutomatically;
     const entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE | undefined = configuration.entitlementVerificationMode;
@@ -15,12 +15,12 @@ function checkPurchasesConfiguration(configuration: PurchasesConfiguration) {
         appUserID: appUserID,
         observerMode: observerMode,
         userDefaultsSuiteName: userDefaultsSuiteName,
-        usesStoreKit2IfAvailable: usesStoreKit2IfAvailable,
+        storeKitVersion: storeKitVersion,
         useAmazon: useAmazon,
         shouldShowInAppMessagesAutomatically: shouldShowInAppMessagesAutomatically,
         entitlementVerificationMode: entitlementVerificationMode
-    } 
+    }
     const configuration3: PurchasesConfiguration = {
         apiKey: apiKey
-    } 
+    }
 }

--- a/typescript/src/enums.ts
+++ b/typescript/src/enums.ts
@@ -84,7 +84,7 @@ export enum IN_APP_MESSAGE_TYPE {
   BILLING_ISSUE = 0,
 
   /**
-   * iOS-only. This message will show if you increase the price of a subscription and 
+   * iOS-only. This message will show if you increase the price of a subscription and
    * the user needs to opt-in to the increase.
    */
   PRICE_INCREASE_CONSENT = 1,
@@ -155,7 +155,7 @@ export enum VERIFICATION_RESULT {
 }
 
 /**
- * The result of presenting a paywall. This will be the last situation the user experienced before the 
+ * The result of presenting a paywall. This will be the last situation the user experienced before the
  * paywall closed.
  */
 export enum PAYWALL_RESULT {
@@ -183,4 +183,26 @@ export enum PAYWALL_RESULT {
    * If a successful restore happened inside the paywall
    */
   RESTORED = "RESTORED",
+}
+
+/**
+ * Defines which version of StoreKit may be used
+ */
+export enum STOREKIT_VERSION {
+  /**
+   * Always use StoreKit 1.
+   */
+  STOREKIT_1 = "STOREKIT_1",
+
+  /**
+   * Always use StoreKit 2 (StoreKit 1 will be used if StoreKit 2 is not available in the current device.)
+   * - Warning: Make sure you have an In-App Purchase Key configured in your app.
+   * Please see https://rev.cat/in-app-purchase-key-configuration for more info.
+   */
+  STOREKIT_2 = "STOREKIT_2",
+
+  /**
+   * Let RevenueCat use the most appropiate version of StoreKit
+  */
+ DEFAULT = "DEFAULT",
 }

--- a/typescript/src/enums.ts
+++ b/typescript/src/enums.ts
@@ -203,6 +203,6 @@ export enum STOREKIT_VERSION {
 
   /**
    * Let RevenueCat use the most appropiate version of StoreKit
-  */
- DEFAULT = "DEFAULT",
+   */
+  DEFAULT = "DEFAULT",
 }

--- a/typescript/src/offerings.ts
+++ b/typescript/src/offerings.ts
@@ -209,9 +209,9 @@ export interface PurchasesStoreProductDiscount {
    */
   readonly period: string;
   /**
-   * Unit for the billing period of the discount, can be DAY, WEEK, MONTH or YEAR.
+   * Unit for the billing period of the discount.
    */
-  readonly periodUnit: string;
+  readonly periodUnit: PERIOD_UNIT;
   /**
    * Number of units for the billing period of the discount.
    */
@@ -236,9 +236,9 @@ export interface PurchasesIntroPrice {
    */
   readonly period: string;
   /**
-   * Unit for the billing period of the discount, can be DAY, WEEK, MONTH or YEAR.
+   * Unit for the billing period of the discount.
    */
-  readonly periodUnit: string;
+  readonly periodUnit: PERIOD_UNIT;
   /**
    * Number of units for the billing period of the discount.
    */

--- a/typescript/src/purchasesConfiguration.ts
+++ b/typescript/src/purchasesConfiguration.ts
@@ -1,4 +1,4 @@
-import { ENTITLEMENT_VERIFICATION_MODE } from "./enums";
+import { ENTITLEMENT_VERIFICATION_MODE, STOREKIT_VERSION } from "./enums";
 
 /**
  * Holds parameters to initialize the SDK.
@@ -26,16 +26,15 @@ export interface PurchasesConfiguration {
   userDefaultsSuiteName?: string;
   /**
    * iOS-only, will be ignored for Android.
-   * Set this to TRUE to enable StoreKit2.
-   * Default is FALSE.
-   * 
-   * @deprecated RevenueCat currently uses StoreKit 1 for purchases, as its stability in production scenarios has
-   * proven to be more performant than StoreKit 2.
-   * We're collecting more data on the best approach, but StoreKit 1 vs StoreKit 2 is an implementation detail
-   * that you shouldn't need to care about.
-   * We recommend not using this parameter, letting RevenueCat decide for you which StoreKit implementation to use.
+   * Default is STOREKIT_2.
+   *
+   * - Warning: Make sure you have an In-App Purchase Key configured in your app.
+   * Please see https://rev.cat/in-app-purchase-key-configuration for more info.
+   *
+   * - Note: StoreKit 2 is only available on iOS 15+. StoreKit 1 will be used for previous iOS versions
+   * regardless of this setting.
    */
-  usesStoreKit2IfAvailable?: boolean;
+  storeKitVersion?: STOREKIT_VERSION;
   /**
    * An optional boolean. Android only. Required to configure the plugin to be used in the Amazon Appstore.
    */


### PR DESCRIPTION
Version 10.0.0 of `purchases-hybrid-common` bumps the iOS SDK to 5.0.0.

- Removed all iOS 13 and equivalent availability checks since we bumped the minimum target.
- Exposed new APIs: StoreKitVersion and SK2 observer mode.
- Update Typescript APIs to use PERIOD_UNIT type instead of string: https://github.com/RevenueCat/purchases-hybrid-common/pull/797