### PR TITLE
Add `RC_BILLING` store

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementInfo+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementInfo+HybridAdditions.swift
@@ -88,6 +88,8 @@ private extension EntitlementInfo {
             return "AMAZON"
         case .stripe:
             return "STRIPE"
+        case .rcBilling:
+            return "RC_BILLING"
         @unknown default:
             return "UNKNOWN_STORE"
         }

--- a/typescript/src/customerInfo.ts
+++ b/typescript/src/customerInfo.ts
@@ -49,7 +49,7 @@ export interface PurchasesEntitlementInfo {
     /**
      * The store where this entitlement was unlocked from.
      */
-    readonly store: "PLAY_STORE" | "APP_STORE" | "STRIPE" | "MAC_APP_STORE" | "PROMOTIONAL" | "AMAZON" | "UNKNOWN_STORE";
+    readonly store: "PLAY_STORE" | "APP_STORE" | "STRIPE" | "MAC_APP_STORE" | "PROMOTIONAL" | "AMAZON" | "RC_BILLING" | "UNKNOWN_STORE";
     /**
      * The product identifier that unlocked this entitlement
      */


### PR DESCRIPTION
Depends on https://github.com/RevenueCat/purchases-ios/pull/3773 and https://github.com/RevenueCat/purchases-android/pull/1657. 

Adds the `RC_BILLING` store support to PHC. In android, we don't need to map it since we use the enum's `name` property.

#### TODO
- [x] Holding until natives have been deployed and updated in PHC.