### PR TITLE
Fix compilation in xcode 14 (Swift 5.8)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ aliases:
     parameters:
       xcode_version:
         type: string
-        default: 15.2.0
+        default: 14.3.1
     working_directory: ~/ios
     shell: /bin/bash --login -o pipefail
   release-tags: &release-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ aliases:
     parameters:
       xcode_version:
         type: string
-        default: 14.3.1
+        default: 15.2.0
     working_directory: ~/ios
     shell: /bin/bash --login -o pipefail
   release-tags: &release-tags

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/PaywallProxy.swift
@@ -69,10 +69,11 @@ import UIKit
             displayCloseButton = options[PaywallOptionsKeys.displayCloseButton] as? Bool ?? false,
             fontName = options[PaywallOptionsKeys.fontName] as? String
 
-        let content = if (offeringIdentifier != nil) {
-            Content.offeringIdentifier(offeringIdentifier!)
+        let content: Content
+        if (offeringIdentifier != nil) {
+            content = Content.offeringIdentifier(offeringIdentifier!)
         } else {
-            Content.defaultOffering
+            content = Content.defaultOffering
         }
 
         self.privatePresentPaywall(displayCloseButton: displayCloseButton,
@@ -93,10 +94,11 @@ import UIKit
             displayCloseButton = options[PaywallOptionsKeys.displayCloseButton] as? Bool ?? false,
             fontName = options[PaywallOptionsKeys.fontName] as? String
 
-        let content = if (offeringIdentifier != nil) {
-            Content.offeringIdentifier(offeringIdentifier!)
+        let content: Content
+        if (offeringIdentifier != nil) {
+            content = Content.offeringIdentifier(offeringIdentifier!)
         } else {
-            Content.defaultOffering
+            content = Content.defaultOffering
         }
 
         self.privatePresentPaywallIfNeeded(requiredEntitlementIdentifier: requiredEntitlementIdentifier,


### PR DESCRIPTION
We were using a feature only available in Swift 5.9

React Native is failing to build when upgrading to 10.3.0 https://app.circleci.com/pipelines/github/RevenueCat/react-native-purchases/3497/workflows/8346248e-481b-4999-8c3a-3a55f075501a/jobs/13454