### PR TITLE
fix(PaywallProxy): check if root view controller is already presenting

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/PaywallProxy.swift
@@ -143,9 +143,16 @@ import UIKit
                                        fontName: String? = nil,
                                        shouldBlockTouchEvents: Bool = false,
                                        paywallResultHandler: ((String) -> Void)? = nil) {
-        guard let rootController = Self.rootViewController else {
+        guard var rootController = Self.rootViewController else {
             NSLog("Unable to find root UIViewController")
             return
+        }
+
+        // In case we are currently presenting a modal or any other
+        // view controller get to the top of the chain.
+        while (true) {
+          guard let presentedVC = rootController.presentedViewController else { break };
+          rootController = presentedVC
         }
 
         let fontProvider: PaywallFontProvider


### PR DESCRIPTION
In case our root view controller is already presenting another view controller, go to the top of the "view controller food chain" and present the paywall there.

This will fix the issue, where it was not possible to present a paywall on top of a modal presentation style view controller.

I previously discussed this issue with Michael from the developer support team. I think there should be an issue in Zendesk about this (id39622).