### PR TITLE
Update `periodUnit` fields to use `PERIOD_UNIT` type

### DIFF
--- a/typescript/apitesters/offerings.ts
+++ b/typescript/apitesters/offerings.ts
@@ -51,7 +51,7 @@ function checkDiscount(discount: PurchasesStoreProductDiscount) {
   const priceString: string = discount.priceString;
   const cycles: number = discount.cycles;
   const period: string = discount.period;
-  const periodUnit: string = discount.periodUnit;
+  const periodUnit: PERIOD_UNIT = discount.periodUnit;
   const periodNumberOfUnits: number = discount.periodNumberOfUnits;
 }
 
@@ -60,7 +60,7 @@ function checkIntroPrice(introPrice: PurchasesIntroPrice) {
   const priceString: string = introPrice.priceString;
   const cycles: number = introPrice.cycles;
   const period: string = introPrice.period;
-  const periodUnit: string = introPrice.periodUnit;
+  const periodUnit: PERIOD_UNIT = introPrice.periodUnit;
   const periodNumberOfUnits: number = introPrice.periodNumberOfUnits;
 }
 

--- a/typescript/src/offerings.ts
+++ b/typescript/src/offerings.ts
@@ -209,9 +209,9 @@ export interface PurchasesStoreProductDiscount {
    */
   readonly period: string;
   /**
-   * Unit for the billing period of the discount, can be DAY, WEEK, MONTH or YEAR.
+   * Unit for the billing period of the discount.
    */
-  readonly periodUnit: string;
+  readonly periodUnit: PERIOD_UNIT;
   /**
    * Number of units for the billing period of the discount.
    */
@@ -236,9 +236,9 @@ export interface PurchasesIntroPrice {
    */
   readonly period: string;
   /**
-   * Unit for the billing period of the discount, can be DAY, WEEK, MONTH or YEAR.
+   * Unit for the billing period of the discount.
    */
-  readonly periodUnit: string;
+  readonly periodUnit: PERIOD_UNIT;
   /**
    * Number of units for the billing period of the discount.
    */


### PR DESCRIPTION
We had a couple types for a periodUnit type using string instead of the existing `PERIOD_UNIT` enum. This enum already has the same underlying string types, but we should be using the enum.

This is a breaking change so will be part of the next major.

This will address #786 