### PR TITLE
Add support for new OneSignal `setOnesignalUserID` method for OneSignal 11+

### DIFF
--- a/android/api-tests/src/test/java/com/revenuecat/apitests/java/SubscriberAttributesApiTests.java
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/java/SubscriberAttributesApiTests.java
@@ -30,6 +30,7 @@ class SubscriberAttributesApiTests {
 
     private void checkSetOnesignalID(String id) {
         SubscriberAttributesKt.setOnesignalID(id);
+        SubscriberAttributesKt.setOnesignalUserID(id);
     }
 
     private void checkSetAirshipChannelID(String id) {

--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/SubscriberAttributesApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/SubscriberAttributesApiTests.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.hybridcommon.setKeyword
 import com.revenuecat.purchases.hybridcommon.setMediaSource
 import com.revenuecat.purchases.hybridcommon.setMparticleID
 import com.revenuecat.purchases.hybridcommon.setOnesignalID
+import com.revenuecat.purchases.hybridcommon.setOnesignalUserID
 import com.revenuecat.purchases.hybridcommon.setPhoneNumber
 import com.revenuecat.purchases.hybridcommon.setPushToken
 
@@ -46,6 +47,7 @@ private class SubscriberAttributesApiTests {
 
     fun checkSetOnesignalID(id: String?) {
         setOnesignalID(id)
+        setOnesignalUserID(id)
     }
 
     fun checkSetAirshipChannelID(id: String?) {

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/subscriberAttributes.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/subscriberAttributes.kt
@@ -40,6 +40,10 @@ fun setOnesignalID(onesignalID: String?) {
     Purchases.sharedInstance.setOnesignalID(onesignalID)
 }
 
+fun setOnesignalUserID(onesignalUserID: String?) {
+    Purchases.sharedInstance.setOnesignalUserID(onesignalUserID)
+}
+
 fun setAirshipChannelID(airshipChannelID: String?) {
     Purchases.sharedInstance.setAirshipChannelID(airshipChannelID)
 }

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -151,6 +151,8 @@ NS_ASSUME_NONNULL_BEGIN
     [RCCommonFunctionality setMparticleID:nil];
     [RCCommonFunctionality setOnesignalID:@""];
     [RCCommonFunctionality setOnesignalID:nil];
+    [RCCommonFunctionality setOnesignalUserID:@""];
+    [RCCommonFunctionality setOnesignalUserID:nil];
     [RCCommonFunctionality setAirshipChannelID:@""];
     [RCCommonFunctionality setAirshipChannelID:nil];
     [RCCommonFunctionality setMediaSource:@""];

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -556,6 +556,9 @@ import RevenueCat
     @objc static func setOnesignalID(_ onesignalID: String?) {
         Self.sharedInstance.attribution.setOnesignalID(onesignalID)
     }
+    @objc static func setOnesignalUserID(_ onesignalUserID: String?) {
+        Self.sharedInstance.attribution.setOnesignalUserID(onesignalUserID)
+    }
     @objc static func setAirshipChannelID(_ airshipChannelID: String?) {
         Self.sharedInstance.attribution.setAirshipChannelID(airshipChannelID)
     }


### PR DESCRIPTION
This adds support for the new method to set the user id when using Onesignal SDK 11+