### PR TITLE
Adds .aiexclude

### DIFF
--- a/android/.aiexclude
+++ b/android/.aiexclude
@@ -1,0 +1,2 @@
+../fastlane/.env
+local.properties


### PR DESCRIPTION
Adds `.aiexclude` to exclude files with sensitive info from being accessed by Gemini in Android Studio. More info can be read [here](https://developer.android.com/studio/preview/gemini/aiexclude).

Adds it to the `android` folder, as I reckon that's the folder you'll open in Android Studio. Not sure if the `fastlane` sibling folder is necessary to add, but better safe than sorry. 