### PR TITLE
Fix typescript API tests

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -105,7 +105,7 @@ end
 desc "Check typescript library API changes"
 lane :check_typescript_api_changes do
   update_typescript_api_report
-  sh("git diff --exit-code typescript/api-report/**")
+  sh("git diff --exit-code ../typescript/api-report/**")
 end
 
 desc "Update typescript library API report"


### PR DESCRIPTION
The command is executed from the fastlane folder, so the diff was failing and not catching issues