### PR TITLE
Add Kotlin version of the syncPurchases method that returns the customerInfo

### DIFF
--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
@@ -173,8 +173,9 @@ private class CommonApiTests {
         getCustomerInfo(onResult)
     }
 
-    fun checkSyncPurchases() {
+    fun checkSyncPurchases(onResult: OnResult) {
         syncPurchases()
+        syncPurchases(onResult)
     }
 
     fun checkIsAnonymous() {

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -35,6 +35,7 @@ import com.revenuecat.purchases.models.googleProduct
 import com.revenuecat.purchases.purchaseWith
 import com.revenuecat.purchases.restorePurchasesWith
 import com.revenuecat.purchases.syncAttributesAndOfferingsIfNeededWith
+import com.revenuecat.purchases.syncPurchasesWith
 import java.net.URL
 
 @Deprecated(
@@ -469,6 +470,14 @@ fun getCustomerInfo(
 
 fun syncPurchases() {
     Purchases.sharedInstance.syncPurchases()
+}
+
+fun syncPurchases(
+    onResult: OnResult,
+) {
+    Purchases.sharedInstance.syncPurchasesWith(onError = { onResult.onError(it.map()) }) {
+        onResult.onReceived(it.map())
+    }
 }
 
 fun isAnonymous(): Boolean {


### PR DESCRIPTION
The iOS already returns it, but not the Android one. This adds a method overload on Kotlin so we can potentially implement this in the hybrids.