### PR TITLE
Require STOREKIT_VERSION when PURCHASES_ARE_COMPLETED_BY is MY_APP

### DIFF
--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -226,15 +226,6 @@ export enum PURCHASE_TYPE {
 }
 
 // @public
-export type PURCHASES_ARE_COMPLETED_BY = PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT | PURCHASES_ARE_COMPLETED_BY_MY_APP;
-
-// @public
-export type PURCHASES_ARE_COMPLETED_BY_MY_APP = {
-    type: PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP;
-    storeKitVersion: STOREKIT_VERSION;
-};
-
-// @public
 export enum PURCHASES_ARE_COMPLETED_BY_TYPE {
     MY_APP = "MY_APP",
     REVENUECAT = "REVENUECAT"
@@ -315,12 +306,21 @@ export enum PURCHASES_ERROR_CODE {
 }
 
 // @public
+export type PurchasesAreCompletedBy = PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT | PurchasesAreCompletedByMyApp;
+
+// @public
+export type PurchasesAreCompletedByMyApp = {
+    type: PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP;
+    storeKitVersion: STOREKIT_VERSION;
+};
+
+// @public
 export interface PurchasesConfiguration {
     apiKey: string;
     appUserID?: string | null;
     entitlementVerificationMode?: ENTITLEMENT_VERIFICATION_MODE;
     pendingTransactionsForPrepaidPlansEnabled?: boolean;
-    purchasesAreCompletedBy?: PURCHASES_ARE_COMPLETED_BY;
+    purchasesAreCompletedBy?: PurchasesAreCompletedBy;
     shouldShowInAppMessagesAutomatically?: boolean;
     storeKitVersion?: STOREKIT_VERSION;
     useAmazon?: boolean;

--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -226,7 +226,16 @@ export enum PURCHASE_TYPE {
 }
 
 // @public
-export enum PURCHASES_ARE_COMPLETED_BY {
+export type PURCHASES_ARE_COMPLETED_BY = PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT | PURCHASES_ARE_COMPLETED_BY_MY_APP;
+
+// @public
+export type PURCHASES_ARE_COMPLETED_BY_MY_APP = {
+    type: PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP;
+    storeKitVersion: STOREKIT_VERSION;
+};
+
+// @public
+export enum PURCHASES_ARE_COMPLETED_BY_TYPE {
     MY_APP = "MY_APP",
     REVENUECAT = "REVENUECAT"
 }
@@ -310,8 +319,6 @@ export interface PurchasesConfiguration {
     apiKey: string;
     appUserID?: string | null;
     entitlementVerificationMode?: ENTITLEMENT_VERIFICATION_MODE;
-    // @deprecated
-    observerMode?: boolean;
     pendingTransactionsForPrepaidPlansEnabled?: boolean;
     purchasesAreCompletedBy?: PURCHASES_ARE_COMPLETED_BY;
     shouldShowInAppMessagesAutomatically?: boolean;

--- a/typescript/src/enums.ts
+++ b/typescript/src/enums.ts
@@ -249,7 +249,7 @@ export enum PURCHASES_ARE_COMPLETED_BY_TYPE {
  * Configuration option that specifies that your app will complete purchases.
  * @public
  */
-export type PURCHASES_ARE_COMPLETED_BY_MY_APP = {
+export type PurchasesAreCompletedByMyApp = {
   type: PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP;
 
   /**
@@ -283,6 +283,6 @@ export type PURCHASES_ARE_COMPLETED_BY_MY_APP = {
  * ```
  * @public
  */
-export type PURCHASES_ARE_COMPLETED_BY =
+export type PurchasesAreCompletedBy =
   | PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT
-  | PURCHASES_ARE_COMPLETED_BY_MY_APP;
+  | PurchasesAreCompletedByMyApp;

--- a/typescript/src/enums.ts
+++ b/typescript/src/enums.ts
@@ -228,7 +228,7 @@ export enum STOREKIT_VERSION {
  * Modes for completing the purchase process.
  * @public
  */
-export enum PURCHASES_ARE_COMPLETED_BY_VALUE {
+export enum PURCHASES_ARE_COMPLETED_BY_TYPE {
   /**
    * RevenueCat will **not** automatically acknowledge any purchases. You will have to do so manually.
    *
@@ -245,11 +245,44 @@ export enum PURCHASES_ARE_COMPLETED_BY_VALUE {
   REVENUECAT = "REVENUECAT",
 }
 
+/**
+ * Configuration option that specifies that your app will complete purchases.
+ * @public
+ */
 export type PURCHASES_ARE_COMPLETED_BY_MY_APP = {
-  type: PURCHASES_ARE_COMPLETED_BY_VALUE.MY_APP;
+  type: PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP;
+
+  /**
+   * The version of StoreKit that your app is using to make purchases. This value is ignored
+   * on Android, so if your app is Android-only, you may provide any value.
+   */
   storeKitVersion: STOREKIT_VERSION;
 };
 
+/**
+ * Allows you to specify whether you want RevenueCat to complete your app's purchases
+ * or if your app will do so.
+ *
+ * You can configure RevenueCat to complete your purchases like so:
+ * ```typescript
+ * Purchases.configure({
+ *  apiKey: "123",
+ *  purchasesAreCompletedBy: PURCHASES_ARE_COMPLETED_BY.MY_APP,
+ * });
+ * ```
+ *
+ * You can specify that purchase are completed by your app like so:
+ * ```typescript
+ * Purchases.configure({
+ *  apiKey: "123",
+ *  purchasesAreCompletedBy: {
+ *    type: PURCHASES_ARE_COMPLETED_BY.MY_APP,
+ *    storeKitVersion: STOREKIT_VERSION.STOREKIT_1
+ *  },
+ * });
+ * ```
+ * @public
+ */
 export type PURCHASES_ARE_COMPLETED_BY =
-  | PURCHASES_ARE_COMPLETED_BY_VALUE.REVENUECAT
+  | PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT
   | PURCHASES_ARE_COMPLETED_BY_MY_APP;

--- a/typescript/src/enums.ts
+++ b/typescript/src/enums.ts
@@ -228,7 +228,7 @@ export enum STOREKIT_VERSION {
  * Modes for completing the purchase process.
  * @public
  */
-export enum PURCHASES_ARE_COMPLETED_BY {
+export enum PURCHASES_ARE_COMPLETED_BY_VALUE {
   /**
    * RevenueCat will **not** automatically acknowledge any purchases. You will have to do so manually.
    *
@@ -244,3 +244,12 @@ export enum PURCHASES_ARE_COMPLETED_BY {
    */
   REVENUECAT = "REVENUECAT",
 }
+
+export type PURCHASES_ARE_COMPLETED_BY_MY_APP = {
+  type: PURCHASES_ARE_COMPLETED_BY_VALUE.MY_APP;
+  storeKitVersion: STOREKIT_VERSION;
+};
+
+export type PURCHASES_ARE_COMPLETED_BY =
+  | PURCHASES_ARE_COMPLETED_BY_VALUE.REVENUECAT
+  | PURCHASES_ARE_COMPLETED_BY_MY_APP;

--- a/typescript/src/enums.ts
+++ b/typescript/src/enums.ts
@@ -267,7 +267,7 @@ export type PURCHASES_ARE_COMPLETED_BY_MY_APP = {
  * ```typescript
  * Purchases.configure({
  *  apiKey: "123",
- *  purchasesAreCompletedBy: PURCHASES_ARE_COMPLETED_BY.MY_APP,
+ *  purchasesAreCompletedBy: PURCHASES_ARE_COMPLETED_BY.REVENUECAT,
  * });
  * ```
  *

--- a/typescript/src/purchasesConfiguration.ts
+++ b/typescript/src/purchasesConfiguration.ts
@@ -18,9 +18,12 @@ export interface PurchasesConfiguration {
    */
   appUserID?: string | null;
   /**
-   * Set this to MY_APP if you have your own IAP implementation and
-   * want to use only RevenueCat's backend. Default is REVENUECAT. If you are on Android and setting this to MY_APP, you will have
-   * to acknowledge the purchases yourself.
+   * Set this to MY_APP and provide a STOREKIT_VERSION if you have your own IAP implementation and
+   * want to only use RevenueCat's backend. Defaults to PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT.
+   *
+   * If you are on Android and setting this to MY_APP, will have to acknowledge the purchases yourself.
+   * If your app is only on Android, you may specify any StoreKit version, as it is ignored by the
+   * Android SDK.
    */
   purchasesAreCompletedBy?: PurchasesAreCompletedBy;
   /**

--- a/typescript/src/purchasesConfiguration.ts
+++ b/typescript/src/purchasesConfiguration.ts
@@ -18,13 +18,6 @@ export interface PurchasesConfiguration {
    */
   appUserID?: string | null;
   /**
-   * An optional boolean. Set this to TRUE if you have your own IAP implementation and
-   * want to use only RevenueCat's backend. Default is FALSE. If you are on Android and setting this to ON, you will have
-   * to acknowledge the purchases yourself.
-   * @deprecated Use purchasesAreCompletedBy instead.
-   */
-  observerMode?: boolean;
-  /**
    * Set this to MY_APP if you have your own IAP implementation and
    * want to use only RevenueCat's backend. Default is REVENUECAT. If you are on Android and setting this to MY_APP, you will have
    * to acknowledge the purchases yourself.

--- a/typescript/src/purchasesConfiguration.ts
+++ b/typescript/src/purchasesConfiguration.ts
@@ -1,7 +1,7 @@
 import {
   ENTITLEMENT_VERIFICATION_MODE,
   STOREKIT_VERSION,
-  PURCHASES_ARE_COMPLETED_BY,
+  PurchasesAreCompletedBy,
 } from "./enums";
 
 /**
@@ -22,7 +22,7 @@ export interface PurchasesConfiguration {
    * want to use only RevenueCat's backend. Default is REVENUECAT. If you are on Android and setting this to MY_APP, you will have
    * to acknowledge the purchases yourself.
    */
-  purchasesAreCompletedBy?: PURCHASES_ARE_COMPLETED_BY;
+  purchasesAreCompletedBy?: PurchasesAreCompletedBy;
   /**
    * An optional string. iOS-only, will be ignored for Android.
    * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults


### PR DESCRIPTION
As of iOS native SDK 5.0.0, developers must specify the StoreKit version they're using when setting `PurchasesAreCompletedBy`. This PR adjusts the typescript APIs to:
- Remove the existing `observerMode: bool` parameter
- Change `purchasesAreCompletedBy` to be a new `PURCHASES_ARE_COMPLETED_BY` combined type, which can be either `PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT` or a new type, `PURCHASES_ARE_COMPLETED_BY_MY_APP`, which requires developers specify their StoreKit version.

### Code Samples
Setting `purchasesAreCompletedBy` to `REVENUECAT`:
```typescript
Purchases.configure({
 apiKey: "123",
 purchasesAreCompletedBy: PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT,
});
```

Settings `purchasesAreCompletedBy` to `MY_APP`:
```typescript
Purchases.configure({
 apiKey: "123",
 purchasesAreCompletedBy: {
    type: PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP,
    storeKitVersion: STOREKIT_VERSION.STOREKIT_1
 },
});
```

### Android-Only Apps with `PURCHASES_ARE_COMPLETED_BY` == `MY_APP`
Android-only apps that want to complete their own purchases can specify any StoreKit version as that parameter is ignored by the Android SDK. This fact has been detailed in `PURCHASES_ARE_COMPLETED_BY_MY_APP`'s docstring.

### Acknowledgements
Huge thanks to @vegaro for coming up with the idea and prototyping it!