### PR TITLE
StoreKitVersion Docstring Typo Fix

### DIFF
--- a/typescript/src/enums.ts
+++ b/typescript/src/enums.ts
@@ -219,7 +219,7 @@ export enum STOREKIT_VERSION {
   STOREKIT_2 = "STOREKIT_2",
 
   /**
-   * Let RevenueCat use the most appropiate version of StoreKit
+   * Let RevenueCat use the most appropriate version of StoreKit
    */
   DEFAULT = "DEFAULT",
 }


### PR DESCRIPTION
Fixes a typo in the docstrings for the typescript `StoreKitVersion` enum.