### PR TITLE
Adds StoreProduct.priceAmount and StoreProductDiscount.priceAmount on iOS.

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProduct+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProduct+HybridAdditions.swift
@@ -12,7 +12,11 @@ import StoreKit
 
 @objc public extension StoreProduct {
     
-    // Re-exports pricePerPeriod properties with different names to avoid recursion.
+    // Re-exports price properties with different names to avoid recursion.
+
+    @objc(price) var priceAmount: NSDecimalNumber {
+        return self.priceDecimalNumber
+    }
 
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     @objc var pricePerWeekAmount: NSDecimalNumber? {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProduct+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProduct+HybridAdditions.swift
@@ -14,7 +14,7 @@ import StoreKit
     
     // Re-exports price properties with different names to avoid recursion.
 
-    @objc(price) var priceAmount: NSDecimalNumber {
+    @objc var priceAmount: NSDecimalNumber {
         return self.priceDecimalNumber
     }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProductDiscount+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProductDiscount+HybridAdditions.swift
@@ -10,6 +10,16 @@ import Foundation
 import StoreKit
 import RevenueCat
 
+@objc public extension StoreProductDiscount {
+    
+    // Re-exports price property with a different name to avoid recursion.
+
+    @objc(price) var priceAmount: NSDecimalNumber {
+        return self.priceDecimalNumber
+    }
+
+}
+
 internal extension StoreProductDiscount {
 
     var rc_currencyCode: String? {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProductDiscount+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProductDiscount+HybridAdditions.swift
@@ -14,7 +14,7 @@ import RevenueCat
     
     // Re-exports price property with a different name to avoid recursion.
 
-    @objc(price) var priceAmount: NSDecimalNumber {
+    @objc var priceAmount: NSDecimalNumber {
         return self.priceDecimalNumber
     }
 


### PR DESCRIPTION
As the title says. 

## Motivation
Because these were not exposed before this PR, purchases-kmp was reconstructing the price by parsing the formatted price. Besides being very brittle, this _might_ also be the cause of https://github.com/RevenueCat/purchases-kmp/issues/161, as we return `0` if the price formatter is null. 