### PR TITLE
Support integration via Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ ios/purchases-common-build
 ios/PurchasesHybridCommon/Pods/
 *.bck
 fastlane/report.xml
+.build
+**/xcuserdata/
 
 android/.composite-enable
 android/caches/

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "1c8e7b22f143659dfd3d9b4d8325e3eacccb1e50f24657cf6a87483bc3d6717a",
+  "pins" : [
+    {
+      "identity" : "purchases-ios-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RevenueCat/purchases-ios-spm",
+      "state" : {
+        "revision" : "dabbf506344b6f924b44bdfabbaec96bc7943d5d",
+        "version" : "5.3.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,44 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "PurchasesHybridCommon",
+    platforms: [
+        .macOS(.v10_15),
+        .watchOS("6.2"),
+        .tvOS(.v13),
+        .iOS(.v13),
+        .visionOS(.v1)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "PurchasesHybridCommon",
+            targets: ["PurchasesHybridCommon"]),
+        .library(
+            name: "PurchasesHybridCommonUI",
+            targets: ["PurchasesHybridCommonUI"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/RevenueCat/purchases-ios-spm", exact: "5.3.3"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "PurchasesHybridCommon",
+            dependencies: [
+                .product(name: "RevenueCat", package: "purchases-ios-spm"),
+            ],
+            path: "ios/PurchasesHybridCommon/PurchasesHybridCommon"),
+        .target(
+            name: "PurchasesHybridCommonUI",
+            dependencies: [
+                .target(name: "PurchasesHybridCommon"),
+                .product(name: "RevenueCatUI", package: "purchases-ios-spm"),
+            ],
+            path: "ios/PurchasesHybridCommon/PurchasesHybridCommonUI"),
+    ]
+)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,11 +24,13 @@ files_with_version_number_without_prerelease_modifiers = {
     './ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Info.plist' => PLIST_VERSION_PATTERNS,
 }
 POD_VERSION_PATTERNS = ['\'RevenueCat\', \'{x}\'', '\'RevenueCatUI\', \'{x}\'']
+SPM_VERSION_PATTERNS = ['.package(url: "https://github.com/RevenueCat/purchases-ios-spm", exact: "{x}"),']
 files_to_update_ios_dependency = {
     'PurchasesHybridCommon.podspec' => POD_VERSION_PATTERNS,
     'PurchasesHybridCommonUI.podspec' => POD_VERSION_PATTERNS,
     'ios/PurchasesHybridCommon/Podfile' => POD_VERSION_PATTERNS,
     'DEVELOPMENT.md' => POD_VERSION_PATTERNS,
+    'Package.swift' => SPM_VERSION_PATTERNS,
 }
 
 files_to_update_android_dependency = {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ files_with_version_number_without_prerelease_modifiers = {
 }
 POD_VERSION_PATTERNS = ['\'RevenueCat\', \'{x}\'', '\'RevenueCatUI\', \'{x}\'']
 SPM_VERSION_PATTERNS = ['.package(url: "https://github.com/RevenueCat/purchases-ios-spm", exact: "{x}"),']
-SPM_RESOLVED_VERSION_PATTERNS = ['        "version" : "{x}"']
+SPM_RESOLVED_VERSION_PATTERNS = ['"version" : "{x}"']
 files_to_update_ios_dependency = {
     'PurchasesHybridCommon.podspec' => POD_VERSION_PATTERNS,
     'PurchasesHybridCommonUI.podspec' => POD_VERSION_PATTERNS,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,12 +25,14 @@ files_with_version_number_without_prerelease_modifiers = {
 }
 POD_VERSION_PATTERNS = ['\'RevenueCat\', \'{x}\'', '\'RevenueCatUI\', \'{x}\'']
 SPM_VERSION_PATTERNS = ['.package(url: "https://github.com/RevenueCat/purchases-ios-spm", exact: "{x}"),']
+SPM_RESOLVED_VERSION_PATTERNS = ['        "version" : "{x}"']
 files_to_update_ios_dependency = {
     'PurchasesHybridCommon.podspec' => POD_VERSION_PATTERNS,
     'PurchasesHybridCommonUI.podspec' => POD_VERSION_PATTERNS,
     'ios/PurchasesHybridCommon/Podfile' => POD_VERSION_PATTERNS,
     'DEVELOPMENT.md' => POD_VERSION_PATTERNS,
     'Package.swift' => SPM_VERSION_PATTERNS,
+    'Package.resolved' => SPM_RESOLVED_VERSION_PATTERNS,
 }
 
 files_to_update_android_dependency = {
@@ -266,6 +268,16 @@ private_lane :update_ios_native_version do |options|
     new_version_number: new_version_number,
     previous_version_number: previous_version_number,
     files_to_update: files_to_update_ios_dependency
+  )
+
+  # Updating the commit hash in Package.resolved.
+  ios_spm_repository = "https://github.com/RevenueCat/purchases-ios-spm"
+  previous_commit_hash = get_commit_hash_for_tag(ios_spm_repository, previous_version_number)
+  new_commit_hash = get_commit_hash_for_tag(ios_spm_repository, new_version_number)
+  replace_text_in_files(
+    previous_text: previous_commit_hash,
+    new_text: new_commit_hash,
+    paths_of_files_to_update: ["Package.resolved"]
   )
 end
 
@@ -536,4 +548,8 @@ def detect_bump_type(a, b)
   else
     return :major
   end
+end
+
+def get_commit_hash_for_tag(repository, tag)
+  sh("git ls-remote --tags #{repository} | grep refs/tags/#{tag}^{} | cut -f 1 | tr -d '\n'")
 end


### PR DESCRIPTION
This adds a `Package.swift` file, allowing PHC to be integrated via SPM. This is mainly useful for purchases-kmp users, who need to integrate PHC manually, many of which aren't using CocoaPods. Some requests for this: 

- https://github.com/RevenueCat/purchases-kmp/issues/177#issuecomment-2331069006
- https://github.com/RevenueCat/purchases-kmp/issues/216#issuecomment-2367751406 

I was able to show a Paywall on iOS in a fresh KMP project by pointing it at the `Package.swift` file on my machine, without integrating CocoaPods.