### PR TITLE
Adds `Offerings.currentOfferingForPlacement()`

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/Offerings+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/Offerings+HybridAdditions.swift
@@ -13,7 +13,7 @@ import RevenueCat
     
     // Re-exports currentOfferingForPlacement function for use in hybrids.
 
-    @objc func currentOfferingForPlacement(placementIdentifier: String) -> Offering? {
+    @objc func currentOfferingForPlacement(_ placementIdentifier: String) -> Offering? {
         return self.currentOffering(forPlacement: placementIdentifier)
     }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/Offerings+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/Offerings+HybridAdditions.swift
@@ -9,6 +9,16 @@
 import Foundation
 import RevenueCat
 
+@objc public extension Offerings {
+    
+    // Re-exports currentOfferingForPlacement function for use in hybrids.
+
+    @objc func currentOfferingForPlacement(placementIdentifier: String) -> Offering? {
+        return self.currentOffering(forPlacement: placementIdentifier)
+    }
+
+}
+
 internal extension Offerings {
 
     var dictionary: [String: Any] {


### PR DESCRIPTION
As the title says. Used the same approach as we did for `StoreProduct.priceAmount` in https://github.com/RevenueCat/purchases-hybrid-common/pull/911. 

Note that there's an existing `getCurrentOfferingForPlacement()` in `CommonFunctionality`, but that's an async call and thus not entirely the same thing. 

- Dependant: https://github.com/RevenueCat/purchases-kmp/pull/243
- Addresses: https://github.com/RevenueCat/purchases-kmp/issues/242