### PR TITLE
Support SK win-back offer messages

### DIFF
--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -59,7 +59,8 @@ export interface GoogleProductChangeInfo {
 export enum IN_APP_MESSAGE_TYPE {
     BILLING_ISSUE = 0,
     GENERIC = 2,
-    PRICE_INCREASE_CONSENT = 1
+    PRICE_INCREASE_CONSENT = 1,
+    WIN_BACK_OFFER = 3
 }
 
 // @public

--- a/typescript/src/enums.ts
+++ b/typescript/src/enums.ts
@@ -104,6 +104,12 @@ export enum IN_APP_MESSAGE_TYPE {
    * iOS-only. StoreKit generic messages.
    */
   GENERIC = 2,
+
+  /**
+   * iOS-only. This message will show if the subscriber is eligible for an iOS win-back
+   * offer and will allow the subscriber to redeem the offer.
+   */
+  WIN_BACK_OFFER = 3,
 }
 
 /**


### PR DESCRIPTION
This PR introduces the ability for a user to display deferred StoreKit win-back offer messages to the user. The functionality was introduced in https://github.com/RevenueCat/purchases-ios/pull/4343.

Other than the enum addition, no other changes are necessary. We'll follow this PR up with PRs in the individual hybrid SDKs to enable support there.