### PR TITLE
Expose fetching & redeeming win-backs on custom paywalls to hybrids

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,3 +26,12 @@ In the  `android` directory run:
 ```
 
 Then "Sync Project with Gradle files" in Android Studio
+
+# Typescript
+
+## Update the Typescript API Report
+In the `/typescript` directory:
+
+```bash
+yarn build && yarn extract-api
+```

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -78,6 +78,23 @@ NS_ASSUME_NONNULL_BEGIN
                                              RCErrorContainer * _Nullable error) {
     }];
 
+    // Win-Back Offers
+    [RCCommonFunctionality winBackOffersForProductIdentifier:@"" completionBlock:^(NSArray<NSDictionary *> * _Nullable offers, RCErrorContainer * _Nullable error) {
+    }];
+
+    [RCCommonFunctionality purchaseProduct:@""
+                            winBackOfferID:@""
+                           completionBlock:^(NSDictionary * _Nullable customerInfo,
+                                             RCErrorContainer * _Nullable error) {
+    }];
+
+    [RCCommonFunctionality purchasePackage:@""
+                  presentedOfferingContext:@{}
+                            winBackOfferID:@""
+                           completionBlock:^(NSDictionary * _Nullable customerInfo,
+                                             RCErrorContainer * _Nullable error) {
+    }];
+
     [RCCommonFunctionality makeDeferredPurchase:^(void (^ _Nonnull startDeferredPurchase)
                                                   (RCStoreTransaction * _Nullable storeTransaction,
                                                    RCCustomerInfo * _Nullable customerInfo,

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
     }];
 
     // Win-Back Offers
-    [RCCommonFunctionality winBackOffersForProductIdentifier:@"" completionBlock:^(NSArray<NSDictionary *> * _Nullable offers, RCErrorContainer * _Nullable error) {
+    [RCCommonFunctionality eligibleWinBackOffersForProductIdentifier:@"" completionBlock:^(NSArray<NSDictionary *> * _Nullable offers, RCErrorContainer * _Nullable error) {
     }];
 
     [RCCommonFunctionality purchaseProduct:@""

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		FD31DE772841420000C0CA3A /* CustomerInfo+TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD31DE762841420000C0CA3A /* CustomerInfo+TestExtensions.swift */; };
 		FD3652DF2C53EFD400B513F6 /* PurchasesAreCompletedBy+HybridAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3652DE2C53EFD400B513F6 /* PurchasesAreCompletedBy+HybridAdditions.swift */; };
 		FD3652E12C53FA7A00B513F6 /* PurchasesAreCompletedByHybridAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3652E02C53FA7A00B513F6 /* PurchasesAreCompletedByHybridAdditionsTests.swift */; };
+		FD5EB01F2CEBC2CF004B88EF /* WinBackOffer+HybridAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5EB01E2CEBC2CF004B88EF /* WinBackOffer+HybridAdditions.swift */; };
 		FD922B66283D7493009E36C3 /* EntitlementInfo+HybridAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD922B65283D7493009E36C3 /* EntitlementInfo+HybridAdditionsTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -209,6 +210,7 @@
 		FD31DE762841420000C0CA3A /* CustomerInfo+TestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+TestExtensions.swift"; sourceTree = "<group>"; };
 		FD3652DE2C53EFD400B513F6 /* PurchasesAreCompletedBy+HybridAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PurchasesAreCompletedBy+HybridAdditions.swift"; sourceTree = "<group>"; };
 		FD3652E02C53FA7A00B513F6 /* PurchasesAreCompletedByHybridAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesAreCompletedByHybridAdditionsTests.swift; sourceTree = "<group>"; };
+		FD5EB01E2CEBC2CF004B88EF /* WinBackOffer+HybridAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WinBackOffer+HybridAdditions.swift"; sourceTree = "<group>"; };
 		FD922B65283D7493009E36C3 /* EntitlementInfo+HybridAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EntitlementInfo+HybridAdditionsTests.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -366,6 +368,7 @@
 				2DD3D1822810A7F400A19EC6 /* FatalErrorUtil.swift */,
 				FD1425A42C3C444E00323B48 /* StoreKitVersion+HybridAdditions.swift */,
 				FD3652DE2C53EFD400B513F6 /* PurchasesAreCompletedBy+HybridAdditions.swift */,
+				FD5EB01E2CEBC2CF004B88EF /* WinBackOffer+HybridAdditions.swift */,
 			);
 			path = PurchasesHybridCommon;
 			sourceTree = "<group>";
@@ -869,6 +872,7 @@
 				2DD3D1872810AF5A00A19EC6 /* ErrorContainer.swift in Sources */,
 				2DD3D18F2810AF5A00A19EC6 /* EntitlementInfo+HybridAdditions.swift in Sources */,
 				2DD3D1922810AF5A00A19EC6 /* PromotionalOffer+HybridAdditions.swift in Sources */,
+				FD5EB01F2CEBC2CF004B88EF /* WinBackOffer+HybridAdditions.swift in Sources */,
 				2DD3D1862810AF5A00A19EC6 /* Package+HybridAdditions.swift in Sources */,
 				2DD3D18C2810AF5A00A19EC6 /* Purchases+HybridAdditions.swift in Sources */,
 				2DD3D18D2810AF5A00A19EC6 /* StoreTransaction+HybridAdditions.swift in Sources */,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -693,8 +693,8 @@ import RevenueCat
     /// - Parameters:
     ///   - productIdentifier: The identifier of the product to fetch win-back offers for.
     ///   - completion: A closure that receives an array of win-back offer dictionaries or an error container if something went wrong.
-    @objc(winBackOffersForProductIdentifier:completionBlock:)
-    static func winBackOffers(
+    @objc(eligibleWinBackOffersForProductIdentifier:completionBlock:)
+    static func eligibleWinBackOffers(
         for productIdentifier: String,
         completion: @escaping ([[String: Any]]?, ErrorContainer?) -> Void
     ) {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -317,78 +317,6 @@ import RevenueCat
 
     }
 
-    // MARK: - Purchasing with Win-Back Offers
-    @objc(purchaseProduct:winBackOfferID:completionBlock:)
-    static func purchase(product productIdentifier: String,
-                         winBackOfferID: String,
-                         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        let hybridCompletion = Self.createPurchaseCompletionBlock(completion: completion)
-
-        self.product(with: productIdentifier) { storeProduct in
-            guard let storeProduct = storeProduct else {
-                completion(nil, productNotFoundError(description: "Couldn't find product.", userCancelled: false))
-                return
-            }
-
-            if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-                guard let winBackOffer: WinBackOffer = self.winBackOffersByID[winBackOfferID] else {
-                    completion(
-                        nil,
-                        productNotFoundError(description: "Couldn't find win-back offer.", userCancelled: false)
-                    )
-                    return
-                }
-
-                let purchaseParams = PurchaseParams.Builder(product: storeProduct)
-                    .with(winBackOffer: winBackOffer)
-                    .build()
-
-                Self.sharedInstance.purchase(purchaseParams, completion: hybridCompletion)
-                return
-            }
-
-            Self.sharedInstance.purchase(product: storeProduct, completion: hybridCompletion)
-        }
-    }
-
-    @objc(purchasePackage:presentedOfferingContext:winBackOfferID:completionBlock:)
-    static func purchase(package packageIdentifier: String,
-                         presentedOfferingContext: [String: Any],
-                         winBackOfferID: String,
-                         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
-        let hybridCompletion = Self.createPurchaseCompletionBlock(completion: completion)
-
-        Self.package(
-            withIdentifier: packageIdentifier,
-            presentedOfferingContext: Self.toPresentedOfferingContext(presentedOfferingContext: presentedOfferingContext)
-        ) { package in
-            guard let package = package else {
-                let error = productNotFoundError(description: "Couldn't find package", userCancelled: false)
-                completion(nil, error)
-                return
-            }
-
-            if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-                guard let winBackOffer: WinBackOffer = self.winBackOffersByID[winBackOfferID] else {
-                    completion(
-                        nil,
-                        productNotFoundError(description: "Couldn't find win-back offer.", userCancelled: false)
-                    )
-                    return
-                }
-
-                let purchaseParams = PurchaseParams.Builder(package: package)
-                    .with(winBackOffer: winBackOffer)
-                    .build()
-
-                Self.sharedInstance.purchase(purchaseParams, completion: hybridCompletion)
-                return
-            }
-
-            Self.sharedInstance.purchase(package: package, completion: hybridCompletion)
-        }
-    }
-
     @objc(makeDeferredPurchase:completionBlock:)
     static func makeDeferredPurchase(_ startPurchase: StartPurchaseBlock,
                                      completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
@@ -745,6 +673,77 @@ import RevenueCat
 
                 completion(winBackDictionaries, nil)
             }
+        }
+    }
+
+    @objc(purchaseProduct:winBackOfferID:completionBlock:)
+    static func purchase(product productIdentifier: String,
+                         winBackOfferID: String,
+                         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
+        let hybridCompletion = Self.createPurchaseCompletionBlock(completion: completion)
+
+        self.product(with: productIdentifier) { storeProduct in
+            guard let storeProduct = storeProduct else {
+                completion(nil, productNotFoundError(description: "Couldn't find product.", userCancelled: false))
+                return
+            }
+
+            if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+                guard let winBackOffer: WinBackOffer = self.winBackOffersByID[winBackOfferID] else {
+                    completion(
+                        nil,
+                        productNotFoundError(description: "Couldn't find win-back offer.", userCancelled: false)
+                    )
+                    return
+                }
+
+                let purchaseParams = PurchaseParams.Builder(product: storeProduct)
+                    .with(winBackOffer: winBackOffer)
+                    .build()
+
+                Self.sharedInstance.purchase(purchaseParams, completion: hybridCompletion)
+                return
+            }
+
+            Self.sharedInstance.purchase(product: storeProduct, completion: hybridCompletion)
+        }
+    }
+
+    @objc(purchasePackage:presentedOfferingContext:winBackOfferID:completionBlock:)
+    static func purchase(package packageIdentifier: String,
+                         presentedOfferingContext: [String: Any],
+                         winBackOfferID: String,
+                         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
+        let hybridCompletion = Self.createPurchaseCompletionBlock(completion: completion)
+
+        Self.package(
+            withIdentifier: packageIdentifier,
+            presentedOfferingContext: Self.toPresentedOfferingContext(presentedOfferingContext: presentedOfferingContext)
+        ) { package in
+            guard let package = package else {
+                let error = productNotFoundError(description: "Couldn't find package", userCancelled: false)
+                completion(nil, error)
+                return
+            }
+
+            if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+                guard let winBackOffer: WinBackOffer = self.winBackOffersByID[winBackOfferID] else {
+                    completion(
+                        nil,
+                        productNotFoundError(description: "Couldn't find win-back offer.", userCancelled: false)
+                    )
+                    return
+                }
+
+                let purchaseParams = PurchaseParams.Builder(package: package)
+                    .with(winBackOffer: winBackOffer)
+                    .build()
+
+                Self.sharedInstance.purchase(purchaseParams, completion: hybridCompletion)
+                return
+            }
+
+            Self.sharedInstance.purchase(package: package, completion: hybridCompletion)
         }
     }
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -282,11 +282,10 @@ import RevenueCat
         }
     }
 
-    @objc(purchasePackage:presentedOfferingContext:signedDiscountTimestamp:winBackOfferID:completionBlock:)
+    @objc(purchasePackage:presentedOfferingContext:signedDiscountTimestamp:completionBlock:)
     static func purchase(package packageIdentifier: String,
                          presentedOfferingContext: [String: Any],
                          signedDiscountTimestamp: String?,
-                         winBackOfferID: String? = nil,
                          completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
         let hybridCompletion = Self.createPurchaseCompletionBlock(completion: completion)
 
@@ -313,7 +312,63 @@ import RevenueCat
                 }
             }
 
-            if let winBackOfferID, #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            Self.sharedInstance.purchase(package: package, completion: hybridCompletion)
+        }
+
+    }
+
+    // MARK: - Purchasing with Win-Back Offers
+    @objc(purchaseProduct:winBackOfferID:completionBlock:)
+    static func purchase(product productIdentifier: String,
+                         winBackOfferID: String,
+                         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
+        let hybridCompletion = Self.createPurchaseCompletionBlock(completion: completion)
+
+        self.product(with: productIdentifier) { storeProduct in
+            guard let storeProduct = storeProduct else {
+                completion(nil, productNotFoundError(description: "Couldn't find product.", userCancelled: false))
+                return
+            }
+
+            if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+                guard let winBackOffer: WinBackOffer = self.winBackOffersByID[winBackOfferID] else {
+                    completion(
+                        nil,
+                        productNotFoundError(description: "Couldn't find win-back offer.", userCancelled: false)
+                    )
+                    return
+                }
+
+                let purchaseParams = PurchaseParams.Builder(product: storeProduct)
+                    .with(winBackOffer: winBackOffer)
+                    .build()
+
+                Self.sharedInstance.purchase(purchaseParams, completion: hybridCompletion)
+                return
+            }
+
+            Self.sharedInstance.purchase(product: storeProduct, completion: hybridCompletion)
+        }
+    }
+
+    @objc(purchasePackage:presentedOfferingContext:winBackOfferID:completionBlock:)
+    static func purchase(package packageIdentifier: String,
+                         presentedOfferingContext: [String: Any],
+                         winBackOfferID: String,
+                         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
+        let hybridCompletion = Self.createPurchaseCompletionBlock(completion: completion)
+
+        Self.package(
+            withIdentifier: packageIdentifier,
+            presentedOfferingContext: Self.toPresentedOfferingContext(presentedOfferingContext: presentedOfferingContext)
+        ) { package in
+            guard let package = package else {
+                let error = productNotFoundError(description: "Couldn't find package", userCancelled: false)
+                completion(nil, error)
+                return
+            }
+
+            if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
                 guard let winBackOffer: WinBackOffer = self.winBackOffersByID[winBackOfferID] else {
                     completion(
                         nil,
@@ -332,7 +387,6 @@ import RevenueCat
 
             Self.sharedInstance.purchase(package: package, completion: hybridCompletion)
         }
-
     }
 
     @objc(makeDeferredPurchase:completionBlock:)

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -306,11 +306,9 @@ import RevenueCat
                         completion(nil, productNotFoundError(description: "Couldn't find discount.", userCancelled: false))
                         return
                     }
-                    let purchaseParams = PurchaseParams.Builder(package: package)
-                        .with(promotionalOffer: promotionalOffer)
-                        .build()
-
-                    Self.sharedInstance.purchase(purchaseParams, completion: hybridCompletion)
+                    Self.sharedInstance.purchase(package: package,
+                                                 promotionalOffer: promotionalOffer,
+                                                 completion: hybridCompletion)
                     return
                 }
             }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/WinBackOffer+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/WinBackOffer+HybridAdditions.swift
@@ -1,0 +1,18 @@
+//
+//  WinBackOffer+HybridAdditions.swift
+//  PurchasesHybridCommon
+//
+//  Created by Will Taylor on 11/18/24.
+//  Copyright © 2024 RevenueCat. All rights reserved.
+//
+
+import Foundation
+import RevenueCat
+
+@objc public extension WinBackOffer {
+
+    var rc_dictionary: [String: Any] {
+        return self.discount.rc_dictionary
+    }
+
+}

--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -483,6 +483,10 @@ export interface PurchasesStoreTransaction {
 }
 
 // @public
+export interface PurchasesWinBackOffer extends PurchasesStoreProductDiscount {
+}
+
+// @public
 export enum RECURRENCE_MODE {
     FINITE_RECURRING = 2,
     INFINITE_RECURRING = 1,

--- a/typescript/src/offerings.ts
+++ b/typescript/src/offerings.ts
@@ -101,14 +101,14 @@ export interface PurchasesStoreProduct {
   readonly priceString: string;
   /**
    * Null for INAPP products. The price of the PurchasesStoreProduct in a weekly recurrence.
-   * This means that, for example, if the period is monthly, the price will be 
+   * This means that, for example, if the period is monthly, the price will be
    * divided by 4. Note that this value may be an approximation. For Google subscriptions,
    * this value will use the basePlan to calculate the value.
    */
   readonly pricePerWeek: number;
   /**
    * Null for INAPP products. The price of the PurchasesStoreProduct in a monthly recurrence.
-   * This means that, for example, if the period is annual, the price will be 
+   * This means that, for example, if the period is annual, the price will be
    * divided by 12. Note that this value may be an approximation. For Google subscriptions,
    * this value will use the basePlan to calculate the value.
    */
@@ -123,7 +123,7 @@ export interface PurchasesStoreProduct {
   /**
    * Null for INAPP products. The price of the PurchasesStoreProduct formatted for the current
    * locale in a weekly recurrence. This means that, for example, if the period is monthly,
-   * the price will be divided by 4. It uses a currency formatter to format the price in the 
+   * the price will be divided by 4. It uses a currency formatter to format the price in the
    * given locale. Note that this value may be an approximation. For Google subscriptions,
    * this value will use the basePlan to calculate the value.
    */
@@ -131,7 +131,7 @@ export interface PurchasesStoreProduct {
   /**
    * Null for INAPP products. The price of the PurchasesStoreProduct formatted for the current
    * locale in a monthly recurrence. This means that, for example, if the period is annual,
-   * the price will be divided by 12. It uses a currency formatter to format the price in the 
+   * the price will be divided by 12. It uses a currency formatter to format the price in the
    * given locale. Note that this value may be an approximation. For Google subscriptions,
    * this value will use the basePlan to calculate the value.
    */
@@ -510,6 +510,12 @@ export interface PurchasesPromotionalOffer {
   readonly signature: string;
   readonly timestamp: number;
 }
+
+/**
+ * Holds the information about a Win-Back Offer in Apple's App Store.
+ * @public
+ */
+export interface PurchasesWinBackOffer extends PurchasesStoreProductDiscount {}
 
 /**
  * Enum with possible proration modes in a subscription upgrade or downgrade in the Play Store. Used only for Google.


### PR DESCRIPTION
## Description
This PR adds the ability for developers to fetch & redeem eligible win-back offers to the PHC.

### How It Works
#### New `PurchasesWinBackOffer` Type
A new `PurchasesWinBackOffer` type has been created, which is an extension of the `PurchasesStoreProductDiscount` type since the native `WinBackOffer` struct only contains a `StoreProductDiscount`.

#### Fetching Win-Back Offers
When the hybrid SDK calls `winBackOffers(for ProductIdentifier)`, PHC queries the native iOS SDK for a list of all eligible win-back offers for the given product. It then caches them in a dictionary for use when redeeming the win-back offer later. It then returns all eligible win-back offers as an array of `PurchasesStoreProductDiscount` dictionaries

#### Redeeming Win-Back Offers
A new optional `winBackOfferID: String` param has been added to one of the purchase functions. When the hybrid SDK calls this function with no promotional offer, the function fetches the `WinBackOffer` from the cache, and if one is found, redeems it.


### Testing
Tested fetching & purchasing a win-back offer manually through the react native purchase tester app