### PR TITLE
Syncs version in `Package.swift` and `Package.resolved` with other iOS version files

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-ios-spm",
       "state" : {
-        "revision" : "dabbf506344b6f924b44bdfabbaec96bc7943d5d",
-        "version" : "5.3.3"
+        "revision" : "3dd291434fd63594b8ada87bca960e001b708241",
+        "version" : "5.8.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
             targets: ["PurchasesHybridCommonUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/RevenueCat/purchases-ios-spm", exact: "5.3.3"),
+        .package(url: "https://github.com/RevenueCat/purchases-ios-spm", exact: "5.8.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
As the title says. 

## What
The `Package.swift` and `Package.resolved` files were stuck at `5.3.3` of purchases-ios, while the current dependency version is actually `5.8.0`. Other version files such as `.podspec` correctly contain `5.8.0`. 

## How
When SPM support was merged (https://github.com/RevenueCat/purchases-hybrid-common/pull/922), it contained `5.3.3`, but it was merged after the CI job had already updated the dependency to `5.3.4` in the existing iOS version files. (See [`PurchasesHybridCommon.podspec`](https://github.com/RevenueCat/purchases-hybrid-common/blob/886951d557fe8849dd1944548da1772d88968978/PurchasesHybridCommon.podspec#L18) at that point in time.) 

This meant the `Package.swift` and `Package.resolved` files were out-of-sync from the start. Subsequent CI jobs therefore didn't update them, because they didn't contain the expected version (`5.3.4`). 

## Fix
This PR syncs the `Package.swift` and `Package.resolved` files back up with the other version files. I confirmed locally that they do get properly updated after this change. 

We should really make sure to merge this before the next bump is merged. 😅 