### PR TITLE
[AUTOMATIC] iOS 5.8.0 => 5.10.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-ios-spm",
       "state" : {
-        "revision" : "3dd291434fd63594b8ada87bca960e001b708241",
-        "version" : "5.8.0"
+        "revision" : "0cba1063bbb8366fd6868ed85b533e2d68004d23",
+        "version" : "5.10.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
             targets: ["PurchasesHybridCommonUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/RevenueCat/purchases-ios-spm", exact: "5.8.0"),
+        .package(url: "https://github.com/RevenueCat/purchases-ios-spm", exact: "5.10.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/PurchasesHybridCommon.podspec
+++ b/PurchasesHybridCommon.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.framework      = 'StoreKit'
 
-  s.dependency 'RevenueCat', '5.8.0'
+  s.dependency 'RevenueCat', '5.10.0'
   s.swift_version = '5.7'
 
   s.ios.deployment_target = '13.0'

--- a/PurchasesHybridCommonUI.podspec
+++ b/PurchasesHybridCommonUI.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.framework      = 'StoreKit'
   s.framework      = 'SwiftUI'
 
-  s.dependency 'RevenueCatUI', '5.8.0'
+  s.dependency 'RevenueCatUI', '5.10.0'
   s.dependency 'PurchasesHybridCommon', s.version.to_s
   s.swift_version = '5.7'
 

--- a/ios/PurchasesHybridCommon/Podfile
+++ b/ios/PurchasesHybridCommon/Podfile
@@ -4,7 +4,7 @@ target 'PurchasesHybridCommon' do
   platform :ios, '13.0'
   use_frameworks!
 
-  pod 'RevenueCat', '5.8.0'
+  pod 'RevenueCat', '5.10.0'
 
   target 'PurchasesHybridCommonTests' do
     # Pods for testing
@@ -24,8 +24,8 @@ target 'PurchasesHybridCommonUI' do
   platform :ios, '13.0'
   use_frameworks!
 
-  pod 'RevenueCat', '5.8.0'
-  pod 'RevenueCatUI', '5.8.0'
+  pod 'RevenueCat', '5.10.0'
+  pod 'RevenueCatUI', '5.10.0'
 
 end
 
@@ -33,6 +33,6 @@ target 'ObjCAPITester' do
   platform :ios, '13.0'
   use_frameworks!
 
-  pod 'RevenueCat', '5.8.0'
-  pod 'RevenueCatUI', '5.8.0'
+  pod 'RevenueCat', '5.10.0'
+  pod 'RevenueCatUI', '5.10.0'
 end

--- a/ios/PurchasesHybridCommon/Podfile.lock
+++ b/ios/PurchasesHybridCommon/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
   - Nimble (10.0.0)
   - Quick (5.0.1)
-  - RevenueCat (5.8.0)
-  - RevenueCatUI (5.8.0):
-    - RevenueCat (= 5.8.0)
+  - RevenueCat (5.10.0)
+  - RevenueCatUI (5.10.0):
+    - RevenueCat (= 5.10.0)
 
 DEPENDENCIES:
   - Nimble (= 10.0.0)
   - Quick (= 5.0.1)
-  - RevenueCat (= 5.8.0)
-  - RevenueCatUI (= 5.8.0)
+  - RevenueCat (= 5.10.0)
+  - RevenueCatUI (= 5.10.0)
 
 SPEC REPOS:
   trunk:
@@ -21,9 +21,9 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
-  RevenueCat: 4cd1daad3a57d2b4015ed2b4aef0a0f24ffce0a1
-  RevenueCatUI: b4691e230f3e5435f408b840929c9061dab6c46b
+  RevenueCat: 0d1cb52b93ab2d3d63fad9a62bd8650ce82e43e2
+  RevenueCatUI: 4bf74b5e791850f75caeb04148aeea80440a79ff
 
-PODFILE CHECKSUM: c4a3f36d4db58e9fff6e1437e51e91dcd23c96ff
+PODFILE CHECKSUM: 5fd857e6fa1f2ae6fb061d9a71dade07c576707a
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/Mocks/MockPurchases.swift
@@ -262,6 +262,41 @@ final class MockPurchases: PurchasesType {
         invokedPurchasePackageWithPromotionalOfferParametersList.append((package, promotionalOffer, completion))
     }
 
+    var invokedPurchaseParamsCompletion = false
+    var invokedPurchaseParamsCompletionCount = 0
+    var invokedPurchaseParamsCompletionParameters: (params: PurchaseParams, completion: PurchaseCompletedBlock)?
+    var invokedPurchaseParamsCompletionParametersList: [(params: PurchaseParams, completion: PurchaseCompletedBlock)] = []
+    func purchase(
+        _ params: PurchaseParams,
+        completion: @escaping PurchaseCompletedBlock
+    ) {
+        invokedPurchaseParamsCompletion = true
+        invokedPurchaseParamsCompletionCount += 1
+        invokedPurchaseParamsCompletionParameters = (params, completion)
+        invokedPurchaseParamsCompletionParametersList.append((params, completion))
+    }
+
+    var invokedEligibleWinBackOffersCompletion = false
+    var invokedEligibleWinBackOffersCompletionCount = 0
+    var invokedEligibleWinBackOffersCompletionParameters: (
+        product: StoreProduct,
+        completion: ([WinBackOffer]?, PublicError?) -> Void
+    )?
+    var invokedEligibleWinBackOffersCompletionParametersList: [(
+        product: StoreProduct,
+        completion: ([WinBackOffer]?, PublicError?) -> Void
+    )] = []
+    @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    func eligibleWinBackOffers(
+        forProduct product: StoreProduct,
+        completion: @escaping @Sendable ([WinBackOffer]?, PublicError?) -> Void
+    ) {
+        invokedEligibleWinBackOffersCompletion = true
+        invokedEligibleWinBackOffersCompletionCount += 1
+        invokedEligibleWinBackOffersCompletionParameters = (product, completion)
+        invokedEligibleWinBackOffersCompletionParametersList.append((product, completion))
+    }
+
     var invokedInvalidateCustomerInfoCache = false
     var invokedInvalidateCustomerInfoCacheCount = 0
 
@@ -681,6 +716,17 @@ extension MockPurchases: PurchasesSwiftType {
     func recordPurchase(
         _ purchaseResult: Product.PurchaseResult
     ) async throws -> RevenueCat.StoreTransaction? {
+        fatalError("Not mocked")
+    }
+
+    @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    func eligibleWinBackOffers(forProduct product: RevenueCat.StoreProduct) async throws -> [RevenueCat.WinBackOffer] {
+        fatalError("Not mocked")
+    }
+
+    func purchase(
+        _ params: PurchaseParams
+    ) async throws -> PurchaseResultData {
         fatalError("Not mocked")
     }
 }


### PR DESCRIPTION
This PR bumps the native iOS SDK version from 5.8.0 to 5.10.0 and updates `MockPurchases` to include the new APIs introduced in 5.10.0