### PR TITLE
Add methods to set Tenjin and Kochava integration IDs

### DIFF
--- a/android/api-tests/src/test/java/com/revenuecat/apitests/java/SubscriberAttributesApiTests.java
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/java/SubscriberAttributesApiTests.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 @SuppressWarnings("unused")
 class SubscriberAttributesApiTests {
+
     // region Attribution IDs
 
     private void checkCollectDeviceIdentifiers() {
@@ -35,6 +36,16 @@ class SubscriberAttributesApiTests {
 
     private void checkSetAirshipChannelID(String id) {
         SubscriberAttributesKt.setAirshipChannelID(id);
+    }
+
+    private void checkTenjinInstallationID() {
+        SubscriberAttributesKt.setTenjinAnalyticsInstallationID("tenjin_installation_id");
+        SubscriberAttributesKt.setTenjinAnalyticsInstallationID(null);
+    }
+
+    private void checkKochavaDeviceID() {
+        SubscriberAttributesKt.setKochavaDeviceID("kochava_device_id");
+        SubscriberAttributesKt.setKochavaDeviceID(null);
     }
 
     // endregion

--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/SubscriberAttributesApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/SubscriberAttributesApiTests.kt
@@ -13,12 +13,14 @@ import com.revenuecat.purchases.hybridcommon.setDisplayName
 import com.revenuecat.purchases.hybridcommon.setEmail
 import com.revenuecat.purchases.hybridcommon.setFBAnonymousID
 import com.revenuecat.purchases.hybridcommon.setKeyword
+import com.revenuecat.purchases.hybridcommon.setKochavaDeviceID
 import com.revenuecat.purchases.hybridcommon.setMediaSource
 import com.revenuecat.purchases.hybridcommon.setMparticleID
 import com.revenuecat.purchases.hybridcommon.setOnesignalID
 import com.revenuecat.purchases.hybridcommon.setOnesignalUserID
 import com.revenuecat.purchases.hybridcommon.setPhoneNumber
 import com.revenuecat.purchases.hybridcommon.setPushToken
+import com.revenuecat.purchases.hybridcommon.setTenjinAnalyticsInstallationID
 
 @Suppress("unused")
 private class SubscriberAttributesApiTests {
@@ -52,6 +54,16 @@ private class SubscriberAttributesApiTests {
 
     fun checkSetAirshipChannelID(id: String?) {
         setAirshipChannelID(id)
+    }
+
+    fun checkTenjinInstallationID() {
+        setTenjinAnalyticsInstallationID("tenjinAnalyticsInstallationID")
+        setTenjinAnalyticsInstallationID(null)
+    }
+
+    fun checkKochavaDeviceID() {
+        setKochavaDeviceID("kochavaDeviceId")
+        setKochavaDeviceID(null)
     }
 
     // endregion

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/subscriberAttributes.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/subscriberAttributes.kt
@@ -28,12 +28,20 @@ fun setCleverTapID(cleverTapID: String?) {
     Purchases.sharedInstance.setCleverTapID(cleverTapID)
 }
 
+fun setKochavaDeviceID(kochavaDeviceID: String?) {
+    Purchases.sharedInstance.setKochavaDeviceID(kochavaDeviceID)
+}
+
 fun setMixpanelDistinctID(mixpanelDistinctID: String?) {
     Purchases.sharedInstance.setMixpanelDistinctID(mixpanelDistinctID)
 }
 
 fun setFirebaseAppInstanceID(firebaseAppInstanceID: String?) {
     Purchases.sharedInstance.setFirebaseAppInstanceID(firebaseAppInstanceID)
+}
+
+fun setTenjinAnalyticsInstallationID(tenjinAnalyticsInstallationID: String?) {
+    Purchases.sharedInstance.setTenjinAnalyticsInstallationID(tenjinAnalyticsInstallationID)
 }
 
 fun setOnesignalID(onesignalID: String?) {

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -172,6 +172,10 @@ NS_ASSUME_NONNULL_BEGIN
     [RCCommonFunctionality setOnesignalUserID:nil];
     [RCCommonFunctionality setAirshipChannelID:@""];
     [RCCommonFunctionality setAirshipChannelID:nil];
+    [RCCommonFunctionality setTenjinAnalyticsInstallationID:@""];
+    [RCCommonFunctionality setTenjinAnalyticsInstallationID:nil];
+    [RCCommonFunctionality setKochavaDeviceID:@""];
+    [RCCommonFunctionality setKochavaDeviceID:nil];
     [RCCommonFunctionality setMediaSource:@""];
     [RCCommonFunctionality setMediaSource:nil];
     [RCCommonFunctionality setCampaign:@""];

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -577,6 +577,12 @@ import RevenueCat
     @objc static func setFirebaseAppInstanceID(_ firebaseAppInstanceID: String?) {
         Self.sharedInstance.attribution.setFirebaseAppInstanceID(firebaseAppInstanceID)
     }
+    @objc static func setTenjinAnalyticsInstallationID(_ tenjinAnalyticsInstallationID: String?) {
+        Self.sharedInstance.attribution.setTenjinAnalyticsInstallationID(tenjinAnalyticsInstallationID)
+    }
+    @objc static func setKochavaDeviceID(_ kochavaDeviceID: String?) {
+        Self.sharedInstance.attribution.setKochavaDeviceID(kochavaDeviceID)
+    }
     @objc static func setOnesignalID(_ onesignalID: String?) {
         Self.sharedInstance.attribution.setOnesignalID(onesignalID)
     }


### PR DESCRIPTION
This brings the `setKochavaDeviceID` and `setTenjinAnalyticsInstallationID` setter methods to PHC, to be used by the hybrids.
