### PR TITLE
Change dependency-update job to macos machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,6 +413,7 @@ workflows:
       - detekt-android
       - typescript-lint
       - typescript-apitests
+      - dependency-update
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,15 +287,14 @@ jobs:
           command: bundle exec fastlane github_release_current
 
   dependency-update:
-    docker:
-      - image: cimg/ruby:3.3.0
+    <<: *base-ios-job
     steps:
       - checkout
       - attach_workspace:
           at: .
       - setup-git-credentials
       - trust-github-key
-      - revenuecat/install-gem-unix-dependencies:
+      - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - run:
           name: Update dependencies to latest versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,7 +413,6 @@ workflows:
       - detekt-android
       - typescript-lint
       - typescript-apitests
-      - dependency-update
 
   deploy:
     when:


### PR DESCRIPTION
After updating cocoapods in https://github.com/RevenueCat/purchases-hybrid-common/pull/957, it seems the dependency-update job has been failing. I thought about reverting to a previous cocoapods version, but I think it might be good to stay on the latest... 
