### PR TITLE
Add empty `NSPrivacyCollectedDataTypes`

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/PrivacyInfo.xcprivacy
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Adding an empty `NSPrivacyCollectedDataTypes` removes this error when archiving

<img width="948" alt="Screenshot 2024-12-16 at 16 24 59" src="https://github.com/user-attachments/assets/54126775-10b7-42f0-9a86-b6ef9bbcafe1" />

Related community report https://community.revenuecat.com/sdks-51/missing-an-expected-key-nsprivacycollecteddatatypes-5347?postid=18704#post18704