### PR TITLE
Updates `Package.swift` and `Package.resolved`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,14 @@
 {
-  "originHash" : "1c8e7b22f143659dfd3d9b4d8325e3eacccb1e50f24657cf6a87483bc3d6717a",
   "pins" : [
     {
       "identity" : "purchases-ios-spm",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-ios-spm",
       "state" : {
-        "revision" : "92f42b658c9638430d094103d1e86cea950f9ffb",
-        "version" : "5.12.1"
+        "revision" : "27eae63e68557b7866d29c53d8159aa9f2887c2f",
+        "version" : "5.14.0"
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
             targets: ["PurchasesHybridCommonUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/RevenueCat/purchases-ios-spm", exact: "5.12.1"),
+        .package(url: "https://github.com/RevenueCat/purchases-ios-spm", exact: "5.14.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
These seem to have been missed in the manual update in #987. Brought up by https://github.com/RevenueCat/purchases-hybrid-common/issues/966#issuecomment-2554916580. This causes purchases-kmp `1.3.5+13.13.0` to link to the wrong purchases-ios dependency.