### PR TITLE
Add `parseAsWebPurchaseRedemption` API to iOS

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -757,6 +757,13 @@ import RevenueCat
 // MARK: - Redemption links
 @objc public extension CommonFunctionality {
 
+    @objc static func parseAsWebPurchaseRedemption(urlString: String) -> WebPurchaseRedemption? {
+        guard let url = URL(string: urlString) else {
+            return nil
+        }
+        return url.asWebPurchaseRedemption
+    }
+
     @objc(isWebPurchaseRedemptionURL:)
     static func isWebPurchaseRedemptionURL(urlString: String) -> Bool {
         guard let url = URL(string: urlString) else { return false }


### PR DESCRIPTION
This adds a new API to be used by the KMP SDK. This is because we need to have access to the iOS native `WebPurchaseRedemption` object in order to use the native `redeemWebPurchase` method, as we do in the KMP SDK.

 This replaces the PR in https://github.com/RevenueCat/purchases-ios/pull/4629, since we don't really need access to those APIs from the native SDK.
