### PR TITLE
Expose storeKitError for iOS if any

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/ErrorContainer.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/ErrorContainer.swift
@@ -27,6 +27,14 @@ import RevenueCat
 
         info["underlyingErrorMessage"] = underlyingErrorMessage ?? ""
 
+        if let storeKitError = self.findStoreKitErrorCodeIfAny(nsError) {
+            info["storeKitError"] = [
+                "code": storeKitError.code,
+                "domain": storeKitError.domain,
+                "message": storeKitError.localizedDescription
+            ]
+        }
+
         // todo: remove "readable_error_code" and instead send whole user info instead
         // also: code name is already exposed as error.code
         if let readableErrorCode = nsError.userInfo["readable_error_code"] {
@@ -52,5 +60,19 @@ import RevenueCat
         self.error = nsError
 
         self.info = info
+    }
+
+    private func findStoreKitErrorCodeIfAny(_ error: Error) -> NSError? {
+        var currentError: NSError? = error as NSError
+        var storeKitError: NSError?
+        while let underlyingNSError = currentError?.userInfo[NSUnderlyingErrorKey] as? NSError {
+            if underlyingNSError.domain == "StoreKit.StoreKitError" {
+                storeKitError = underlyingNSError
+                break
+            } else {
+                currentError = underlyingNSError
+            }
+        }
+        return storeKitError
     }
 }


### PR DESCRIPTION
This adds the `storeKitError` property that includes the `code`, `domain` and `message` properties for the original storekit error if any.