### PR TITLE
Dismiss PaywallFragment after PaywallActivity is dismissed

### DIFF
--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
@@ -99,7 +99,11 @@ internal class PaywallFragment : Fragment(), PaywallResultHandler {
         // This should normally never happen, but just in case, we don't want to try to present the paywall
         // if the SDK is not configured.
         if (!Purchases.isConfigured) {
-            Log.e("PaywallFragment", "Purchases is not configured. Make sure to call Purchases.configure() before launching the paywall. Dismissing.")
+            Log.e(
+                "PaywallFragment",
+                "Purchases is not configured. " +
+                    "Make sure to call Purchases.configure() before launching the paywall. Dismissing.",
+            )
             removeFragment()
             return
         }

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
@@ -96,6 +96,8 @@ internal class PaywallFragment : Fragment(), PaywallResultHandler {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // This should normally never happen, but just in case, we don't want to try to present the paywall
+        // if the SDK is not configured.
         if (!Purchases.isConfigured) {
             Log.e("PaywallFragment", "Purchases is not configured. Make sure to call Purchases.configure() before launching the paywall. Dismissing.")
             removeFragment()
@@ -132,6 +134,7 @@ internal class PaywallFragment : Fragment(), PaywallResultHandler {
             override fun onPaywallDisplayResult(wasDisplayed: Boolean) {
                 if (!wasDisplayed) {
                     viewModel.paywallResultListener?.onPaywallResult(notPresentedPaywallResult)
+                    removeFragment()
                 }
             }
         }

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
@@ -96,8 +96,6 @@ internal class PaywallFragment : Fragment(), PaywallResultHandler {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // This should normally never happen, but just in case, we don't want to try to present the paywall
-        // if the SDK is not configured.
         if (!Purchases.isConfigured) {
             Log.e("PaywallFragment", "Purchases is not configured. Make sure to call Purchases.configure() before launching the paywall. Dismissing.")
             removeFragment()

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
@@ -2,9 +2,11 @@ package com.revenuecat.purchases.hybridcommon.ui
 
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
+import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallDisplayCallback
@@ -94,6 +96,14 @@ internal class PaywallFragment : Fragment(), PaywallResultHandler {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // This should normally never happen, but just in case, we don't want to try to present the paywall
+        // if the SDK is not configured.
+        if (!Purchases.isConfigured) {
+            Log.e("PaywallFragment", "Purchases is not configured. Make sure to call Purchases.configure() before launching the paywall. Dismissing.")
+            removeFragment()
+            return
+        }
+
         launcher = PaywallActivityLauncher(
             this,
             this,
@@ -108,6 +118,11 @@ internal class PaywallFragment : Fragment(), PaywallResultHandler {
     override fun onActivityResult(result: PaywallResult) {
         viewModel.paywallResultListener?.onPaywallResult(result)
         viewModel.paywallResultListener?.onPaywallResult(result.name)
+        removeFragment()
+    }
+
+    private fun removeFragment() {
+        parentFragmentManager.beginTransaction().remove(this).commit()
     }
 
     private fun launchPaywallIfNeeded(requiredEntitlementIdentifier: String) {


### PR DESCRIPTION
We were not dismissing the `PaywallFragment` after the `PaywallActivity` was closed. This caused some crashes like: https://github.com/RevenueCat/purchases-flutter/issues/1090.

Repro steps were:
- Present paywall
- Dismiss it
- Background the app
- Wait for app to be killed by the system or kill it with adb
- Reopen app and crash