### PR TITLE
Adds API availability check for `enableAdServicesAttributionTokenCollection()`

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/IOSAPIAvailabilityChecker.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/IOSAPIAvailabilityChecker.swift
@@ -32,12 +32,13 @@ public final class IOSAPIAvailabilityChecker: NSObject {
     public func isEnableAdServicesAttributionTokenCollectionAPIAvailable() -> Bool {
         #if os(tvOS) || os(watchOS)
             return false
+        #else
+            if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
+                return true
+            } else {
+                return false
+            }
         #endif
-        if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
-            return true
-        } else {
-            return false
-        }
     }
 
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/IOSAPIAvailabilityChecker.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/IOSAPIAvailabilityChecker.swift
@@ -24,5 +24,20 @@ public final class IOSAPIAvailabilityChecker: NSObject {
             return false
         }
     }
+    
+    /// Determines if the enableAdServicesAttributionTokenCollection API is available on the current device.
+    ///
+    /// - Returns: `true` if the enableAdServicesAttributionTokenCollection API is available, `false` otherwise.
+    @objc
+    public func isEnableAdServicesAttributionTokenCollectionAPIAvailable() -> Bool {
+        #if os(tvOS) || os(watchOS)
+            return false
+        #endif
+        if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
+            return true
+        } else {
+            return false
+        }
+    }
 
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/IOSAPIAvailabilityChecker.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/IOSAPIAvailabilityChecker.swift
@@ -27,7 +27,8 @@ public final class IOSAPIAvailabilityChecker: NSObject {
     
     /// Determines if the enableAdServicesAttributionTokenCollection API is available on the current device.
     ///
-    /// - Returns: `true` if the enableAdServicesAttributionTokenCollection API is available, `false` otherwise.
+    /// - Returns: `true` if the ``CommonFunctionality/enableAdServicesAttributionTokenCollection()`` API is available,
+    /// `false` otherwise.
     @objc
     public func isEnableAdServicesAttributionTokenCollectionAPIAvailable() -> Bool {
         #if os(tvOS) || os(watchOS)


### PR DESCRIPTION
## Description
This is in line with https://github.com/RevenueCat/purchases-hybrid-common/pull/1008 and in preparation of https://github.com/RevenueCat/purchases-kmp/issues/294.