### PR TITLE
[CI] Remove requirement for pod push to succeed to continue release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,8 +441,6 @@ workflows:
       - make-github-release:
           <<: *release-tags
           requires:
-            - deploy-ios-phc
-            - deploy-ios-phcui
             - deploy-android
             - deploy-typescript
             - deploy-typescript-esm


### PR DESCRIPTION
Pushing new pods has been very brittle lately. It's been a problem since our current CI doesn't allow to continue the workflow after the job fails. This makes it so the release process can continue even if pushing the pods fail.

Some notes about this:
- We are still running the pod lint command for the tests before releasing
- There is still a dependency of the `phcui` library to `phc`. This is because the first one depends on the second one, so it doesn't make sense to continue if the first one failed.

