### PR TITLE
Import foundation in IOSAPIAvailabilityChecker

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/IOSAPIAvailabilityChecker.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/IOSAPIAvailabilityChecker.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2025 RevenueCat. All rights reserved.
 //
 
+import Foundation
+
 /// A utility class that checks the availability of iOS-specific APIs based on the operating system version.
 @objc
 public final class IOSAPIAvailabilityChecker: NSObject {


### PR DESCRIPTION
When building PHC alone and as a part of the KMP Purchase Tester app, the IOSAPIAvailabilityChecker class compiles, but when building it in an app using the KMP SDK, it fails to build with the following errors:

![image](https://github.com/user-attachments/assets/988f04ab-3994-4ce8-b59e-1cf181e63af1)

This PR imports Foundation in `IOSAPIAvailabilityChecker` to avoid these errors.

## Testing
I manually added this line in my KMP app and this resolved the build failures.