### PR TITLE
Adds `IntroEligibility` to public API surface

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		57FFDE3F286A777D0089A57B /* StoreKitIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFDE3E286A777D0089A57B /* StoreKitIntegrationTests.swift */; };
 		57FFDE41286A77E30089A57B /* CommonFunctionality+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFDE40286A77E30089A57B /* CommonFunctionality+async.swift */; };
 		57FFDE46286B606A0089A57B /* XCTestCase+Expectations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD3D1842810A81F00A19EC6 /* XCTestCase+Expectations.swift */; };
+		7720A92A2D520021009EA43C /* IntroEligibility+HybridExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7720A9292D520021009EA43C /* IntroEligibility+HybridExtensions.swift */; };
 		77D5E72A2C233E2C002ECC77 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D5E7292C233E2C002ECC77 /* Constants.swift */; };
 		AE0B58267EE48614BBF43A9E /* Pods_PurchasesHybridCommonUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D02631302E453BBC6C5F5471 /* Pods_PurchasesHybridCommonUI.framework */; };
 		B1C9A7EEA6961CC6DE22BCAD /* Pods_PurchasesHybridCommon_PurchasesHybridCommonTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E05FA8EACFF88F020CF8B9BB /* Pods_PurchasesHybridCommon_PurchasesHybridCommonTests.framework */; };
@@ -193,6 +194,7 @@
 		711DF19865BA5A0D096991CE /* Pods-PurchasesHybridCommon.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommon.release.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommon/Pods-PurchasesHybridCommon.release.xcconfig"; sourceTree = "<group>"; };
 		7242C47A3C4806DEA1CF448A /* Pods_PurchasesHybridCommonSwift_PurchasesHybridCommonSwiftTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PurchasesHybridCommonSwift_PurchasesHybridCommonSwiftTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		73AF1F3DF376D2EA6B061FDB /* Pods_PurchasesHybridCommon_PurchasesHybridCommonIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PurchasesHybridCommon_PurchasesHybridCommonIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7720A9292D520021009EA43C /* IntroEligibility+HybridExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntroEligibility+HybridExtensions.swift"; sourceTree = "<group>"; };
 		77D5E7292C233E2C002ECC77 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		874034FC7C4796FE81D5697E /* Pods-ObjCAPITester.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjCAPITester.release.xcconfig"; path = "Target Support Files/Pods-ObjCAPITester/Pods-ObjCAPITester.release.xcconfig"; sourceTree = "<group>"; };
 		8C34B61CED05F8CC62580BC8 /* Pods-PurchasesHybridCommonTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommonTests.release.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommonTests/Pods-PurchasesHybridCommonTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -375,6 +377,7 @@
 				FD3652DE2C53EFD400B513F6 /* PurchasesAreCompletedBy+HybridAdditions.swift */,
 				FD5EB01E2CEBC2CF004B88EF /* WinBackOffer+HybridAdditions.swift */,
 				FD178BD72D42BFE10000BE8E /* PurchaseParamsBuilder+HybridExtensions.swift */,
+				7720A9292D520021009EA43C /* IntroEligibility+HybridExtensions.swift */,
 			);
 			path = PurchasesHybridCommon;
 			sourceTree = "<group>";
@@ -879,6 +882,7 @@
 				2DD3D18F2810AF5A00A19EC6 /* EntitlementInfo+HybridAdditions.swift in Sources */,
 				2DD3D1922810AF5A00A19EC6 /* PromotionalOffer+HybridAdditions.swift in Sources */,
 				FD5EB01F2CEBC2CF004B88EF /* WinBackOffer+HybridAdditions.swift in Sources */,
+				7720A92A2D520021009EA43C /* IntroEligibility+HybridExtensions.swift in Sources */,
 				2DD3D1862810AF5A00A19EC6 /* Package+HybridAdditions.swift in Sources */,
 				2DD3D18C2810AF5A00A19EC6 /* Purchases+HybridAdditions.swift in Sources */,
 				2DD3D18D2810AF5A00A19EC6 /* StoreTransaction+HybridAdditions.swift in Sources */,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/IntroEligibility+HybridExtensions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/IntroEligibility+HybridExtensions.swift
@@ -1,0 +1,21 @@
+//
+//  IntroEligibility+HybridExtensions.swift
+//  PurchasesHybridCommon
+//
+//  Created by Jay Shortway on 04/02/2025.
+//  Copyright © 2025 RevenueCat. All rights reserved.
+//
+
+import Foundation
+import RevenueCat
+
+@objc
+public extension IntroEligibility {
+
+    // IntroEligibilityisn't exposed as a part of the PHC's public API to KMP by default.
+    // We can expose it by adding this function to the IntroEligibility class. This function is intentionally a no-op
+    // and shouldn't be called anywhere but also shouldn't be removed without ensuring that the IntroEligibility
+    // class is exposed to KMP in some other way.
+    @objc
+    func noOP() {}
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/IntroEligibility+HybridExtensions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/IntroEligibility+HybridExtensions.swift
@@ -12,7 +12,7 @@ import RevenueCat
 @objc
 public extension IntroEligibility {
 
-    // IntroEligibilityisn't exposed as a part of the PHC's public API to KMP by default.
+    // IntroEligibility isn't exposed as a part of the PHC's public API to KMP by default.
     // We can expose it by adding this function to the IntroEligibility class. This function is intentionally a no-op
     // and shouldn't be called anywhere but also shouldn't be removed without ensuring that the IntroEligibility
     // class is exposed to KMP in some other way.


### PR DESCRIPTION
## Motivation
This is done in preparation of https://github.com/RevenueCat/purchases-kmp/issues/309.

It uses the same approach as in https://github.com/RevenueCat/purchases-hybrid-common/pull/1028. 