### PR TITLE
Add prepaid as a period type

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementInfo+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/EntitlementInfo+HybridAdditions.swift
@@ -48,6 +48,8 @@ private extension EntitlementInfo {
             return "NORMAL"
         case .trial:
             return "TRIAL"
+        case .prepaid:
+            return "PREPAID"
         @unknown default:
             return "UNKNOWN"
         }

--- a/typescript/src/customerInfo.ts
+++ b/typescript/src/customerInfo.ts
@@ -18,7 +18,7 @@ export interface PurchasesEntitlementInfo {
      */
     readonly willRenew: boolean;
     /**
-     * The last period type this entitlement was in. Either: NORMAL, INTRO, TRIAL.
+     * The last period type this entitlement was in. Either: NORMAL, INTRO, TRIAL, PREPAID.
      */
     readonly periodType: string;
     /**


### PR DESCRIPTION
Added prepaid as a periodType [here](https://github.com/RevenueCat/purchases-android/pull/2141#event-16278601110). 

Not sure if this is all we need for hybrids though. 