### PR TITLE
chore: Fix Gemfile versions to avoid Gemfile.lock updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source "https://rubygems.org"
 
-gem "fastlane"
+gem 'fastlane', '2.226.0'
 
 eval_gemfile("fastlane/Pluginfile")
 
 gem "cocoapods", "~> 1.16"
-gem 'danger'
-gem 'rest-client'
-gem "lefthook", "~> 1.10"
+gem 'danger', '9.5.1'
+gem 'rest-client', '2.1.0'
+gem "lefthook", "1.10.10"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,21 +32,22 @@ GEM
       json (>= 1.5.1)
     artifactory (3.0.17)
     atomos (0.1.3)
-    aws-eventstream (1.3.0)
-    aws-partitions (1.1021.0)
-    aws-sdk-core (3.214.0)
+    aws-eventstream (1.3.1)
+    aws-partitions (1.1052.0)
+    aws-sdk-core (3.219.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
+      base64
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.96.0)
-      aws-sdk-core (~> 3, >= 3.210.0)
+    aws-sdk-kms (1.99.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.176.0)
-      aws-sdk-core (~> 3, >= 3.210.0)
+    aws-sdk-s3 (1.182.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
-    aws-sigv4 (1.10.1)
+    aws-sigv4 (1.11.0)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     base64 (0.2.0)
@@ -117,7 +118,7 @@ GEM
       pstore (~> 0.1)
       terminal-table (>= 1, < 4)
     declarative (0.0.20)
-    digest-crc (0.6.5)
+    digest-crc (0.7.0)
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
@@ -157,7 +158,7 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
-    fastimage (2.3.1)
+    fastimage (2.4.0)
     fastlane (2.226.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
@@ -204,7 +205,6 @@ GEM
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
     ffi (1.17.0)
-    ffi (1.17.0-arm64-darwin)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -256,7 +256,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
     json (2.9.0)
-    jwt (2.9.3)
+    jwt (2.10.1)
       base64
     kramdown (2.4.0)
       rexml
@@ -283,15 +283,13 @@ GEM
     nokogiri (1.17.1)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.17.1-arm64-darwin)
-      racc (~> 1.4)
     octokit (9.2.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     open4 (1.3.4)
     optparse (0.6.0)
     os (1.1.4)
-    plist (3.7.1)
+    plist (3.7.2)
     pstore (0.1.3)
     public_suffix (4.0.7)
     racc (1.8.1)
@@ -311,7 +309,7 @@ GEM
     rouge (3.28.0)
     ruby-macho (2.5.1)
     ruby2_keywords (0.0.5)
-    rubyzip (2.3.2)
+    rubyzip (2.4.1)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -359,12 +357,12 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 1.16)
-  danger
-  fastlane
+  danger (= 9.5.1)
+  fastlane (= 2.226.0)
   fastlane-plugin-revenuecat_internal!
   fastlane-plugin-versioning_android
-  lefthook (~> 1.10)
-  rest-client
+  lefthook (= 1.10.10)
+  rest-client (= 2.1.0)
 
 BUNDLED WITH
    2.4.6


### PR DESCRIPTION
This PR fixes the Gemfile to avoid unnecessary .lock updates