### PR TITLE
fix: improve period unit ts type

### DIFF
--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -385,7 +385,7 @@ export interface PurchasesIntroPrice {
     readonly cycles: number;
     readonly period: string;
     readonly periodNumberOfUnits: number;
-    readonly periodUnit: string;
+    readonly periodUnit: "DAY" | "WEEK" | "MONTH" | "YEAR";
     readonly price: number;
     readonly priceString: string;
 }

--- a/typescript/src/offerings.ts
+++ b/typescript/src/offerings.ts
@@ -311,7 +311,7 @@ export interface PurchasesIntroPrice {
   /**
    * Unit for the billing period of the discount, can be DAY, WEEK, MONTH or YEAR.
    */
-  readonly periodUnit: string;
+  readonly periodUnit: "DAY" | "WEEK" | "MONTH" | "YEAR";
   /**
    * Number of units for the billing period of the discount.
    */


### PR DESCRIPTION
Thank you for contributing to purchases-hybrid-common. Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial: 
  		If periodUnit can be only `DAY, WEEK, MONTH or YEAR` as mentioned in the comment, then it is better to type it that way. Makes it easier to switch on the predefined union or perform if checks with intellisense

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those:
  		There is no issue number

  - [x] If applicable, unit tests.
  		Not applicable
