### PR TITLE
chore: clarify namespace for Xcode 16.3 iOS 18.4

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProduct+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/StoreProduct+HybridAdditions.swift
@@ -93,7 +93,7 @@ internal extension StoreProduct {
         return dictionary
     }
 
-    static func rc_normalized(subscriptionPeriod: SubscriptionPeriod) -> String {
+    static func rc_normalized(subscriptionPeriod: RevenueCat.SubscriptionPeriod) -> String {
         let unitString: String
         switch subscriptionPeriod.unit {
         case .day:
@@ -110,7 +110,7 @@ internal extension StoreProduct {
         return "P\(subscriptionPeriod.value)\(unitString)"
     }
 
-    static func rc_normalized(subscriptionPeriodUnit: SubscriptionPeriod.Unit) -> String {
+    static func rc_normalized(subscriptionPeriodUnit: RevenueCat.SubscriptionPeriod.Unit) -> String {
         switch subscriptionPeriodUnit {
         case .day:
             return "DAY"


### PR DESCRIPTION
Trivial resolution of a namespace issue introduced by StoreKit's new SubscriptionPeriod symbol in Xcode 16.3 affecting our builds. See issue #1051. 