### PR TITLE
feat(ios): expose showManageSubscriptions

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -198,6 +198,18 @@ import RevenueCat
 
 }
 
+// MARK: Manage subscriptions
+@objc public extension CommonFunctionality {
+
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(iOS 13.0, macOS 10.15, *)
+    @objc(showManageSubscriptions:)
+    static func showManageSubscriptions() async throws {
+        try await Purchases.shared.showManageSubscriptions()
+    }
+}
+
 // MARK: In app messages
 @objc public extension CommonFunctionality {
 


### PR DESCRIPTION
This makes it possible to show an in-app modal to manage users subscriptions (without having being redirected outside of the app).

Many people are requesting this in the react native package: https://github.com/RevenueCat/react-native-purchases/issues/816