### PR TITLE
[EXTERNAL] feat(ios): expose showManageSubscriptions (#1064) by @dylancom

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -198,6 +198,8 @@ import RevenueCat
 
 }
 
+#if os(iOS) || os(macOS) || VISION_OS
+
 // MARK: Manage subscriptions
 @objc public extension CommonFunctionality {
 
@@ -216,6 +218,8 @@ import RevenueCat
         }
     }
 }
+
+#endif
 
 // MARK: In app messages
 @objc public extension CommonFunctionality {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -201,9 +201,9 @@ import RevenueCat
 // MARK: Manage subscriptions
 @objc public extension CommonFunctionality {
 
+    @available(iOS 13.0, macOS 10.15, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    @available(iOS 13.0, macOS 10.15, *)
     @objc(showManageSubscriptions:)
     static func showManageSubscriptions() async throws {
         try await Purchases.shared.showManageSubscriptions()

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -205,8 +205,15 @@ import RevenueCat
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     @objc(showManageSubscriptions:)
-    static func showManageSubscriptions() async throws {
-        try await Purchases.shared.showManageSubscriptions()
+    static func showManageSubscriptions(completion: @escaping (ErrorContainer?) -> Void) {
+        _ = Task<Void, Never> {
+            do {
+                try await Self.sharedInstance.showManageSubscriptions()
+                completion(nil)
+            } catch {
+                completion(Self.createErrorContainer(error: error))
+            }
+        }
     }
 }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -198,6 +198,18 @@ import RevenueCat
 
 }
 
+// MARK: Manage subscriptions
+@objc public extension CommonFunctionality {
+
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(iOS 13.0, macOS 10.15, *)
+    @objc(showManageSubscriptions:)
+    static func showManageSubscriptions() async throws {
+        try await Purchases.shared.showManageSubscriptions()
+    }
+}
+
 // MARK: In app messages
 @objc public extension CommonFunctionality {
 


### PR DESCRIPTION
This makes it possible to show an in-app modal to manage users subscriptions (without having being redirected outside of the app).

Many people are requesting this in the react native package: https://github.com/RevenueCat/react-native-purchases/issues/816

Contributed by @dylancom in #1064 
