### PR TITLE
Add `subscriptionsByProductIdentifier` to CustomerInfo

### DIFF
--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -32,6 +32,9 @@ export interface CustomerInfo {
     readonly originalAppUserId: string;
     readonly originalPurchaseDate: string | null;
     readonly requestDate: string;
+    readonly subscriptionsByProductIdentifier: {
+        [key: string]: PurchasesSubscriptionInfo;
+    };
 }
 
 // @public

--- a/typescript/src/customerInfo.ts
+++ b/typescript/src/customerInfo.ts
@@ -208,6 +208,11 @@ export interface CustomerInfo {
      * non-subscription purchases
      */
     readonly nonSubscriptionTransactions: PurchasesStoreTransaction[];
+
+    /**
+     * Information about the customer's subscriptions for each product identifier.
+     */
+    readonly subscriptionsByProductIdentifier: { [key: string]: PurchasesSubscriptionInfo };
 }
 
 /**


### PR DESCRIPTION
I forgot to add this in #1067, so it's not available in the RN + capacitor yet.
