### PR TITLE
[purchases-js-hybrid-mapping] Add mapping for errors and run prettier in the library

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -465,7 +465,7 @@ platform :web do
   desc "Run linter for purchases-js-hybrid-mappings"
   lane :lint_js_mappings do |options|
     Dir.chdir(File.expand_path('purchases-js-hybrid-mappings', get_root_folder)) do
-      sh("yarn && yarn lint")
+      sh("yarn && yarn format:check && yarn lint")
     end
   end
 end

--- a/purchases-js-hybrid-mappings/.prettierrc
+++ b/purchases-js-hybrid-mappings/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "bracketSpacing": true,
+  "arrowParens": "avoid"
+} 

--- a/purchases-js-hybrid-mappings/package.json
+++ b/purchases-js-hybrid-mappings/package.json
@@ -23,7 +23,9 @@
     "api-test:ci": "npm run build && api-extractor run --verbose",
     "prepack": "npm run build && api-extractor run --local",
     "lint": "eslint . --ext .ts",
-    "lint:fix": "eslint . --ext .ts --fix"
+    "lint:fix": "eslint . --ext .ts --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\""
   },
   "dependencies": {
     "@revenuecat/purchases-js": "^1.1.0"
@@ -35,6 +37,7 @@
     "@typescript-eslint/parser": "^7.1.0",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
+    "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",
     "typescript": "~5.3.3"
   },

--- a/purchases-js-hybrid-mappings/src/mappers/customer_info_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/customer_info_mapper.ts
@@ -3,123 +3,191 @@ import {
   EntitlementInfo,
   EntitlementInfos,
   NonSubscriptionTransaction,
-  PeriodType, SubscriptionInfo
-} from "@revenuecat/purchases-js";
+  PeriodType,
+  SubscriptionInfo,
+} from '@revenuecat/purchases-js';
 
 export function mapCustomerInfo(customerInfo: CustomerInfo): Record<string, unknown> {
-  const validDates = Object.values(customerInfo.allExpirationDatesByProduct).filter((date): date is Date => date !== null);
-  const latestExpirationDate = validDates.length > 0 ? new Date(Math.max(...validDates.map((date) => date.getTime()))) : null;
+  const validDates = Object.values(customerInfo.allExpirationDatesByProduct).filter(
+    (date): date is Date => date !== null,
+  );
+  const latestExpirationDate =
+    validDates.length > 0 ? new Date(Math.max(...validDates.map(date => date.getTime()))) : null;
 
   return {
-    "entitlements": mapEntitlementInfos(customerInfo.entitlements),
-    "activeSubscriptions": Array.from(customerInfo.activeSubscriptions),
-    "allPurchasedProductIdentifiers": Object.keys(customerInfo.allPurchaseDatesByProduct),
-    "latestExpirationDate": latestExpirationDate ? latestExpirationDate.toISOString() : null,
-    "latestExpirationDateMillis": latestExpirationDate ? latestExpirationDate.getTime() : null,
-    "firstSeen": customerInfo.firstSeenDate.toISOString(),
-    "firstSeenMillis": customerInfo.firstSeenDate.getTime(),
-    "originalAppUserId": customerInfo.originalAppUserId,
-    "requestDate": customerInfo.requestDate.toISOString(),
-    "requestDateMillis": customerInfo.requestDate.getTime(),
-    "allExpirationDates": Object.fromEntries(
-      Object.entries(customerInfo.allExpirationDatesByProduct).map(([key, value]) => [key, value ? value.toISOString() : null])
+    entitlements: mapEntitlementInfos(customerInfo.entitlements),
+    activeSubscriptions: Array.from(customerInfo.activeSubscriptions),
+    allPurchasedProductIdentifiers: Object.keys(customerInfo.allPurchaseDatesByProduct),
+    latestExpirationDate: latestExpirationDate ? latestExpirationDate.toISOString() : null,
+    latestExpirationDateMillis: latestExpirationDate ? latestExpirationDate.getTime() : null,
+    firstSeen: customerInfo.firstSeenDate.toISOString(),
+    firstSeenMillis: customerInfo.firstSeenDate.getTime(),
+    originalAppUserId: customerInfo.originalAppUserId,
+    requestDate: customerInfo.requestDate.toISOString(),
+    requestDateMillis: customerInfo.requestDate.getTime(),
+    allExpirationDates: Object.fromEntries(
+      Object.entries(customerInfo.allExpirationDatesByProduct).map(([key, value]) => [
+        key,
+        value ? value.toISOString() : null,
+      ]),
     ),
-    "allExpirationDatesMillis": Object.fromEntries(
-      Object.entries(customerInfo.allExpirationDatesByProduct).map(([key, value]) => [key, value ? value.getTime() : null])
+    allExpirationDatesMillis: Object.fromEntries(
+      Object.entries(customerInfo.allExpirationDatesByProduct).map(([key, value]) => [
+        key,
+        value ? value.getTime() : null,
+      ]),
     ),
-    "allPurchaseDates": Object.fromEntries(
-      Object.entries(customerInfo.allPurchaseDatesByProduct).map(([key, value]) => [key, value ? value.toISOString() : null])
+    allPurchaseDates: Object.fromEntries(
+      Object.entries(customerInfo.allPurchaseDatesByProduct).map(([key, value]) => [
+        key,
+        value ? value.toISOString() : null,
+      ]),
     ),
-    "allPurchaseDatesMillis": Object.fromEntries(
-      Object.entries(customerInfo.allPurchaseDatesByProduct).map(([key, value]) => [key, value ? value.getTime() : null])
+    allPurchaseDatesMillis: Object.fromEntries(
+      Object.entries(customerInfo.allPurchaseDatesByProduct).map(([key, value]) => [
+        key,
+        value ? value.getTime() : null,
+      ]),
     ),
-    "originalApplicationVersion": null,
-    "managementURL": customerInfo.managementURL,
-    "originalPurchaseDate": customerInfo.originalPurchaseDate ? customerInfo.originalPurchaseDate.toISOString() : null,
-    "originalPurchaseDateMillis": customerInfo.originalPurchaseDate ? customerInfo.originalPurchaseDate.getTime() : null,
-    "nonSubscriptionTransactions": mapNonSubscriptionTransactions(customerInfo.nonSubscriptionTransactions),
-    "subscriptionsByProductIdentifier": mapSubscriptionInfos(customerInfo.subscriptionsByProductIdentifier),
+    originalApplicationVersion: null,
+    managementURL: customerInfo.managementURL,
+    originalPurchaseDate: customerInfo.originalPurchaseDate
+      ? customerInfo.originalPurchaseDate.toISOString()
+      : null,
+    originalPurchaseDateMillis: customerInfo.originalPurchaseDate
+      ? customerInfo.originalPurchaseDate.getTime()
+      : null,
+    nonSubscriptionTransactions: mapNonSubscriptionTransactions(
+      customerInfo.nonSubscriptionTransactions,
+    ),
+    subscriptionsByProductIdentifier: mapSubscriptionInfos(
+      customerInfo.subscriptionsByProductIdentifier,
+    ),
   };
 }
 
 function mapEntitlementInfos(entitlementInfos: EntitlementInfos): Record<string, unknown> {
   return {
-    "all": Object.fromEntries(
-      Object.entries(entitlementInfos.all).map(([key, value]) => [key, mapEntitlementInfo(value)])
+    all: Object.fromEntries(
+      Object.entries(entitlementInfos.all).map(([key, value]) => [key, mapEntitlementInfo(value)]),
     ),
-    "active": Object.fromEntries(
-      Object.entries(entitlementInfos.active).map(([key, value]) => [key, mapEntitlementInfo(value)])
+    active: Object.fromEntries(
+      Object.entries(entitlementInfos.active).map(([key, value]) => [
+        key,
+        mapEntitlementInfo(value),
+      ]),
     ),
-    "verification": "NOT_REQUESTED" // TODO: Trusted entitlements not available in JS SDK
+    verification: 'NOT_REQUESTED', // TODO: Trusted entitlements not available in JS SDK
   };
 }
 
 function mapEntitlementInfo(entitlementInfo: EntitlementInfo): Record<string, unknown> {
   return {
-    "identifier": entitlementInfo.identifier,
-    "isActive": entitlementInfo.isActive,
-    "willRenew": entitlementInfo.willRenew,
-    "periodType": mapPeriodType(entitlementInfo.periodType),
-    "latestPurchaseDate": entitlementInfo.latestPurchaseDate ? entitlementInfo.latestPurchaseDate.toISOString() : null,
-    "latestPurchaseDateMillis": entitlementInfo.latestPurchaseDate ? entitlementInfo.latestPurchaseDate.getTime() : null,
-    "originalPurchaseDate": entitlementInfo.originalPurchaseDate ? entitlementInfo.originalPurchaseDate.toISOString() : null,
-    "originalPurchaseDateMillis": entitlementInfo.originalPurchaseDate ? entitlementInfo.originalPurchaseDate.getTime() : null,
-    "expirationDate": entitlementInfo.expirationDate ? entitlementInfo.expirationDate.toISOString() : null,
-    "expirationDateMillis": entitlementInfo.expirationDate ? entitlementInfo.expirationDate.getTime() : null,
-    "store": entitlementInfo.store,
-    "productIdentifier": entitlementInfo.productIdentifier,
-    "productPlanIdentifier": entitlementInfo.productPlanIdentifier,
-    "isSandbox": entitlementInfo.isSandbox,
-    "unsubscribeDetectedAt": entitlementInfo.unsubscribeDetectedAt ? entitlementInfo.unsubscribeDetectedAt.toISOString() : null,
-    "unsubscribeDetectedAtMillis": entitlementInfo.unsubscribeDetectedAt ? entitlementInfo.unsubscribeDetectedAt.getTime() : null,
-    "billingIssueDetectedAt": entitlementInfo.billingIssueDetectedAt ? entitlementInfo.billingIssueDetectedAt.toISOString() : null,
-    "billingIssueDetectedAtMillis": entitlementInfo.billingIssueDetectedAt ? entitlementInfo.billingIssueDetectedAt.getTime() : null,
-    "ownershipType": entitlementInfo.ownershipType,
-    "verification": "NOT_REQUESTED", // TODO: Trusted entitlements not available in JS SDK
+    identifier: entitlementInfo.identifier,
+    isActive: entitlementInfo.isActive,
+    willRenew: entitlementInfo.willRenew,
+    periodType: mapPeriodType(entitlementInfo.periodType),
+    latestPurchaseDate: entitlementInfo.latestPurchaseDate
+      ? entitlementInfo.latestPurchaseDate.toISOString()
+      : null,
+    latestPurchaseDateMillis: entitlementInfo.latestPurchaseDate
+      ? entitlementInfo.latestPurchaseDate.getTime()
+      : null,
+    originalPurchaseDate: entitlementInfo.originalPurchaseDate
+      ? entitlementInfo.originalPurchaseDate.toISOString()
+      : null,
+    originalPurchaseDateMillis: entitlementInfo.originalPurchaseDate
+      ? entitlementInfo.originalPurchaseDate.getTime()
+      : null,
+    expirationDate: entitlementInfo.expirationDate
+      ? entitlementInfo.expirationDate.toISOString()
+      : null,
+    expirationDateMillis: entitlementInfo.expirationDate
+      ? entitlementInfo.expirationDate.getTime()
+      : null,
+    store: entitlementInfo.store,
+    productIdentifier: entitlementInfo.productIdentifier,
+    productPlanIdentifier: entitlementInfo.productPlanIdentifier,
+    isSandbox: entitlementInfo.isSandbox,
+    unsubscribeDetectedAt: entitlementInfo.unsubscribeDetectedAt
+      ? entitlementInfo.unsubscribeDetectedAt.toISOString()
+      : null,
+    unsubscribeDetectedAtMillis: entitlementInfo.unsubscribeDetectedAt
+      ? entitlementInfo.unsubscribeDetectedAt.getTime()
+      : null,
+    billingIssueDetectedAt: entitlementInfo.billingIssueDetectedAt
+      ? entitlementInfo.billingIssueDetectedAt.toISOString()
+      : null,
+    billingIssueDetectedAtMillis: entitlementInfo.billingIssueDetectedAt
+      ? entitlementInfo.billingIssueDetectedAt.getTime()
+      : null,
+    ownershipType: entitlementInfo.ownershipType,
+    verification: 'NOT_REQUESTED', // TODO: Trusted entitlements not available in JS SDK
   };
 }
 
-function mapNonSubscriptionTransactions(nonSubscriptionTransactions: NonSubscriptionTransaction[]): Record<string, unknown>[] {
-  return nonSubscriptionTransactions.map((transaction) => {
+function mapNonSubscriptionTransactions(
+  nonSubscriptionTransactions: NonSubscriptionTransaction[],
+): Record<string, unknown>[] {
+  return nonSubscriptionTransactions.map(transaction => {
     return {
-      "transactionIdentifier": transaction.transactionIdentifier,
-      "revenueCatId": transaction.transactionIdentifier, // Deprecated: Use transactionIdentifier in this map instead
-      "productIdentifier": transaction.productIdentifier,
-      "productId": transaction.productIdentifier, // Deprecated: Use productIdentifier in this map instead
-      "purchaseDate": transaction.purchaseDate.toISOString(),
-      "purchaseDateMillis": transaction.purchaseDate.getTime(),
-      "store": transaction.store,
+      transactionIdentifier: transaction.transactionIdentifier,
+      revenueCatId: transaction.transactionIdentifier, // Deprecated: Use transactionIdentifier in this map instead
+      productIdentifier: transaction.productIdentifier,
+      productId: transaction.productIdentifier, // Deprecated: Use productIdentifier in this map instead
+      purchaseDate: transaction.purchaseDate.toISOString(),
+      purchaseDateMillis: transaction.purchaseDate.getTime(),
+      store: transaction.store,
     };
   });
 }
 
-function mapSubscriptionInfos(subscriptionsByProductIdentifier: Record<string, SubscriptionInfo>): Record<string, unknown> {
+function mapSubscriptionInfos(
+  subscriptionsByProductIdentifier: Record<string, SubscriptionInfo>,
+): Record<string, unknown> {
   return Object.fromEntries(
-    Object.entries(subscriptionsByProductIdentifier).map(([productId, subscriptionInfo]) => [productId, {
-      "productIdentifier": subscriptionInfo.productIdentifier,
-      "purchaseDate": subscriptionInfo.purchaseDate.toISOString(),
-      "originalPurchaseDate": subscriptionInfo.originalPurchaseDate ? subscriptionInfo.originalPurchaseDate.toISOString() : null,
-      "expiresDate": subscriptionInfo.expiresDate ? subscriptionInfo.expiresDate.toISOString() : null,
-      "store": subscriptionInfo.store,
-      "isSandbox": subscriptionInfo.isSandbox,
-      "unsubscribeDetectedAt": subscriptionInfo.unsubscribeDetectedAt ? subscriptionInfo.unsubscribeDetectedAt.toISOString() : null,
-      "billingIssuesDetectedAt": subscriptionInfo.billingIssuesDetectedAt ? subscriptionInfo.billingIssuesDetectedAt.toISOString() : null,
-      "gracePeriodExpiresDate": subscriptionInfo.gracePeriodExpiresDate ? subscriptionInfo.gracePeriodExpiresDate.toISOString() : null,
-      "ownershipType": subscriptionInfo.ownershipType,
-      "periodType": mapPeriodType(subscriptionInfo.periodType),
-      "refundedAt": subscriptionInfo.refundedAt ? subscriptionInfo.refundedAt.toISOString() : null,
-      "storeTransactionId": subscriptionInfo.storeTransactionId,
-      "isActive": subscriptionInfo.isActive,
-      "willRenew": subscriptionInfo.willRenew,
-    }])
-  )
+    Object.entries(subscriptionsByProductIdentifier).map(([productId, subscriptionInfo]) => [
+      productId,
+      {
+        productIdentifier: subscriptionInfo.productIdentifier,
+        purchaseDate: subscriptionInfo.purchaseDate.toISOString(),
+        originalPurchaseDate: subscriptionInfo.originalPurchaseDate
+          ? subscriptionInfo.originalPurchaseDate.toISOString()
+          : null,
+        expiresDate: subscriptionInfo.expiresDate
+          ? subscriptionInfo.expiresDate.toISOString()
+          : null,
+        store: subscriptionInfo.store,
+        isSandbox: subscriptionInfo.isSandbox,
+        unsubscribeDetectedAt: subscriptionInfo.unsubscribeDetectedAt
+          ? subscriptionInfo.unsubscribeDetectedAt.toISOString()
+          : null,
+        billingIssuesDetectedAt: subscriptionInfo.billingIssuesDetectedAt
+          ? subscriptionInfo.billingIssuesDetectedAt.toISOString()
+          : null,
+        gracePeriodExpiresDate: subscriptionInfo.gracePeriodExpiresDate
+          ? subscriptionInfo.gracePeriodExpiresDate.toISOString()
+          : null,
+        ownershipType: subscriptionInfo.ownershipType,
+        periodType: mapPeriodType(subscriptionInfo.periodType),
+        refundedAt: subscriptionInfo.refundedAt ? subscriptionInfo.refundedAt.toISOString() : null,
+        storeTransactionId: subscriptionInfo.storeTransactionId,
+        isActive: subscriptionInfo.isActive,
+        willRenew: subscriptionInfo.willRenew,
+      },
+    ]),
+  );
 }
 
 function mapPeriodType(periodType: PeriodType): string {
   switch (periodType) {
-    case "normal": return "NORMAL"
-    case "prepaid": return "PREPAID"
-    case "trial": return "TRIAL"
-    case "intro": return "INTRO"
+    case 'normal':
+      return 'NORMAL';
+    case 'prepaid':
+      return 'PREPAID';
+    case 'trial':
+      return 'TRIAL';
+    case 'intro':
+      return 'INTRO';
   }
 }

--- a/purchases-js-hybrid-mappings/src/mappers/offerings_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/offerings_mapper.ts
@@ -9,70 +9,79 @@ import {
   PricingPhase,
   Product,
   ProductType,
-  SubscriptionOption
-} from "@revenuecat/purchases-js";
+  SubscriptionOption,
+} from '@revenuecat/purchases-js';
 
 export function mapOfferings(offerings: Offerings): Record<string, unknown> {
   return {
-    "all": Object.fromEntries(
-      Object.entries(offerings.all).map(([key, value]) => [key, mapOffering(value)])
+    all: Object.fromEntries(
+      Object.entries(offerings.all).map(([key, value]) => [key, mapOffering(value)]),
     ),
-    "current": offerings.current ? mapOffering(offerings.current) : null,
+    current: offerings.current ? mapOffering(offerings.current) : null,
   };
 }
 
 function mapOffering(offering: Offering): Record<string, unknown> {
   return {
-    "identifier": offering.identifier,
-    "serverDescription": offering.serverDescription,
-    "metadata": offering.metadata,
-    "availablePackages": offering.availablePackages.map(pkg => mapPackage(pkg)),
-    "lifetime": offering.lifetime ? mapPackage(offering.lifetime) : null,
-    "annual": offering.annual ? mapPackage(offering.annual) : null,
-    "sixMonth": offering.sixMonth ? mapPackage(offering.sixMonth) : null,
-    "threeMonth": offering.threeMonth ? mapPackage(offering.threeMonth) : null,
-    "twoMonth": offering.twoMonth ? mapPackage(offering.twoMonth) : null,
-    "monthly": offering.monthly ? mapPackage(offering.monthly) : null,
-    "weekly": offering.weekly ? mapPackage(offering.weekly) : null,
+    identifier: offering.identifier,
+    serverDescription: offering.serverDescription,
+    metadata: offering.metadata,
+    availablePackages: offering.availablePackages.map(pkg => mapPackage(pkg)),
+    lifetime: offering.lifetime ? mapPackage(offering.lifetime) : null,
+    annual: offering.annual ? mapPackage(offering.annual) : null,
+    sixMonth: offering.sixMonth ? mapPackage(offering.sixMonth) : null,
+    threeMonth: offering.threeMonth ? mapPackage(offering.threeMonth) : null,
+    twoMonth: offering.twoMonth ? mapPackage(offering.twoMonth) : null,
+    monthly: offering.monthly ? mapPackage(offering.monthly) : null,
+    weekly: offering.weekly ? mapPackage(offering.weekly) : null,
   };
 }
 
 function mapPackage(pkg: Package): Record<string, unknown> {
   return {
-    "identifier": pkg.identifier,
-    "packageType": mapPackageType(pkg.packageType),
-    "product": mapProduct(pkg.webBillingProduct),
-    "offeringIdentifier": pkg.webBillingProduct.presentedOfferingContext.offeringIdentifier,
-    "presentedOfferingContext": mapPresentedOfferingContext(pkg.webBillingProduct.presentedOfferingContext),
+    identifier: pkg.identifier,
+    packageType: mapPackageType(pkg.packageType),
+    product: mapProduct(pkg.webBillingProduct),
+    offeringIdentifier: pkg.webBillingProduct.presentedOfferingContext.offeringIdentifier,
+    presentedOfferingContext: mapPresentedOfferingContext(
+      pkg.webBillingProduct.presentedOfferingContext,
+    ),
   };
 }
 
 function mapProduct(product: Product): Record<string, unknown> {
   const defaultOptionBasePricingPhase = product.defaultSubscriptionOption?.base;
   return {
-    "identifier": product.identifier,
-    "description": product.description,
-    "title": product.title,
-    "price": product.currentPrice.amountMicros / 1_000_000,
-    "priceString": product.currentPrice.formattedPrice,
-    "currencyCode": product.currentPrice.currency,
-    "introPrice": mapIntroPrice(product), // Not supported in web yet
-    "discounts": null,
-    "pricePerWeek": defaultOptionBasePricingPhase?.pricePerWeek?.amountMicros ?? null,
-    "pricePerMonth": defaultOptionBasePricingPhase?.pricePerMonth?.amountMicros ?? null,
-    "pricePerYear": defaultOptionBasePricingPhase?.pricePerYear?.amountMicros ?? null,
-    "pricePerWeekString": defaultOptionBasePricingPhase?.pricePerWeek?.formattedPrice ?? null,
-    "pricePerMonthString": defaultOptionBasePricingPhase?.pricePerMonth?.formattedPrice ?? null,
-    "pricePerYearString": defaultOptionBasePricingPhase?.pricePerYear?.formattedPrice ?? null,
-    "productCategory": mapProductCategory(product.productType),
-    "productType": mapProductType(product.productType),
-    "subscriptionPeriod": product.normalPeriodDuration ?? null,
-    "defaultOption": product.defaultSubscriptionOption ? mapSubscriptionOption(product.defaultSubscriptionOption, product) : null,
-    "subscriptionOptions": product.subscriptionOptions.isEmpty ? null : Object.fromEntries(
-      Object.entries(product.subscriptionOptions).map(([key, value]) => [key, mapSubscriptionOption(value, product)])
-    ),
-    "presentedOfferingIdentifier": product.presentedOfferingContext.offeringIdentifier,
-    "presentedOfferingContext": mapPresentedOfferingContext(product.presentedOfferingContext)
+    identifier: product.identifier,
+    description: product.description,
+    title: product.title,
+    price: product.currentPrice.amountMicros / 1_000_000,
+    priceString: product.currentPrice.formattedPrice,
+    currencyCode: product.currentPrice.currency,
+    introPrice: mapIntroPrice(product), // Not supported in web yet
+    discounts: null,
+    pricePerWeek: defaultOptionBasePricingPhase?.pricePerWeek?.amountMicros ?? null,
+    pricePerMonth: defaultOptionBasePricingPhase?.pricePerMonth?.amountMicros ?? null,
+    pricePerYear: defaultOptionBasePricingPhase?.pricePerYear?.amountMicros ?? null,
+    pricePerWeekString: defaultOptionBasePricingPhase?.pricePerWeek?.formattedPrice ?? null,
+    pricePerMonthString: defaultOptionBasePricingPhase?.pricePerMonth?.formattedPrice ?? null,
+    pricePerYearString: defaultOptionBasePricingPhase?.pricePerYear?.formattedPrice ?? null,
+    productCategory: mapProductCategory(product.productType),
+    productType: mapProductType(product.productType),
+    subscriptionPeriod: product.normalPeriodDuration ?? null,
+    defaultOption: product.defaultSubscriptionOption
+      ? mapSubscriptionOption(product.defaultSubscriptionOption, product)
+      : null,
+    subscriptionOptions: product.subscriptionOptions.isEmpty
+      ? null
+      : Object.fromEntries(
+          Object.entries(product.subscriptionOptions).map(([key, value]) => [
+            key,
+            mapSubscriptionOption(value, product),
+          ]),
+        ),
+    presentedOfferingIdentifier: product.presentedOfferingContext.offeringIdentifier,
+    presentedOfferingContext: mapPresentedOfferingContext(product.presentedOfferingContext),
   };
 }
 
@@ -83,15 +92,18 @@ function mapIntroPrice(product: Product): Record<string, unknown> | null {
   }
 
   return {
-    "price": 0,
-    "priceString": trialPhase.price?.formattedPrice,
-    "period": trialPhase.periodDuration,
-    "cycles": trialPhase.cycleCount,
-    ...mapPeriodForStoreProduct(trialPhase.period)
-  }
+    price: 0,
+    priceString: trialPhase.price?.formattedPrice,
+    period: trialPhase.periodDuration,
+    cycles: trialPhase.cycleCount,
+    ...mapPeriodForStoreProduct(trialPhase.period),
+  };
 }
 
-function mapSubscriptionOption(option: SubscriptionOption, product: Product): Record<string, unknown> {
+function mapSubscriptionOption(
+  option: SubscriptionOption,
+  product: Product,
+): Record<string, unknown> {
   let period: Record<string, unknown> | null = null;
   if (option.base.period !== null && option.base.periodDuration !== null) {
     period = mapPeriod(option.base.period, option.base.periodDuration);
@@ -105,22 +117,22 @@ function mapSubscriptionOption(option: SubscriptionOption, product: Product): Re
   if (trialPhase) {
     pricingPhases.push(trialPhase);
   }
-  pricingPhases.push(basePhase)
+  pricingPhases.push(basePhase);
   return {
-    "id": option.id,
-    "storeProductId": product.identifier,
-    "productId": product.identifier,
-    "pricingPhases": pricingPhases,
-    "tags": [],
-    "isBasePlan": option.trial === null,
-    "billingPeriod": period,
-    "isPrepaid": false,
-    "fullPricePhase": basePhase,
-    "freePhase": trialPhase,
-    "introPhase": null,
-    "presentedOfferingIdentifier": product.presentedOfferingContext.offeringIdentifier,
-    "presentedOfferingContext": mapPresentedOfferingContext(product.presentedOfferingContext),
-    "installmentsInfo": null,
+    id: option.id,
+    storeProductId: product.identifier,
+    productId: product.identifier,
+    pricingPhases: pricingPhases,
+    tags: [],
+    isBasePlan: option.trial === null,
+    billingPeriod: period,
+    isPrepaid: false,
+    fullPricePhase: basePhase,
+    freePhase: trialPhase,
+    introPhase: null,
+    presentedOfferingIdentifier: product.presentedOfferingContext.offeringIdentifier,
+    presentedOfferingContext: mapPresentedOfferingContext(product.presentedOfferingContext),
+    installmentsInfo: null,
   };
 }
 
@@ -139,29 +151,31 @@ function mapPricingPhase(pricingPhase: PricingPhase): Record<string, unknown> {
   }
   let offerPaymentMode: string | null = null;
   if (pricingPhase.price?.amountMicros == 0) {
-    offerPaymentMode = "FREE_TRIAL";
+    offerPaymentMode = 'FREE_TRIAL';
   }
   return {
-    "billingPeriod": billingPeriod,
-    "recurrenceMode": recurrenceMode,
-    "billingCycleCount": pricingPhase.cycleCount,
-    "price": {
-      "formatted": pricingPhase.price?.formattedPrice ?? "",
-      "amountMicros": pricingPhase.price?.amountMicros ?? 0,
-      "currencyCode": pricingPhase.price?.currency ?? "",
+    billingPeriod: billingPeriod,
+    recurrenceMode: recurrenceMode,
+    billingCycleCount: pricingPhase.cycleCount,
+    price: {
+      formatted: pricingPhase.price?.formattedPrice ?? '',
+      amountMicros: pricingPhase.price?.amountMicros ?? 0,
+      currencyCode: pricingPhase.price?.currency ?? '',
     },
-    "offerPaymentMode": offerPaymentMode,
+    offerPaymentMode: offerPaymentMode,
   };
 }
 
 function mapPresentedOfferingContext(context: PresentedOfferingContext): Record<string, unknown> {
   return {
-    "offeringIdentifier": context.offeringIdentifier,
-    "placementIdentifier": context.placementIdentifier,
-    "targetingContext": context.targetingContext ? {
-      "revision": context.targetingContext.revision,
-      "ruleId": context.targetingContext.ruleId
-    } : null
+    offeringIdentifier: context.offeringIdentifier,
+    placementIdentifier: context.placementIdentifier,
+    targetingContext: context.targetingContext
+      ? {
+          revision: context.targetingContext.revision,
+          ruleId: context.targetingContext.ruleId,
+        }
+      : null,
   };
 }
 
@@ -169,27 +183,27 @@ function mapPeriod(period: Period, periodIso8601: string): Record<string, unknow
   switch (period.unit) {
     case PeriodUnit.Day:
       return {
-        "unit": "DAY",
-        "value": period.number,
-        "iso8601": periodIso8601,
+        unit: 'DAY',
+        value: period.number,
+        iso8601: periodIso8601,
       };
     case PeriodUnit.Week:
       return {
-        "unit": "DAY",
-        "value": period.number * 7,
-        "iso8601": periodIso8601,
+        unit: 'DAY',
+        value: period.number * 7,
+        iso8601: periodIso8601,
       };
     case PeriodUnit.Month:
       return {
-        "unit": "MONTH",
-        "value": period.number,
-        "iso8601": periodIso8601,
+        unit: 'MONTH',
+        value: period.number,
+        iso8601: periodIso8601,
       };
     case PeriodUnit.Year:
       return {
-        "unit": "YEAR",
-        "value": period.number,
-        "iso8601": periodIso8601,
+        unit: 'YEAR',
+        value: period.number,
+        iso8601: periodIso8601,
       };
   }
 }
@@ -200,56 +214,56 @@ function mapPeriodForStoreProduct(period: Period | null): Record<string, unknown
   }
   switch (period.unit) {
     case PeriodUnit.Day:
-      return { "periodUnit": "DAY", "periodNumberOfUnits": period.number };
+      return { periodUnit: 'DAY', periodNumberOfUnits: period.number };
     case PeriodUnit.Month:
-      return { "periodUnit": "MONTH", "periodNumberOfUnits": period.number };
+      return { periodUnit: 'MONTH', periodNumberOfUnits: period.number };
     case PeriodUnit.Week:
-      return { "periodUnit": "DAY", "periodNumberOfUnits": period.number * 7 };
+      return { periodUnit: 'DAY', periodNumberOfUnits: period.number * 7 };
     case PeriodUnit.Year:
-      return { "periodUnit": "YEAR", "periodNumberOfUnits": period.number };
+      return { periodUnit: 'YEAR', periodNumberOfUnits: period.number };
   }
 }
 
 function mapProductCategory(productType: ProductType): string {
   switch (productType) {
     case ProductType.Subscription:
-      return "SUBSCRIPTION";
+      return 'SUBSCRIPTION';
     case ProductType.Consumable:
     case ProductType.NonConsumable:
-        return "NON_SUBSCRIPTION";
+      return 'NON_SUBSCRIPTION';
   }
 }
 
 function mapProductType(productType: ProductType): string {
   switch (productType) {
     case ProductType.Subscription:
-      return "AUTO_RENEWABLE_SUBSCRIPTION";
+      return 'AUTO_RENEWABLE_SUBSCRIPTION';
     case ProductType.Consumable:
-      return "CONSUMABLE";
+      return 'CONSUMABLE';
     case ProductType.NonConsumable:
-      return "NON_CONSUMABLE";
+      return 'NON_CONSUMABLE';
   }
 }
 
 function mapPackageType(packageType: PackageType): string {
   switch (packageType) {
     case PackageType.Custom:
-      return "CUSTOM";
+      return 'CUSTOM';
     case PackageType.Lifetime:
-      return "LIFETIME";
+      return 'LIFETIME';
     case PackageType.Annual:
-      return "ANNUAL";
+      return 'ANNUAL';
     case PackageType.SixMonth:
-      return "SIX_MONTH";
+      return 'SIX_MONTH';
     case PackageType.ThreeMonth:
-      return "THREE_MONTH";
+      return 'THREE_MONTH';
     case PackageType.TwoMonth:
-      return "TWO_MONTH";
+      return 'TWO_MONTH';
     case PackageType.Monthly:
-      return "MONTHLY";
+      return 'MONTHLY';
     case PackageType.Weekly:
-      return "WEEKLY";
+      return 'WEEKLY';
     default:
-      return "UNKNOWN";
+      return 'UNKNOWN';
   }
 }

--- a/purchases-js-hybrid-mappings/src/mappers/purchases_error_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/purchases_error_mapper.ts
@@ -1,0 +1,13 @@
+import { PurchasesError } from '@revenuecat/purchases-js';
+
+export function mapPurchasesError(error: PurchasesError): Record<string, unknown> {
+  return {
+    code: error.errorCode,
+    message: error.message,
+    underlyingErrorMessage: error.underlyingErrorMessage,
+    info: {
+      statusCode: error.extra?.statusCode,
+      backendErrorCode: error.extra?.backendErrorCode,
+    },
+  };
+}

--- a/purchases-js-hybrid-mappings/src/purchases-common.ts
+++ b/purchases-js-hybrid-mappings/src/purchases-common.ts
@@ -1,33 +1,33 @@
-import {Purchases} from "@revenuecat/purchases-js";
-import {mapCustomerInfo} from "./mappers/customer_info_mapper";
-import {mapOfferings} from "./mappers/offerings_mapper";
-import {Logger} from "./utils/logger";
+import { Purchases, PurchasesError } from '@revenuecat/purchases-js';
+import { mapCustomerInfo } from './mappers/customer_info_mapper';
+import { mapOfferings } from './mappers/offerings_mapper';
+import { Logger } from './utils/logger';
+import { mapPurchasesError } from './mappers/purchases_error_mapper';
 
 export class PurchasesCommon {
-
   private static instance: PurchasesCommon | null = null;
   private purchases: Purchases;
 
-  static configure(
-    configuration: {
-      apiKey: string,
-      appUserId: string | undefined,
-    }
-  ): PurchasesCommon {
+  static configure(configuration: {
+    apiKey: string;
+    appUserId: string | undefined;
+  }): PurchasesCommon {
     if (PurchasesCommon.instance) {
-      Logger.warn("PurchasesCommon.configure() called more than once. Previous configuration will be overwritten.");
+      Logger.warn(
+        'PurchasesCommon.configure() called more than once. Previous configuration will be overwritten.',
+      );
     }
     const purchasesInstance = Purchases.configure(
       configuration.apiKey,
       configuration.appUserId || Purchases.generateRevenueCatAnonymousAppUserId(),
-    )
+    );
     PurchasesCommon.instance = new PurchasesCommon(purchasesInstance);
     return PurchasesCommon.instance;
   }
 
   static getInstance(): PurchasesCommon {
     if (!PurchasesCommon.instance) {
-      throw new Error("Purchases not configured. Call configure() first.");
+      throw new Error('Purchases not configured. Call configure() first.');
     }
     return PurchasesCommon.instance;
   }
@@ -37,12 +37,30 @@ export class PurchasesCommon {
   }
 
   public async getCustomerInfo(): Promise<Record<string, unknown>> {
-    const customerInfo = await this.purchases.getCustomerInfo();
-    return mapCustomerInfo(customerInfo);
+    try {
+      const customerInfo = await this.purchases.getCustomerInfo();
+      return mapCustomerInfo(customerInfo);
+    } catch (error) {
+      if (error instanceof PurchasesError) {
+        this.handleError(error);
+      }
+      throw error;
+    }
   }
 
   public async getOfferings(): Promise<Record<string, unknown>> {
-    const offerings = await this.purchases.getOfferings();
-    return mapOfferings(offerings);
+    try {
+      const offerings = await this.purchases.getOfferings();
+      return mapOfferings(offerings);
+    } catch (error) {
+      if (error instanceof PurchasesError) {
+        this.handleError(error);
+      }
+      throw error;
+    }
+  }
+
+  private handleError(error: PurchasesError): never {
+    throw mapPurchasesError(error);
   }
 }

--- a/purchases-js-hybrid-mappings/tests/mappers/purchases_error_mapper.test.ts
+++ b/purchases-js-hybrid-mappings/tests/mappers/purchases_error_mapper.test.ts
@@ -1,0 +1,29 @@
+import { PurchasesError, ErrorCode } from "@revenuecat/purchases-js";
+import { mapPurchasesError } from "../../src/mappers/purchases_error_mapper.ts";
+
+describe('mapPurchasesError', () => {
+  it('maps PurchasesError correctly', () => {
+    const error: PurchasesError = {
+      name: "PurchasesError",
+      message: "Something went wrong",
+      underlyingErrorMessage: "Network error",
+      errorCode: ErrorCode.NetworkError,
+      extra: {
+        statusCode: 500,
+        backendErrorCode: 7000
+      }
+    };
+
+    const result = mapPurchasesError(error);
+
+    expect(result).toEqual({
+      code: error.errorCode,
+      message: error.message,
+      underlyingErrorMessage: error.underlyingErrorMessage,
+      info: {
+        statusCode: error.extra?.statusCode,
+        backendErrorCode: error.extra?.backendErrorCode
+      }
+    });
+  });
+});


### PR DESCRIPTION
2 main changes in this PR:
- Adds mapping for `purchases-js` `PurchasesError` into the error format expected in hybrids
- Adds prettier and runs it over the codebase.