### PR TITLE
[purchases-js-hybrid-mappings] Add login/logout functions and set PlatformInfo

### DIFF
--- a/purchases-js-hybrid-mappings/api-report/api.json
+++ b/purchases-js-hybrid-mappings/api-report/api.json
@@ -199,7 +199,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "{\n        apiKey: string;\n        appUserId: string | undefined;\n    }"
+                  "text": "{\n        apiKey: string;\n        appUserId: string | undefined;\n        flavor: string;\n        flavorVersion: string;\n    }"
                 },
                 {
                   "kind": "Content",
@@ -358,6 +358,113 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "getOfferings"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "purchases-js-hybrid-mappings!PurchasesCommon#logIn:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "logIn(appUserId: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Record",
+                  "canonicalReference": "!Record:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<string, unknown>>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 7
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "appUserId",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "logIn"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "purchases-js-hybrid-mappings!PurchasesCommon#logOut:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "logOut(): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Record",
+                  "canonicalReference": "!Record:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<string, unknown>>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 5
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "logOut"
             }
           ],
           "implementsTokenRanges": []

--- a/purchases-js-hybrid-mappings/api-report/purchases-js-hybrid-mappings.api.md
+++ b/purchases-js-hybrid-mappings/api-report/purchases-js-hybrid-mappings.api.md
@@ -10,6 +10,8 @@ export class PurchasesCommon {
     static configure(configuration: {
         apiKey: string;
         appUserId: string | undefined;
+        flavor: string;
+        flavorVersion: string;
     }): PurchasesCommon;
     // (undocumented)
     getCustomerInfo(): Promise<Record<string, unknown>>;
@@ -17,6 +19,10 @@ export class PurchasesCommon {
     static getInstance(): PurchasesCommon;
     // (undocumented)
     getOfferings(): Promise<Record<string, unknown>>;
+    // (undocumented)
+    logIn(appUserId: string): Promise<Record<string, unknown>>;
+    // (undocumented)
+    logOut(): Promise<Record<string, unknown>>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/purchases-js-hybrid-mappings/package.json
+++ b/purchases-js-hybrid-mappings/package.json
@@ -25,7 +25,8 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "format": "prettier --write \"src/**/*.ts\"",
-    "format:check": "prettier --check \"src/**/*.ts\""
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "allchecks": "npm run format && npm run lint:fix && npm run api-test && npm run test"
   },
   "dependencies": {
     "@revenuecat/purchases-js": "^1.1.0"

--- a/purchases-js-hybrid-mappings/src/purchases-common.ts
+++ b/purchases-js-hybrid-mappings/src/purchases-common.ts
@@ -47,10 +47,7 @@ export class PurchasesCommon {
       const customerInfo = await this.purchases.getCustomerInfo();
       return mapCustomerInfo(customerInfo);
     } catch (error) {
-      if (error instanceof PurchasesError) {
-        this.handleError(error);
-      }
-      throw error;
+      this.handleError(error);
     }
   }
 
@@ -59,10 +56,7 @@ export class PurchasesCommon {
       const offerings = await this.purchases.getOfferings();
       return mapOfferings(offerings);
     } catch (error) {
-      if (error instanceof PurchasesError) {
-        this.handleError(error);
-      }
-      throw error;
+      this.handleError(error);
     }
   }
 
@@ -71,7 +65,7 @@ export class PurchasesCommon {
       const customerInfo = await this.purchases.changeUser(appUserId);
       return mapCustomerInfo(customerInfo);
     } catch (error) {
-      this.handleError(error as PurchasesError);
+      this.handleError(error);
     }
   }
 
@@ -82,11 +76,14 @@ export class PurchasesCommon {
       );
       return mapCustomerInfo(customerInfo);
     } catch (error) {
-      this.handleError(error as PurchasesError);
+      this.handleError(error);
     }
   }
 
-  private handleError(error: PurchasesError): never {
-    throw mapPurchasesError(error);
+  private handleError(error: unknown): never {
+    if (error instanceof PurchasesError) {
+      throw mapPurchasesError(error);
+    }
+    throw error;
   }
 }

--- a/purchases-js-hybrid-mappings/src/purchases-common.ts
+++ b/purchases-js-hybrid-mappings/src/purchases-common.ts
@@ -11,12 +11,18 @@ export class PurchasesCommon {
   static configure(configuration: {
     apiKey: string;
     appUserId: string | undefined;
+    flavor: string;
+    flavorVersion: string;
   }): PurchasesCommon {
     if (PurchasesCommon.instance) {
       Logger.warn(
         'PurchasesCommon.configure() called more than once. Previous configuration will be overwritten.',
       );
     }
+    Purchases.setPlatformInfo({
+      flavor: configuration.flavor,
+      version: configuration.flavorVersion,
+    });
     const purchasesInstance = Purchases.configure(
       configuration.apiKey,
       configuration.appUserId || Purchases.generateRevenueCatAnonymousAppUserId(),
@@ -57,6 +63,26 @@ export class PurchasesCommon {
         this.handleError(error);
       }
       throw error;
+    }
+  }
+
+  public async logIn(appUserId: string): Promise<Record<string, unknown>> {
+    try {
+      const customerInfo = await this.purchases.changeUser(appUserId);
+      return mapCustomerInfo(customerInfo);
+    } catch (error) {
+      this.handleError(error as PurchasesError);
+    }
+  }
+
+  public async logOut(): Promise<Record<string, unknown>> {
+    try {
+      const customerInfo = await this.purchases.changeUser(
+        Purchases.generateRevenueCatAnonymousAppUserId(),
+      );
+      return mapCustomerInfo(customerInfo);
+    } catch (error) {
+      this.handleError(error as PurchasesError);
     }
   }
 


### PR DESCRIPTION
- Adds `logIn` and `logOut` functions. Note that `logIn` won't behave the same way the mobile SDKs do, since they won't alias users together.
- Sets the `PlatformInfo` in the web SDK to have proper headers.
- Adds a new npm task to run all checks in one command