### PR TITLE
[purchases-js-hybrid-mappings] Add remaining APIs mappings

### DIFF
--- a/purchases-js-hybrid-mappings/api-report/api.json
+++ b/purchases-js-hybrid-mappings/api-report/api.json
@@ -239,6 +239,99 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "purchases-js-hybrid-mappings!PurchasesCommon#getAppUserId:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getAppUserId(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getAppUserId"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "purchases-js-hybrid-mappings!PurchasesCommon#getCurrentOfferingForPlacement:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getCurrentOfferingForPlacement(placementIdentifier: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Record",
+                  "canonicalReference": "!Record:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<string, unknown> | null>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 7
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "placementIdentifier",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getCurrentOfferingForPlacement"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "purchases-js-hybrid-mappings!PurchasesCommon#getCustomerInfo:member(1)",
               "docComment": "",
               "excerptTokens": [
@@ -358,6 +451,37 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "getOfferings"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "purchases-js-hybrid-mappings!PurchasesCommon#isSandbox:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "isSandbox(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "isSandbox"
             },
             {
               "kind": "Method",
@@ -536,6 +660,54 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "purchasePackage"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "purchases-js-hybrid-mappings!PurchasesCommon.setLogLevel:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "static setLogLevel(logLevel: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": true,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "logLevel",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "setLogLevel"
             }
           ],
           "implementsTokenRanges": []

--- a/purchases-js-hybrid-mappings/api-report/purchases-js-hybrid-mappings.api.md
+++ b/purchases-js-hybrid-mappings/api-report/purchases-js-hybrid-mappings.api.md
@@ -14,11 +14,17 @@ export class PurchasesCommon {
         flavorVersion: string;
     }): PurchasesCommon;
     // (undocumented)
+    getAppUserId(): string;
+    // (undocumented)
+    getCurrentOfferingForPlacement(placementIdentifier: string): Promise<Record<string, unknown> | null>;
+    // (undocumented)
     getCustomerInfo(): Promise<Record<string, unknown>>;
     // (undocumented)
     static getInstance(): PurchasesCommon;
     // (undocumented)
     getOfferings(): Promise<Record<string, unknown>>;
+    // (undocumented)
+    isSandbox(): boolean;
     // (undocumented)
     logIn(appUserId: string): Promise<Record<string, unknown>>;
     // (undocumented)
@@ -32,6 +38,8 @@ export class PurchasesCommon {
         selectedLocale?: string;
         defaultLocale?: string;
     }): Promise<Record<string, unknown>>;
+    // (undocumented)
+    static setLogLevel(logLevel: string): void;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/purchases-js-hybrid-mappings/src/mappers/log_level_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/log_level_mapper.ts
@@ -1,5 +1,5 @@
 import { LogLevel } from '@revenuecat/purchases-js';
-import { Logger } from 'src/utils/logger';
+import { Logger } from '../utils/logger';
 
 export function mapLogLevel(logLevel: string): LogLevel | null {
   const upperCaseLogLevel = logLevel.toUpperCase();

--- a/purchases-js-hybrid-mappings/src/mappers/log_level_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/log_level_mapper.ts
@@ -1,0 +1,23 @@
+import { LogLevel } from '@revenuecat/purchases-js';
+import { Logger } from 'src/utils/logger';
+
+export function mapLogLevel(logLevel: string): LogLevel | null {
+  const upperCaseLogLevel = logLevel.toUpperCase();
+  switch (upperCaseLogLevel) {
+    case 'VERBOSE':
+      return LogLevel.Verbose;
+    case 'DEBUG':
+      return LogLevel.Debug;
+    case 'INFO':
+      return LogLevel.Info;
+    case 'WARN':
+      return LogLevel.Warn;
+    case 'ERROR':
+      return LogLevel.Error;
+    case 'SILENT':
+      return LogLevel.Silent;
+    default:
+      Logger.warn(`Invalid log level: ${logLevel}`);
+      return null;
+  }
+}

--- a/purchases-js-hybrid-mappings/src/mappers/offerings_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/offerings_mapper.ts
@@ -21,7 +21,7 @@ export function mapOfferings(offerings: Offerings): Record<string, unknown> {
   };
 }
 
-function mapOffering(offering: Offering): Record<string, unknown> {
+export function mapOffering(offering: Offering): Record<string, unknown> {
   return {
     identifier: offering.identifier,
     serverDescription: offering.serverDescription,


### PR DESCRIPTION
This adds the remaining APIs from purchases-js that we want to expose to hybrids at least for now, there are likely more once we start using this library. This includes:
- getCurrentOfferingForPlacement
- getAppUserId
- isSandbox
- setLogLevel