### PR TITLE
[purchases-js-hybrid-mappings] Finalize last APIs + export UMD files

### DIFF
--- a/purchases-js-hybrid-mappings/api-report/api.json
+++ b/purchases-js-hybrid-mappings/api-report/api.json
@@ -182,7 +182,7 @@
               "text": "declare class PurchasesCommon "
             }
           ],
-          "fileUrlPath": "dist/index.d.ts",
+          "fileUrlPath": "src/index.ts",
           "releaseTag": "Public",
           "isAbstract": false,
           "name": "PurchasesCommon",
@@ -454,6 +454,68 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js-hybrid-mappings!PurchasesCommon#isAnonymous:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "isAnonymous(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "isAnonymous"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js-hybrid-mappings!PurchasesCommon.isConfigured:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "static isConfigured(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": true,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "isConfigured"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@revenuecat/purchases-js-hybrid-mappings!PurchasesCommon#isSandbox:member(1)",
               "docComment": "",
               "excerptTokens": [
@@ -708,6 +770,54 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "setLogLevel"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js-hybrid-mappings!PurchasesCommon.setProxyUrl:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "static setProxyUrl(proxyUrl: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": true,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "proxyUrl",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "setProxyUrl"
             }
           ],
           "implementsTokenRanges": []

--- a/purchases-js-hybrid-mappings/api-report/purchases-js-hybrid-mappings.api.md
+++ b/purchases-js-hybrid-mappings/api-report/purchases-js-hybrid-mappings.api.md
@@ -24,6 +24,10 @@ export class PurchasesCommon {
     // (undocumented)
     getOfferings(): Promise<Record<string, unknown>>;
     // (undocumented)
+    isAnonymous(): boolean;
+    // (undocumented)
+    static isConfigured(): boolean;
+    // (undocumented)
     isSandbox(): boolean;
     // (undocumented)
     logIn(appUserId: string): Promise<Record<string, unknown>>;
@@ -40,6 +44,8 @@ export class PurchasesCommon {
     }): Promise<Record<string, unknown>>;
     // (undocumented)
     static setLogLevel(logLevel: string): void;
+    // (undocumented)
+    static setProxyUrl(proxyUrl: string): void;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/purchases-js-hybrid-mappings/package.json
+++ b/purchases-js-hybrid-mappings/package.json
@@ -3,6 +3,7 @@
   "version": "13.29.0",
   "description": "RevenueCat's JavaScript hybrid mappings for purchases-js",
   "main": "dist/index.js",
+  "browser": "dist/index.umd.js",
   "type": "module",
   "files": [
     "dist"
@@ -29,7 +30,7 @@
     "allchecks": "npm run format && npm run lint:fix && npm run api-test && npm run test"
   },
   "dependencies": {
-    "@revenuecat/purchases-js": "^1.1.0"
+    "@revenuecat/purchases-js": "^1.2.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.42.3",

--- a/purchases-js-hybrid-mappings/rollup.config.js
+++ b/purchases-js-hybrid-mappings/rollup.config.js
@@ -7,11 +7,19 @@ import terser from '@rollup/plugin-terser';
 export default defineConfig([
   {
     input: 'src/index.ts',
-    output: {
-      file: 'dist/index.js',
-      format: 'esm',
-      sourcemap: true
-    },
+    output: [
+      {
+        file: 'dist/index.js',
+        format: 'esm',
+        sourcemap: true
+      },
+      {
+        file: 'dist/index.umd.js',
+        format: 'umd',
+        name: 'PurchasesHybridMappings',
+        sourcemap: true
+      }
+    ],
     plugins: [
       nodeResolve(),
       typescript({

--- a/purchases-js-hybrid-mappings/src/mappers/offerings_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/offerings_mapper.ts
@@ -25,7 +25,7 @@ export function mapOffering(offering: Offering): Record<string, unknown> {
   return {
     identifier: offering.identifier,
     serverDescription: offering.serverDescription,
-    metadata: offering.metadata,
+    metadata: offering.metadata ?? {},
     availablePackages: offering.availablePackages.map(pkg => mapPackage(pkg)),
     lifetime: offering.lifetime ? mapPackage(offering.lifetime) : null,
     annual: offering.annual ? mapPackage(offering.annual) : null,
@@ -53,7 +53,7 @@ function mapProduct(product: Product): Record<string, unknown> {
   const defaultOptionBasePricingPhase = product.defaultSubscriptionOption?.base;
   return {
     identifier: product.identifier,
-    description: product.description,
+    description: product.description ?? '',
     title: product.title,
     price: product.currentPrice.amountMicros / 1_000_000,
     priceString: product.currentPrice.formattedPrice,
@@ -72,14 +72,12 @@ function mapProduct(product: Product): Record<string, unknown> {
     defaultOption: product.defaultSubscriptionOption
       ? mapSubscriptionOption(product.defaultSubscriptionOption, product)
       : null,
-    subscriptionOptions: product.subscriptionOptions.isEmpty
-      ? null
-      : Object.fromEntries(
-          Object.entries(product.subscriptionOptions).map(([key, value]) => [
-            key,
-            mapSubscriptionOption(value, product),
-          ]),
-        ),
+    subscriptionOptions:
+      product.productType === ProductType.Subscription
+        ? Object.values(product.subscriptionOptions).map(subscriptionOption =>
+            mapSubscriptionOption(subscriptionOption, product),
+          )
+        : null,
     presentedOfferingIdentifier: product.presentedOfferingContext.offeringIdentifier,
     presentedOfferingContext: mapPresentedOfferingContext(product.presentedOfferingContext),
   };
@@ -93,7 +91,7 @@ function mapIntroPrice(product: Product): Record<string, unknown> | null {
 
   return {
     price: 0,
-    priceString: trialPhase.price?.formattedPrice,
+    priceString: trialPhase.price?.formattedPrice ?? '0.00', // TODO: Improve how we get a formatted price for trials
     period: trialPhase.periodDuration,
     cycles: trialPhase.cycleCount,
     ...mapPeriodForStoreProduct(trialPhase.period),

--- a/purchases-js-hybrid-mappings/src/purchases-common.ts
+++ b/purchases-js-hybrid-mappings/src/purchases-common.ts
@@ -1,5 +1,6 @@
 import {
   ErrorCode,
+  HttpConfig,
   Offering,
   Offerings,
   Package,
@@ -18,6 +19,8 @@ import { mapLogLevel } from './mappers/log_level_mapper';
 
 export class PurchasesCommon {
   private static instance: PurchasesCommon | null = null;
+  private static proxyUrl: string | null = null;
+
   private purchases: Purchases;
 
   private offeringsCache: Offerings | null = null;
@@ -37,9 +40,14 @@ export class PurchasesCommon {
       flavor: configuration.flavor,
       version: configuration.flavorVersion,
     });
+    let httpConfig: HttpConfig | undefined = undefined;
+    if (PurchasesCommon.proxyUrl) {
+      httpConfig = { proxyURL: PurchasesCommon.proxyUrl };
+    }
     const purchasesInstance = Purchases.configure(
       configuration.apiKey,
       configuration.appUserId || Purchases.generateRevenueCatAnonymousAppUserId(),
+      httpConfig,
     );
     PurchasesCommon.instance = new PurchasesCommon(purchasesInstance);
     return PurchasesCommon.instance;
@@ -59,6 +67,16 @@ export class PurchasesCommon {
     }
   }
 
+  static isConfigured(): boolean {
+    return Purchases.isConfigured();
+  }
+
+  static setProxyUrl(proxyUrl: string): void {
+    if (PurchasesCommon.proxyUrl !== proxyUrl) {
+      PurchasesCommon.proxyUrl = proxyUrl;
+    }
+  }
+
   private constructor(purchasesInstance: Purchases) {
     this.purchases = purchasesInstance;
   }
@@ -69,6 +87,10 @@ export class PurchasesCommon {
 
   public isSandbox(): boolean {
     return this.purchases.isSandbox();
+  }
+
+  public isAnonymous(): boolean {
+    return this.purchases.isAnonymous();
   }
 
   public async getCustomerInfo(): Promise<Record<string, unknown>> {

--- a/purchases-js-hybrid-mappings/tests/mappers/offerings_mapper.test.ts
+++ b/purchases-js-hybrid-mappings/tests/mappers/offerings_mapper.test.ts
@@ -99,15 +99,58 @@ describe('mapOfferings', () => {
 
     const result = mapOfferings(fullOfferings);
 
-    const expectedPackageProduct = {
-      currencyCode: 'USD',
-      defaultOption: {
+    const expectedAnnualOption = {
+      billingPeriod: {
+        iso8601: 'P1Y',
+        unit: 'YEAR',
+        value: 1
+      },
+      freePhase: {
+        billingCycleCount: 1,
+        billingPeriod: {
+          iso8601: 'P7D',
+          unit: 'DAY',
+          value: 7
+        },
+        offerPaymentMode: 'FREE_TRIAL',
+        price: {
+          amountMicros: 0,
+          currencyCode: 'USD',
+          formatted: 'Free'
+        },
+        recurrenceMode: 3
+      },
+      fullPricePhase: {
+        billingCycleCount: 0,
         billingPeriod: {
           iso8601: 'P1Y',
           unit: 'YEAR',
           value: 1
         },
-        freePhase: {
+        offerPaymentMode: null,
+        price: {
+          amountMicros: 4990000,
+          currencyCode: 'USD',
+          formatted: '$4.99'
+        },
+        recurrenceMode: 1
+      },
+      id: 'annual_pkg_default',
+      installmentsInfo: null,
+      introPhase: null,
+      isBasePlan: false,
+      isPrepaid: false,
+      presentedOfferingContext: {
+        offeringIdentifier: 'premium_offering',
+        placementIdentifier: 'main_page',
+        targetingContext: {
+          revision: 1,
+          ruleId: 'rule_123'
+        }
+      },
+      presentedOfferingIdentifier: 'premium_offering',
+      pricingPhases: [
+        {
           billingCycleCount: 1,
           billingPeriod: {
             iso8601: 'P7D',
@@ -122,7 +165,7 @@ describe('mapOfferings', () => {
           },
           recurrenceMode: 3
         },
-        fullPricePhase: {
+        {
           billingCycleCount: 0,
           billingPeriod: {
             iso8601: 'P1Y',
@@ -136,57 +179,17 @@ describe('mapOfferings', () => {
             formatted: '$4.99'
           },
           recurrenceMode: 1
-        },
-        id: 'annual_pkg_default',
-        installmentsInfo: null,
-        introPhase: null,
-        isBasePlan: false,
-        isPrepaid: false,
-        presentedOfferingContext: {
-          offeringIdentifier: 'premium_offering',
-          placementIdentifier: 'main_page',
-          targetingContext: {
-            revision: 1,
-            ruleId: 'rule_123'
-          }
-        },
-        presentedOfferingIdentifier: 'premium_offering',
-        pricingPhases: [
-          {
-            billingCycleCount: 1,
-            billingPeriod: {
-              iso8601: 'P7D',
-              unit: 'DAY',
-              value: 7
-            },
-            offerPaymentMode: 'FREE_TRIAL',
-            price: {
-              amountMicros: 0,
-              currencyCode: 'USD',
-              formatted: 'Free'
-            },
-            recurrenceMode: 3
-          },
-          {
-            billingCycleCount: 0,
-            billingPeriod: {
-              iso8601: 'P1Y',
-              unit: 'YEAR',
-              value: 1
-            },
-            offerPaymentMode: null,
-            price: {
-              amountMicros: 4990000,
-              currencyCode: 'USD',
-              formatted: '$4.99'
-            },
-            recurrenceMode: 1
-          }
-        ],
-        productId: 'product_annual_pkg',
-        storeProductId: 'product_annual_pkg',
-        tags: []
-      },
+        }
+      ],
+      productId: 'product_annual_pkg',
+      storeProductId: 'product_annual_pkg',
+      tags: []
+    };
+
+    const expectedPackageProduct = {
+      currencyCode: 'USD',
+      defaultOption: expectedAnnualOption,
+      subscriptionOptions: [expectedAnnualOption],
       description: 'A $rc_annual product with all features',
       discounts: null,
       identifier: 'product_annual_pkg',
@@ -217,22 +220,62 @@ describe('mapOfferings', () => {
       priceString: '$4.99',
       productCategory: 'SUBSCRIPTION',
       productType: 'AUTO_RENEWABLE_SUBSCRIPTION',
-      subscriptionOptions: {},
       subscriptionPeriod: 'P1Y',
       title: '$rc_annual Product'
     };
 
-    const expectedMonthlyProduct = {
-      ...expectedPackageProduct,
-      identifier: 'product_monthly_pkg',
-      description: 'A $rc_monthly product with all features',
-      defaultOption: {
+    const expectedMonthlyOption = {
+      billingPeriod: {
+        iso8601: 'P1M',
+        unit: 'MONTH',
+        value: 1
+      },
+      freePhase: {
+        billingCycleCount: 1,
+        billingPeriod: {
+          iso8601: 'P7D',
+          unit: 'DAY',
+          value: 7
+        },
+        offerPaymentMode: 'FREE_TRIAL',
+        price: {
+          amountMicros: 0,
+          currencyCode: 'USD',
+          formatted: 'Free'
+        },
+        recurrenceMode: 3
+      },
+      fullPricePhase: {
+        billingCycleCount: 0,
         billingPeriod: {
           iso8601: 'P1M',
           unit: 'MONTH',
           value: 1
         },
-        freePhase: {
+        offerPaymentMode: null,
+        price: {
+          amountMicros: 4990000,
+          currencyCode: 'USD',
+          formatted: '$4.99'
+        },
+        recurrenceMode: 1
+      },
+      id: 'monthly_pkg_default',
+      installmentsInfo: null,
+      introPhase: null,
+      isBasePlan: false,
+      isPrepaid: false,
+      presentedOfferingContext: {
+        offeringIdentifier: 'premium_offering',
+        placementIdentifier: 'main_page',
+        targetingContext: {
+          revision: 1,
+          ruleId: 'rule_123'
+        }
+      },
+      presentedOfferingIdentifier: 'premium_offering',
+      pricingPhases: [
+        {
           billingCycleCount: 1,
           billingPeriod: {
             iso8601: 'P7D',
@@ -247,7 +290,7 @@ describe('mapOfferings', () => {
           },
           recurrenceMode: 3
         },
-        fullPricePhase: {
+        {
           billingCycleCount: 0,
           billingPeriod: {
             iso8601: 'P1M',
@@ -261,57 +304,19 @@ describe('mapOfferings', () => {
             formatted: '$4.99'
           },
           recurrenceMode: 1
-        },
-        id: 'monthly_pkg_default',
-        installmentsInfo: null,
-        introPhase: null,
-        isBasePlan: false,
-        isPrepaid: false,
-        presentedOfferingContext: {
-          offeringIdentifier: 'premium_offering',
-          placementIdentifier: 'main_page',
-          targetingContext: {
-            revision: 1,
-            ruleId: 'rule_123'
-          }
-        },
-        presentedOfferingIdentifier: 'premium_offering',
-        pricingPhases: [
-          {
-            billingCycleCount: 1,
-            billingPeriod: {
-              iso8601: 'P7D',
-              unit: 'DAY',
-              value: 7
-            },
-            offerPaymentMode: 'FREE_TRIAL',
-            price: {
-              amountMicros: 0,
-              currencyCode: 'USD',
-              formatted: 'Free'
-            },
-            recurrenceMode: 3
-          },
-          {
-            billingCycleCount: 0,
-            billingPeriod: {
-              iso8601: 'P1M',
-              unit: 'MONTH',
-              value: 1
-            },
-            offerPaymentMode: null,
-            price: {
-              amountMicros: 4990000,
-              currencyCode: 'USD',
-              formatted: '$4.99'
-            },
-            recurrenceMode: 1
-          }
-        ],
-        productId: 'product_monthly_pkg',
-        storeProductId: 'product_monthly_pkg',
-        tags: []
-      },
+        }
+      ],
+      productId: 'product_monthly_pkg',
+      storeProductId: 'product_monthly_pkg',
+      tags: []
+    };
+
+    const expectedMonthlyProduct = {
+      ...expectedPackageProduct,
+      identifier: 'product_monthly_pkg',
+      description: 'A $rc_monthly product with all features',
+      defaultOption: expectedMonthlyOption,
+      subscriptionOptions: [expectedMonthlyOption],
       pricePerMonth: 4990000,
       pricePerMonthString: '$4.99',
       pricePerWeek: 1151538,
@@ -322,17 +327,58 @@ describe('mapOfferings', () => {
       title: '$rc_monthly Product'
     };
 
-    const expectedWeeklyProduct = {
-      ...expectedPackageProduct,
-      identifier: 'product_weekly_pkg',
-      description: 'A $rc_weekly product with all features',
-      defaultOption: {
+    const expectedWeeklyOption = {
+      billingPeriod: {
+        iso8601: 'P1W',
+        unit: 'DAY',
+        value: 7
+      },
+      freePhase: {
+        billingCycleCount: 1,
+        billingPeriod: {
+          iso8601: 'P7D',
+          unit: 'DAY',
+          value: 7
+        },
+        offerPaymentMode: 'FREE_TRIAL',
+        price: {
+          amountMicros: 0,
+          currencyCode: 'USD',
+          formatted: 'Free'
+        },
+        recurrenceMode: 3
+      },
+      fullPricePhase: {
+        billingCycleCount: 0,
         billingPeriod: {
           iso8601: 'P1W',
           unit: 'DAY',
           value: 7
         },
-        freePhase: {
+        offerPaymentMode: null,
+        price: {
+          amountMicros: 4990000,
+          currencyCode: 'USD',
+          formatted: '$4.99'
+        },
+        recurrenceMode: 1
+      },
+      id: 'weekly_pkg_default',
+      installmentsInfo: null,
+      introPhase: null,
+      isBasePlan: false,
+      isPrepaid: false,
+      presentedOfferingContext: {
+        offeringIdentifier: 'premium_offering',
+        placementIdentifier: 'main_page',
+        targetingContext: {
+          revision: 1,
+          ruleId: 'rule_123'
+        }
+      },
+      presentedOfferingIdentifier: 'premium_offering',
+      pricingPhases: [
+        {
           billingCycleCount: 1,
           billingPeriod: {
             iso8601: 'P7D',
@@ -347,7 +393,7 @@ describe('mapOfferings', () => {
           },
           recurrenceMode: 3
         },
-        fullPricePhase: {
+        {
           billingCycleCount: 0,
           billingPeriod: {
             iso8601: 'P1W',
@@ -361,57 +407,19 @@ describe('mapOfferings', () => {
             formatted: '$4.99'
           },
           recurrenceMode: 1
-        },
-        id: 'weekly_pkg_default',
-        installmentsInfo: null,
-        introPhase: null,
-        isBasePlan: false,
-        isPrepaid: false,
-        presentedOfferingContext: {
-          offeringIdentifier: 'premium_offering',
-          placementIdentifier: 'main_page',
-          targetingContext: {
-            revision: 1,
-            ruleId: 'rule_123'
-          }
-        },
-        presentedOfferingIdentifier: 'premium_offering',
-        pricingPhases: [
-          {
-            billingCycleCount: 1,
-            billingPeriod: {
-              iso8601: 'P7D',
-              unit: 'DAY',
-              value: 7
-            },
-            offerPaymentMode: 'FREE_TRIAL',
-            price: {
-              amountMicros: 0,
-              currencyCode: 'USD',
-              formatted: 'Free'
-            },
-            recurrenceMode: 3
-          },
-          {
-            billingCycleCount: 0,
-            billingPeriod: {
-              iso8601: 'P1W',
-              unit: 'DAY',
-              value: 7
-            },
-            offerPaymentMode: null,
-            price: {
-              amountMicros: 4990000,
-              currencyCode: 'USD',
-              formatted: '$4.99'
-            },
-            recurrenceMode: 1
-          }
-        ],
-        productId: 'product_weekly_pkg',
-        storeProductId: 'product_weekly_pkg',
-        tags: []
-      },
+        }
+      ],
+      productId: 'product_weekly_pkg',
+      storeProductId: 'product_weekly_pkg',
+      tags: []
+    };
+
+    const expectedWeeklyProduct = {
+      ...expectedPackageProduct,
+      identifier: 'product_weekly_pkg',
+      description: 'A $rc_weekly product with all features',
+      defaultOption: expectedWeeklyOption,
+      subscriptionOptions: [expectedWeeklyOption],
       pricePerMonth: 4990000,
       pricePerMonthString: '$4.99',
       pricePerWeek: 96346,
@@ -448,7 +456,7 @@ describe('mapOfferings', () => {
       priceString: '$4.99',
       productCategory: 'NON_SUBSCRIPTION',
       productType: 'NON_CONSUMABLE',
-      subscriptionOptions: {},
+      subscriptionOptions: null,
       subscriptionPeriod: null,
       title: '$rc_lifetime Product'
     };
@@ -608,13 +616,15 @@ describe('mapOfferings', () => {
       pricePerWeek: trialPrice
     };
 
+    const optionId = `${identifier}_default`;
+
     const defaultOption = isSubscription ? {
-      id: `${identifier}_default`,
+      id: optionId,
       priceId: `price_${identifier}`,
       base: basePricingPhase,
       trial: trialPricingPhase
     } as SubscriptionOption : {
-      id: `${identifier}_default`,
+      id: optionId,
       priceId: `price_${identifier}`,
       price: price,
       basePrice: price
@@ -631,7 +641,7 @@ describe('mapOfferings', () => {
       productType: productType,
       currentPrice: price,
       normalPeriodDuration: isSubscription ? periodDuration : null,
-      subscriptionOptions: {},
+      subscriptionOptions: isSubscription ? { [optionId]: defaultOption as SubscriptionOption } : {},
       defaultSubscriptionOption: isSubscription ? defaultOption as SubscriptionOption : null,
       defaultNonSubscriptionOption: !isSubscription ? defaultOption as NonSubscriptionOption : null,
       defaultPurchaseOption: defaultOption,


### PR DESCRIPTION
Last batch of fixes to get flutter web working, at least for the common cases. This PR includes:
- Add some missing APIs like: `isAnonymous`, `isConfigured`, `setProxyUrl`
- Fixes some existing APIs where Flutter was expecting non null values. Now we default to some values, same way as in Android/iOS
- Adds extra export so we export UMD files which will be used by flutter web, instead of the raw js output.
- Fixes some tests that were completely wrong/incomplete.