### PR TITLE
[purchases-js-hybrid-mappings] Fix `logIn` result mapping

### DIFF
--- a/purchases-js-hybrid-mappings/api-report/api.json
+++ b/purchases-js-hybrid-mappings/api-report/api.json
@@ -190,6 +190,42 @@
           "members": [
             {
               "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js-hybrid-mappings!PurchasesCommon#close:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "close(): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<void>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "close"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@revenuecat/purchases-js-hybrid-mappings!PurchasesCommon.configure:member(1)",
               "docComment": "",
               "excerptTokens": [

--- a/purchases-js-hybrid-mappings/api-report/purchases-js-hybrid-mappings.api.md
+++ b/purchases-js-hybrid-mappings/api-report/purchases-js-hybrid-mappings.api.md
@@ -7,6 +7,8 @@
 // @public (undocumented)
 export class PurchasesCommon {
     // (undocumented)
+    close(): Promise<void>;
+    // (undocumented)
     static configure(configuration: {
         apiKey: string;
         appUserId: string | undefined;

--- a/purchases-js-hybrid-mappings/src/purchases-common.ts
+++ b/purchases-js-hybrid-mappings/src/purchases-common.ts
@@ -126,7 +126,12 @@ export class PurchasesCommon {
   public async logIn(appUserId: string): Promise<Record<string, unknown>> {
     try {
       const customerInfo = await this.purchases.changeUser(appUserId);
-      return mapCustomerInfo(customerInfo);
+      return {
+        customerInfo: mapCustomerInfo(customerInfo),
+        // TODO: In Web, we don't have a logIn method, which provides the information on whether the user was created
+        // or not. For now, hardcoding this data to false
+        created: false,
+      };
     } catch (error) {
       this.handleError(error);
     }

--- a/purchases-js-hybrid-mappings/src/purchases-common.ts
+++ b/purchases-js-hybrid-mappings/src/purchases-common.ts
@@ -148,6 +148,14 @@ export class PurchasesCommon {
     }
   }
 
+  public async close(): Promise<void> {
+    try {
+      this.purchases.close();
+    } catch (error) {
+      this.handleError(error);
+    }
+  }
+
   public async purchasePackage(purchaseParams: {
     packageIdentifier: string;
     presentedOfferingContext: Record<string, unknown>;


### PR DESCRIPTION
This PR has 2 changes:
- We were not passing the expected result in Flutter for the `logIn` request. This fixes that. One note however is that, for mobile SDKs, we do have a proper `logIn` method, that returns whether the user was created or not by using the response status code. In `purchases-js`, we don't provide a logIn function, only a changeUser, which returns a basic `CustomerInfo`. I think we will need to deprecate that method in `purchases-js` and add a new one that returns an object including this information, however, if we only change the return type, it would be a conflicting declaration, so we would need to rename it 😞. For now, I'm hardcoding this value to `false` until we get this information.
- Adds missing `close` function to close the configured SDK

