### PR TITLE
Do not include tsconfig in `purchases-typescript-internal`

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -7,8 +7,7 @@
   "types": "dist/index.d.ts",
   "source": "src/index",
   "files": [
-    "dist",
-    "tsconfig.json"
+    "dist"
   ],
   "scripts": {
     "apitests": "tsc --p apitesters/",


### PR DESCRIPTION
We don't need to include the `tsconfig.json` file in the published package. This fixes that so we only include the `dist` folder 
