### PR TITLE
Add `Storefront` type to typescript interfaces

### DIFF
--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -536,6 +536,11 @@ export type ShouldPurchasePromoProductListener = (deferredPurchase: () => Promis
 export type Store = "PLAY_STORE" | "APP_STORE" | "STRIPE" | "MAC_APP_STORE" | "PROMOTIONAL" | "AMAZON" | "RC_BILLING" | "EXTERNAL" | "UNKNOWN_STORE";
 
 // @public
+export interface Storefront {
+    readonly countryCode: string;
+}
+
+// @public
 export enum STOREKIT_VERSION {
     DEFAULT = "DEFAULT",
     STOREKIT_1 = "STOREKIT_1",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -5,3 +5,4 @@ export * from './enums';
 export * from './purchasesConfiguration';
 export * from './callbackTypes';
 export * from './webRedemption';
+export * from './storefront';

--- a/typescript/src/storefront.ts
+++ b/typescript/src/storefront.ts
@@ -1,0 +1,10 @@
+/**
+ * Contains the information about the current store account.
+ * @public
+ */
+export interface Storefront {
+    /**
+     * Country code of the current store account.
+     */
+    readonly countryCode: string;
+}


### PR DESCRIPTION
This will be used by RN and Capacitor SDKs. Adds this missing work from #1125 