### PR TITLE
Avoids passing multiple `PaywallResult`s to a single `PaywallResultListener`.

### DIFF
--- a/android/api-tests/src/test/java/com/revenuecat/apitests/java/PaywallApiTests.java
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/java/PaywallApiTests.java
@@ -31,19 +31,16 @@ class PaywallApiTests {
             Offering offering
     ) {
         PaywallHelpersKt.presentPaywallFromFragment(
-                fragmentActivity
+                fragmentActivity, listener
         );
         PaywallHelpersKt.presentPaywallFromFragment(
-                fragmentActivity, requiredEntitlementIdentifier
+                fragmentActivity, listener, requiredEntitlementIdentifier
         );
         PaywallHelpersKt.presentPaywallFromFragment(
-                fragmentActivity, requiredEntitlementIdentifier, listener
+                fragmentActivity, listener, requiredEntitlementIdentifier, shouldDisplayDismissButton
         );
         PaywallHelpersKt.presentPaywallFromFragment(
-                fragmentActivity, requiredEntitlementIdentifier, listener, shouldDisplayDismissButton
-        );
-        PaywallHelpersKt.presentPaywallFromFragment(
-                fragmentActivity, requiredEntitlementIdentifier, listener, shouldDisplayDismissButton, offering
+                fragmentActivity, listener, requiredEntitlementIdentifier, shouldDisplayDismissButton, offering
         );
     }
 }

--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/PaywallApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/PaywallApiTests.kt
@@ -22,30 +22,27 @@ private class PaywallApiTests {
     fun checkPresentPaywall(
         fragmentActivity: FragmentActivity,
         requiredEntitlementIdentifier: String?,
-        paywallResultListener: PaywallResultListener?,
+        paywallResultListener: PaywallResultListener,
         shouldDisplayDismissButton: Boolean?,
         offering: Offering?,
     ) {
         presentPaywallFromFragment(
-            fragment = fragmentActivity,
+            activity = fragmentActivity,
+            paywallResultListener = paywallResultListener,
         )
         presentPaywallFromFragment(
-            fragment = fragmentActivity,
-            requiredEntitlementIdentifier = requiredEntitlementIdentifier,
-        )
-        presentPaywallFromFragment(
-            fragment = fragmentActivity,
+            activity = fragmentActivity,
             requiredEntitlementIdentifier = requiredEntitlementIdentifier,
             paywallResultListener = paywallResultListener,
         )
         presentPaywallFromFragment(
-            fragment = fragmentActivity,
+            activity = fragmentActivity,
             requiredEntitlementIdentifier = requiredEntitlementIdentifier,
             paywallResultListener = paywallResultListener,
             shouldDisplayDismissButton = shouldDisplayDismissButton,
         )
         presentPaywallFromFragment(
-            fragment = fragmentActivity,
+            activity = fragmentActivity,
             requiredEntitlementIdentifier = requiredEntitlementIdentifier,
             paywallResultListener = paywallResultListener,
             shouldDisplayDismissButton = shouldDisplayDismissButton,

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragmentViewModel.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragmentViewModel.kt
@@ -1,7 +1,0 @@
-package com.revenuecat.purchases.hybridcommon.ui
-
-import androidx.lifecycle.ViewModel
-
-internal class PaywallFragmentViewModel : ViewModel() {
-    var paywallResultListener: PaywallResultListener? = null
-}


### PR DESCRIPTION
## Bug
It is possible to have multiple paywalls "alive" (in memory) at the same time, for instance if Paywall A has a button with a deep link that opens Paywall B. 

## Cause
In some of our hybrids, we use an invisible `PaywallFragment` to handle receiving a result from the `PaywallActivity`. In the scenario described above, multiple `PaywallFragment`s are alive, one for each Paywall. The problem arises because they share an Activity-scoped `PaywallFragmentViewModel` instance to hold the `PaywallResultListener`. When a subsequent Paywall is launched, that Paywall's `PaywallResultListener` is set in the shared `PaywallFragmentViewModel`, which all `PaywallFragment`s will now use. (The `PaywallFragmentViewModel` has to be Activity-scoped, because the listener had to be set before the `PaywallFragment` is created.) This causes all of the Paywalls to report their result to the same `PaywallResultListener` instance.  
  
In purchases-flutter, this results in crashes like this: 
```
IllegalStateException: Reply already submitted
```

- https://github.com/RevenueCat/purchases-flutter/issues/1350
- [Play SDK Console](https://play.google.com/sdk-console/accounts/3894912036640479868/sdks/5270760444858964624/crashes/ccfdc45a/details?timeRange=LAST_28_DAYS&affectedApps=AFFECTED_APPS_FIVE_OR_MORE&crashStatuses=SDK_CRASH_STATUS_UNSPECIFIED)

## Fix
The fix implemented in this PR is to use a `FragmentResultListener` tied to the specific `PaywallResultListener`. This means that every `PaywallFragment` only communicates with its own `PaywallResultListener`. This adheres to the "one result per Paywall" contract.