### PR TITLE
Fix clear background of paywalls in iOS

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallProxy.swift
@@ -182,6 +182,7 @@ import UIKit
 
         controller.delegate = self
         controller.modalPresentationStyle = .pageSheet
+        controller.view.backgroundColor = .systemBackground
 
         if let paywallResultHandler {
             self.resultByVC[controller] = (paywallResultHandler, .cancelled)


### PR DESCRIPTION
Paywalls had a transparent background in iOS. This would lead to situations like these

<img src="https://github.com/user-attachments/assets/874e5315-6343-4798-bc61-e6248de0efe0" width="200"/>
<img src="https://github.com/user-attachments/assets/0f62b153-4116-476a-b129-b73e8ed8fc57" width="200"/>


This PR fixes it, by setting the default background of the paywall to the system background color in iOS