### PR TITLE
Ensures async callbacks are called on the main thread.

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }

--- a/android/hybridcommon/build.gradle.kts
+++ b/android/hybridcommon/build.gradle.kts
@@ -49,6 +49,7 @@ android {
 dependencies {
     api(libs.purchases)
     api(libs.purchases.amazon)
+    implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/CustomerInfoMapper.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/CustomerInfoMapper.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.hybridcommon.mappers
 
 import com.revenuecat.purchases.CustomerInfo
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 private fun CustomerInfo.map(): Map<String, Any?> =
     mapOf(
@@ -30,5 +31,8 @@ private fun CustomerInfo.map(): Map<String, Any?> =
 fun CustomerInfo.mapAsync(
     callback: (Map<String, Any?>) -> Unit,
 ) {
-    mapperScope.launch { callback(map()) }
+    mainScope.launch {
+        val map = withContext(mapperDispatcher) { map() }
+        callback(map)
+    }
 }

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/OfferingsMapper.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/OfferingsMapper.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PresentedOfferingContext
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 private fun Offerings.map(): Map<String, Any?> =
     mapOf(
@@ -15,7 +16,10 @@ private fun Offerings.map(): Map<String, Any?> =
 fun Offerings.mapAsync(
     callback: (Map<String, Any?>) -> Unit,
 ) {
-    mapperScope.launch { callback(map()) }
+    mainScope.launch {
+        val map = withContext(mapperDispatcher) { map() }
+        callback(map)
+    }
 }
 
 private fun Offering.map(): Map<String, Any?> =
@@ -36,7 +40,10 @@ private fun Offering.map(): Map<String, Any?> =
 fun Offering.mapAsync(
     callback: (Map<String, Any?>) -> Unit,
 ) {
-    mapperScope.launch { callback(map()) }
+    mainScope.launch {
+        val map = withContext(mapperDispatcher) { map() }
+        callback(map)
+    }
 }
 
 fun Package.map(): Map<String, Any?> =

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/StoreProductMapper.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.SubscriptionOption
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 val StoreProduct.priceAmountMicros: Long
     get() = this.price.amountMicros
@@ -67,7 +68,10 @@ private fun List<StoreProduct>.map(): List<Map<String, Any?>> = this.map { it.ma
 fun List<StoreProduct>.mapAsync(
     callback: (List<Map<String, Any?>>) -> Unit,
 ) {
-    mapperScope.launch { callback(map()) }
+    mainScope.launch {
+        val map = withContext(mapperDispatcher) { map() }
+        callback(map)
+    }
 }
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/mappersHelpers.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/mappersHelpers.kt
@@ -4,7 +4,7 @@ import com.revenuecat.purchases.utils.Iso8601Utils
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.MainScope
 import org.json.JSONArray
 import org.json.JSONObject
 import java.text.NumberFormat
@@ -49,17 +49,14 @@ fun JSONObject.convertToMap(): Map<String, String?> =
     }
 
 /**
- * If this is set before the first time [mapperScope] is accessed, it will be used as the dispatcher for mapping
+ * If this is set before the first time [mapperDispatcher] is accessed, it will be used as the dispatcher for mapping
  * operations. This is useful to override the dispatcher for testing purposes.
  */
 internal var overrideMapperDispatcher: CoroutineDispatcher? = null
 
-private val mapperDispatcher: CoroutineDispatcher by lazy { overrideMapperDispatcher ?: Dispatchers.Default }
+internal val mapperDispatcher: CoroutineDispatcher by lazy { overrideMapperDispatcher ?: Dispatchers.Default }
 
-internal val mapperScope by lazy { CoroutineScope(SupervisorJob() + mapperDispatcher) }
-
-internal fun mapperScope(dispatcher: CoroutineDispatcher = Dispatchers.Default): CoroutineScope =
-    CoroutineScope(SupervisorJob() + dispatcher)
+internal val mainScope: CoroutineScope = MainScope()
 
 internal fun Date.toMillis(): Long = this.time
 

--- a/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.content.Context
 import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
@@ -50,9 +51,13 @@ import io.mockk.mockkObject
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
@@ -66,6 +71,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class CommonKtTests {
 
     private val mockApplicationContext = mockk<Application>(relaxed = true)
@@ -82,8 +88,14 @@ internal class CommonKtTests {
         every { mockContext.applicationContext } returns mockApplicationContext
         every { Purchases.sharedInstance } returns mockPurchases
         every { mockPurchases.store } returns Store.PLAY_STORE
-        @OptIn(ExperimentalCoroutinesApi::class)
-        overrideMapperDispatcher = UnconfinedTestDispatcher()
+        val testDispatcher = UnconfinedTestDispatcher()
+        overrideMapperDispatcher = testDispatcher
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterEach
+    fun teardown() {
+        Dispatchers.resetMain()
     }
 
     @Test
@@ -1314,6 +1326,7 @@ internal class CommonKtTests {
         assertEquals(metadata, mappedMetadata)
     }
 
+    @OptIn(InternalRevenueCatAPI::class)
     private fun getOfferings(
         mockStoreProduct: StoreProduct,
         metadata: Map<String, Any> = emptyMap(),

--- a/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/CustomerInfoMappersTests.kt
+++ b/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/CustomerInfoMappersTests.kt
@@ -11,12 +11,30 @@ import com.revenuecat.purchases.hybridcommon.mappers.toMillis
 import com.revenuecat.purchases.models.Transaction
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.Date
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class CustomerInfoMappersTests {
     val mockCustomerInfo = mockk<CustomerInfo>(relaxed = true)
+
+    @BeforeEach
+    fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterEach
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
 
     @Test
     fun `a CustomerInfo with a null managementURL, should map to a null managementURL`() {


### PR DESCRIPTION
## Description
As a result of https://github.com/RevenueCat/purchases-hybrid-common/pull/1169, callbacks such as the PaywallListener could end up not being called on the main thread. At least Flutter doesn't like that: https://github.com/RevenueCat/purchases-flutter/issues/1395. This PR fixes that by moving back to the main thread before calling the callback. 