### PR TITLE
Use spi(Interal) Import RC in Tests

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
@@ -9,7 +9,7 @@
 import Quick
 import Nimble
 @testable import PurchasesHybridCommon
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import Foundation
 
 class PurchasesHybridCommonTests: QuickSpec {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/VirtualCurrencies+HybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/VirtualCurrencies+HybridAdditionsTests.swift
@@ -11,7 +11,7 @@ import Quick
 import Nimble
 
 @testable import PurchasesHybridCommon
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 class VirtualCurrenciesHybridAdditionsTests: QuickSpec {
     override func spec() {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/VirtualCurrency+HybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/VirtualCurrency+HybridAdditionsTests.swift
@@ -11,7 +11,7 @@ import Quick
 import Nimble
 
 @testable import PurchasesHybridCommon
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 class VirtualCurrencyHybridAdditionsTests: QuickSpec {
     override func spec() {


### PR DESCRIPTION
https://github.com/RevenueCat/purchases-ios/pull/5384 updated the VirtualCurrency object initializers to be @spi(Internal), which broke the compilation of a few tests in PHC. This PR updates the affected test files to use `@spi(Internal) @testable import RevenueCat` to fix the compilation of the tests.