### PR TITLE
Update iOS VC APIs

### DIFF
--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSDictionary<NSString *, NSObject *> __unused *dictionary = [RCCommonFunctionality encodeCustomerInfo:info];
 
     [RCCommonFunctionality getVirtualCurrenciesWithCompletion:^(
-                                                             RCVirtualCurrencies * _Nullable virtualCurrencies,
+                                                            NSDictionary<NSString *, NSObject *> * _Nullable virtualCurrencies,
                                                              RCErrorContainer * _Nullable errorContainer) {}];
 
     [RCCommonFunctionality invalidateVirtualCurrenciesCache];

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -864,6 +864,27 @@ private extension WebPurchaseRedemptionResult {
         }
     }
 
+    @objc(getVirtualCurrenciesDictionariesWithCompletion:) static func getVirtualCurrencies(
+        completion: @escaping ([String: Any]?, ErrorContainer?) -> Void
+    ) {
+        Self.sharedInstance.getVirtualCurrencies { virtualCurrencies, error in
+            if let error = error {
+                completion(nil, Self.createErrorContainer(error: error))
+            } else if let virtualCurrencies = virtualCurrencies {
+                completion(virtualCurrencies.rc_dictionary, nil)
+            } else {
+                completion(
+                    nil,
+                    ErrorContainer(error: ErrorCode.unknownError as NSError, extraPayload: [:])
+                )
+            }
+        }
+    }
+
+    @objc static func getCachedVirtualCurrencies() -> [String: Any]? {
+        return Self.sharedInstance.cachedVirtualCurrencies?.rc_dictionary
+    }
+
     @objc static func invalidateVirtualCurrenciesCache() {
         Self.sharedInstance.invalidateVirtualCurrenciesCache()
     }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -848,23 +848,6 @@ private extension WebPurchaseRedemptionResult {
 @objc public extension CommonFunctionality {
 
     @objc static func getVirtualCurrencies(
-        completion: @escaping (VirtualCurrencies?, ErrorContainer?) -> Void
-    ) {
-        Self.sharedInstance.getVirtualCurrencies { virtualCurrencies, error in
-            if let error = error {
-                completion(nil, Self.createErrorContainer(error: error))
-            } else if let virtualCurrencies = virtualCurrencies {
-                completion(virtualCurrencies, nil)
-            } else {
-                completion(
-                    nil,
-                    ErrorContainer(error: ErrorCode.unknownError as NSError, extraPayload: [:])
-                )
-            }
-        }
-    }
-
-    @objc(getVirtualCurrenciesDictionariesWithCompletion:) static func getVirtualCurrencies(
         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void
     ) {
         Self.sharedInstance.getVirtualCurrencies { virtualCurrencies, error in

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/CommonFunctionality+async.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/CommonFunctionality+async.swift
@@ -130,4 +130,11 @@ extension CommonFunctionality {
         }
     }
 
+    static func virtualCurrencies() async throws -> [String: Any] {
+        return try await withCheckedThrowingContinuation { continuation in
+            Self.getVirtualCurrencies { dictionary, error in
+                continuation.resume(with: Result(dictionary, error?.error))
+            }
+        }
+    }
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
@@ -377,10 +377,10 @@ class PurchasesHybridCommonTests: QuickSpec {
         context("getVirtualCurrencies") {
             it("calls Purchases.getVirtualCurrencies with VirtualCurrencies on success") {
                 var completionCallCount = 0
-                var completionVirtualCurrencies: VirtualCurrencies? = nil
+                var completionVirtualCurrencies: NSDictionary?
                 var completionError: ErrorContainer? = nil
 
-                let expectedVirtualCurrencies = VirtualCurrencies(virtualCurrencies: [
+                let virtualCurrencies = VirtualCurrencies(virtualCurrencies: [
                     "COIN": VirtualCurrency(
                         balance: 1,
                         name: "Coin",
@@ -388,24 +388,42 @@ class PurchasesHybridCommonTests: QuickSpec {
                         serverDescription: nil
                     )
                 ])
-                mockPurchases.getVirtualCurrenciesStub = .success(expectedVirtualCurrencies)
 
-                CommonFunctionality.getVirtualCurrencies { virtualCurrencies, error in
+                mockPurchases.getVirtualCurrenciesStub = .success(virtualCurrencies)
+
+                let expectedVirtualCurrenciesDictionary: NSDictionary = [
+                    "all": [
+                        "COIN": [
+                            "balance": 1,
+                            "name": "Coin",
+                            "code": "COIN",
+                            "serverDescription": nil
+                        ]
+                    ]
+                ]
+
+                CommonFunctionality.getVirtualCurrencies { rcDictionary, error in
+                    guard let rcDictionary else {
+                        fail("rcDictionary must not be nil")
+                        return
+                    }
+
                     completionCallCount += 1
-                    completionVirtualCurrencies = virtualCurrencies
+                    completionVirtualCurrencies = NSDictionary(dictionary: rcDictionary)
                     completionError = error
                 }
 
                 expect(mockPurchases.invokedGetVirtualCurrencies).to(beTrue())
                 expect(mockPurchases.invokedGetVirtualCurrenciesCount).to(equal(1))
                 expect(completionCallCount).to(equal(1))
-                expect(completionVirtualCurrencies).to(equal(expectedVirtualCurrencies))
+                expect(completionVirtualCurrencies).to(equal(expectedVirtualCurrenciesDictionary))
+
                 expect(completionError).to(beNil())
             }
 
             it("calls Purchases.getVirtualCurrencies with ErrorContainer on error") {
                 var completionCallCount = 0
-                var completionVirtualCurrencies: VirtualCurrencies? = nil
+                var completionVirtualCurrencies: NSDictionary? = nil
                 var completionError: ErrorContainer? = nil
 
                 let mockError = NSError(domain: "revenuecat", code: 123)
@@ -416,9 +434,16 @@ class PurchasesHybridCommonTests: QuickSpec {
                 ]
                 mockPurchases.getVirtualCurrenciesStub = .failure(mockError)
 
-                CommonFunctionality.getVirtualCurrencies { virtualCurrencies, error in
+                CommonFunctionality.getVirtualCurrencies { rcDictionary, error in
+                    expect(rcDictionary).to(beNil())
+
+                    if let rcDictionary {
+                        completionVirtualCurrencies = NSDictionary(dictionary: rcDictionary)
+                    } else {
+                        completionVirtualCurrencies = nil
+                    }
+
                     completionCallCount += 1
-                    completionVirtualCurrencies = virtualCurrencies
                     completionError = error
                 }
 
@@ -440,6 +465,45 @@ class PurchasesHybridCommonTests: QuickSpec {
                 CommonFunctionality.invalidateVirtualCurrenciesCache()
                 expect(mockPurchases.invokedInvalidateVirtualCurrenciesCache).to(beTrue())
                 expect(mockPurchases.invokedInvalidateVirtualCurrenciesCacheCount).to(equal(1))
+            }
+        }
+
+        context("getCachedVirtualCurrencies") {
+            it("calls Purchases.cachedVirtualCurrencies") {
+                let expectedCode = "COIN"
+                let expectedName = "Coin"
+                let expectedBalance = 1
+                let expectedServerDescription: String? = nil
+
+                let expectedVirtualCurrenciesDictionary: NSDictionary = [
+                    "all": [
+                        expectedCode: [
+                            "balance": expectedBalance,
+                            "name": expectedName,
+                            "code": expectedCode,
+                            "serverDescription": expectedServerDescription as Any
+                        ]
+                    ]
+                ]
+
+                let cachedVirtualCurrencies = CommonFunctionality.getCachedVirtualCurrencies()
+                expect(cachedVirtualCurrencies).to(beNil())
+
+                let virtualCurrencies = VirtualCurrencies(virtualCurrencies: [
+                    expectedCode: VirtualCurrency(
+                        balance: expectedBalance,
+                        name: expectedName,
+                        code: expectedCode,
+                        serverDescription: expectedServerDescription
+                    )
+                ])
+
+                mockPurchases.cachedVirtualCurrencies = virtualCurrencies
+
+                let cachedVirtualCurrencies2 = CommonFunctionality.getCachedVirtualCurrencies()
+                expect(cachedVirtualCurrencies2).toNot(beNil())
+
+                expect(NSDictionary(dictionary: cachedVirtualCurrencies2!)).to(equal(expectedVirtualCurrenciesDictionary))
             }
         }
     }


### PR DESCRIPTION
### Description
In preparation for adding Virtual Currency functionality to the hybrid SDKs, this PR makes a few changes to the iOS VC APIs exposed through PHC:
- Exposes a new `getCachedVirtualCurrencies()` function. I decided to make this a function instead of a computed property to minimize the risk of running into compatibility issues in any of the hybrid SDKs when trying to access a computed property.
- Updates the signature of the `getVirtualCurrencies()` function's completion handler to return `[String: Any]?` instead of a `VirtualCurrencies` object. 
   - The `getVirtualCurrencies()` function was introduced in https://github.com/RevenueCat/purchases-hybrid-common/pull/1173 and mistakenly returned a `VirtualCurrencies` object instead of a `[String: Any]?` in its completion handler.
   - While this is a breaking change, it shouldn't break any of the individual hybrid SDKs, since they are not consuming the `getVirtualCurrencies()` function yet.
- Updates the existing tests around  `getVirtualCurrencies()` to support the new API signature
- Adds new tests for the `getCachedVirtualCurrencies()` function