### PR TITLE
[purchases-js-hybrid-mappings] Support `setAttributes`

### DIFF
--- a/purchases-js-hybrid-mappings/api-report/api.json
+++ b/purchases-js-hybrid-mappings/api-report/api.json
@@ -761,6 +761,165 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js-hybrid-mappings!PurchasesCommon#setAttributes:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "setAttributes(attributes: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "{\n        [key: string]: string | null;\n    }"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<void>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 5
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "attributes",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "setAttributes"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js-hybrid-mappings!PurchasesCommon#setDisplayName:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "setDisplayName(displayName: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<void>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 5
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "displayName",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "setDisplayName"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js-hybrid-mappings!PurchasesCommon#setEmail:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "setEmail(email: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<void>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 5
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "email",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "setEmail"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@revenuecat/purchases-js-hybrid-mappings!PurchasesCommon.setLogLevel:member(1)",
               "docComment": "",
               "excerptTokens": [
@@ -806,6 +965,59 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "setLogLevel"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js-hybrid-mappings!PurchasesCommon#setPhoneNumber:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "setPhoneNumber(phoneNumber: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<void>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 5
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "phoneNumber",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "setPhoneNumber"
             },
             {
               "kind": "Method",

--- a/purchases-js-hybrid-mappings/api-report/purchases-js-hybrid-mappings.api.md
+++ b/purchases-js-hybrid-mappings/api-report/purchases-js-hybrid-mappings.api.md
@@ -45,7 +45,17 @@ export class PurchasesCommon {
         defaultLocale?: string;
     }): Promise<Record<string, unknown>>;
     // (undocumented)
+    setAttributes(attributes: {
+        [key: string]: string | null;
+    }): Promise<void>;
+    // (undocumented)
+    setDisplayName(displayName: string | null): Promise<void>;
+    // (undocumented)
+    setEmail(email: string | null): Promise<void>;
+    // (undocumented)
     static setLogLevel(logLevel: string): void;
+    // (undocumented)
+    setPhoneNumber(phoneNumber: string | null): Promise<void>;
     // (undocumented)
     static setProxyUrl(proxyUrl: string): void;
 }

--- a/purchases-js-hybrid-mappings/src/purchases-common.ts
+++ b/purchases-js-hybrid-mappings/src/purchases-common.ts
@@ -119,7 +119,7 @@ export class PurchasesCommon {
     return this.purchases.isAnonymous();
   }
 
-  public async setAttributes(attributes: { [key: string]: string | null }) {
+  public async setAttributes(attributes: { [key: string]: string | null }): Promise<void> {
     try {
       await this.purchases.setAttributes(attributes);
     } catch (error) {

--- a/purchases-js-hybrid-mappings/tests/purchases-common.test.ts
+++ b/purchases-js-hybrid-mappings/tests/purchases-common.test.ts
@@ -1,5 +1,21 @@
 import { PurchasesCommon } from '../src/purchases-common';
-import { Purchases, Offering, Package, PurchaseResult, PurchasesError, ErrorCode, EntitlementInfos, CustomerInfo, PackageType, Product, ProductType, ReservedCustomerAttribute, SubscriptionOption, PeriodUnit } from '@revenuecat/purchases-js';
+import {
+  Purchases,
+  Offering,
+  Package,
+  PurchaseResult,
+  PurchasesError,
+  ErrorCode,
+  EntitlementInfos,
+  CustomerInfo,
+  PackageType,
+  Product,
+  ProductType,
+  ReservedCustomerAttribute,
+  SubscriptionOption,
+  PeriodUnit,
+  PurchasesConfig
+} from '@revenuecat/purchases-js';
 import { jest } from '@jest/globals';
 
 describe('PurchasesCommon', () => {
@@ -154,11 +170,13 @@ describe('PurchasesCommon', () => {
         flavorVersion: '1.0.0'
       });
 
-      expect(Purchases.configure).toHaveBeenCalledWith(
-        'test_api_key',
-        appUserId,
-        undefined
-      );
+      const expectedConfig: PurchasesConfig = {
+        apiKey: 'test_api_key',
+        appUserId: appUserId,
+        httpConfig: undefined,
+      }
+
+      expect(Purchases.configure).toHaveBeenCalledWith(expectedConfig);
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
         'revenuecat_user_id',
         appUserId
@@ -176,11 +194,13 @@ describe('PurchasesCommon', () => {
         flavorVersion: '1.0.0'
       });
 
-      expect(Purchases.configure).toHaveBeenCalledWith(
-        'test_api_key',
-        storedUserId,
-        undefined
-      );
+      const expectedConfig: PurchasesConfig = {
+        apiKey: 'test_api_key',
+        appUserId: storedUserId,
+        httpConfig: undefined,
+      }
+
+      expect(Purchases.configure).toHaveBeenCalledWith(expectedConfig);
       expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
     });
 
@@ -194,11 +214,13 @@ describe('PurchasesCommon', () => {
         flavorVersion: '1.0.0'
       });
 
-      expect(Purchases.configure).toHaveBeenCalledWith(
-        'test_api_key',
-        'anonymous_id',
-        undefined
-      );
+      const expectedConfig: PurchasesConfig = {
+        apiKey: 'test_api_key',
+        appUserId: 'anonymous_id',
+        httpConfig: undefined,
+      }
+
+      expect(Purchases.configure).toHaveBeenCalledWith(expectedConfig);
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
         'revenuecat_user_id',
         'anonymous_id'
@@ -220,11 +242,13 @@ describe('PurchasesCommon', () => {
         flavorVersion: '1.0.0'
       });
 
-      expect(Purchases.configure).toHaveBeenCalledWith(
-        'test_api_key',
-        'anonymous_id',
-        undefined
-      );
+      const expectedConfig: PurchasesConfig = {
+        apiKey: 'test_api_key',
+        appUserId: 'anonymous_id',
+        httpConfig: undefined,
+      }
+
+      expect(Purchases.configure).toHaveBeenCalledWith(expectedConfig);
     });
   });
 


### PR DESCRIPTION
This adds support for the `setAttributes` method and some reserved attributes methods.
