### PR TITLE
Add `productIdentifier` to purchase result in JS mappings

### DIFF
--- a/purchases-js-hybrid-mappings/src/mappers/purchase_result_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/purchase_result_mapper.ts
@@ -12,5 +12,6 @@ export function mapPurchaseResult(purchaseResult: PurchaseResult): Record<string
       purchaseDate: purchaseResult.storeTransaction.purchaseDate.toISOString(),
       purchaseDateMillis: purchaseResult.storeTransaction.purchaseDate.getTime(),
     },
+    productIdentifier: purchaseResult.storeTransaction.productIdentifier,
   };
 }

--- a/purchases-js-hybrid-mappings/tests/mappers/purchase_result_mapper.test.ts
+++ b/purchases-js-hybrid-mappings/tests/mappers/purchase_result_mapper.test.ts
@@ -72,6 +72,7 @@ describe('mapPurchaseResult', () => {
         purchaseDate: mockDate.toISOString(),
         purchaseDateMillis: mockDate.getTime(),
       },
+      productIdentifier: 'test-product-id',
     });
   });
 });


### PR DESCRIPTION
We weren't using this property in flutter but we need it in RN... We could also add it there, but since we might be using this in more hybrids, I think it makes more sense to pass the same thing we pass in Android/iOS here.
