### PR TITLE
Run Tests on iOS 18 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,26 @@ jobs:
           path: ios/PurchasesHybridCommon/test_output
           destination: scan-output
 
+  test-ios-18:
+    <<: *base-ios-job
+    steps:
+      - checkout
+      - revenuecat/install-gem-mac-dependencies:
+          cache-version: v1
+      - install-cocoapods
+      - run:
+          name: Run ios tests
+          command: fastlane scan
+          working_directory: ios/PurchasesHybridCommon
+          environment:
+            SCAN_SCHEME: PurchasesHybridCommon
+            SCAN_DEVICE: iPhone 16 (18.5)
+      - store_test_results:
+          path: ios/PurchasesHybridCommon/test_output
+      - store_artifacts:
+          path: ios/PurchasesHybridCommon/test_output
+          destination: scan-output
+
   integration-test-ios:
     <<: *base-ios-job
     steps:
@@ -461,6 +481,7 @@ workflows:
     jobs:
       - test-ios-16
       - test-ios-17
+      - test-ios-18
       - check-pods
       - integration-test-ios
       - test-android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ aliases:
     parameters:
       xcode_version:
         type: string
-        default: 15.2.0
+        default: 16.4.0
     working_directory: ~/ios
     shell: /bin/bash --login -o pipefail
   release-tags: &release-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
           command: bundle exec fastlane scan --result_bundle=true --testplan=CI
           working_directory: ios/PurchasesHybridCommon
           environment:
-            SCAN_DEVICE: iPhone 15 (17.2)
+            SCAN_DEVICE: iPhone 16 (18.5)
             SCAN_SCHEME: PurchasesHybridCommonIntegrationTests
       - run:
           name: Compress result bundle

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem "cocoapods", "~> 1.16"
 gem 'danger'
 gem 'rest-client'
 gem "lefthook", "~> 1.12"
+gem "abbrev"


### PR DESCRIPTION
This PR updates the `purchases-hybrid-common` CI to run iOS tests on iOS 18. Specifically, it:
- Defaults to using Xcode 16.4.0 instead of 15.2.0
- Adds a `test-ios-18` job to be run when the iOS tests are executed
- Runs the iOS integration tests on iOS 18.5 instead of iOS 17.2
- Explicitly adds `abbrev` as a dependency in the `Gemfile`. Without it, the `check-pods` and `integration-tests-ios` jobs fail, since `abbrev` was "promoted from default gems" in Ruby 3.4.0, meaning that it is no longer a default gem ([source](https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/))