### PR TITLE
Add missing fields in SubscriptionInfo

### DIFF
--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/SubscriptionInfoMapper.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/SubscriptionInfoMapper.kt
@@ -2,8 +2,17 @@ package com.revenuecat.purchases.hybridcommon.mappers
 
 import com.revenuecat.purchases.SubscriptionInfo
 
-fun SubscriptionInfo.map(): Map<String, Any?> =
-    mapOf(
+fun SubscriptionInfo.map(): Map<String, Any?> {
+    var priceObject: Map<String, Any>? = null
+    price?.let {
+        priceObject = mapOf(
+            "currency" to it.currencyCode,
+            "amount" to (it.amountMicros.toDouble() / 1_000_000.0),
+            "formatted" to it.formatted,
+        )
+    }
+
+    return mapOf(
         "productIdentifier" to productIdentifier,
         "purchaseDate" to purchaseDate.toIso8601(),
         "originalPurchaseDate" to originalPurchaseDate?.toIso8601(),
@@ -17,6 +26,11 @@ fun SubscriptionInfo.map(): Map<String, Any?> =
         "periodType" to periodType.name,
         "refundedAt" to refundedAt?.toIso8601(),
         "storeTransactionId" to storeTransactionId,
+        "autoResumeDate" to autoResumeDate?.toIso8601(),
+        "price" to priceObject,
+        "productPlanIdentifier" to productPlanIdentifier,
+        "managementURL" to managementURL?.toString(),
         "isActive" to isActive,
         "willRenew" to willRenew,
     )
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/SubscriptionInfo+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/SubscriptionInfo+HybridAdditions.swift
@@ -14,8 +14,19 @@ internal extension SubscriptionInfo {
     var dictionary: [String: Any] {
         var priceObject: [String: Any]? = nil
         if let priceCurrency = price?.currency, let priceAmount = price?.amount {
-            priceObject = ["currency": priceCurrency, "amount": priceAmount]
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .currency
+            formatter.locale = .autoupdatingCurrent
+            formatter.currencyCode = priceCurrency
+            let formattedPrice = formatter.string(from: NSDecimalNumber(decimal: Decimal(priceAmount))) ?? "\(priceAmount) \(priceCurrency)"
+            
+            priceObject = [
+                "currency": priceCurrency,
+                "amount": priceAmount,
+                "formatted": formattedPrice
+            ]
         }
+        
         return [
             "productIdentifier": productIdentifier,
             "purchaseDate": purchaseDate.rc_formattedAsISO8601(),
@@ -30,7 +41,10 @@ internal extension SubscriptionInfo {
             "periodType": periodType.periodTypeString,
             "refundedAt": refundedAt?.rc_formattedAsISO8601() ?? NSNull(),
             "storeTransactionId": storeTransactionId ?? NSNull(),
+            "autoResumeDate": NSNull(),
+            "productPlanIdentifier": NSNull(),
             "price": priceObject ?? NSNull(),
+            "managementURL": managementURL?.absoluteString ?? NSNull(),
             "isActive": isActive,
             "willRenew": willRenew,
         ]


### PR DESCRIPTION
In the Android side:
- `price`
- `autoResumeDate`
- `productPlanIdentifier`
- `managementURL`

In iOS:
- `formatted` to `price`
- `autoResumeDate`
- `productPlanIdentifier`
- `managementURL`