### PR TITLE
Fix web localization not defaulting to browser locale

### DIFF
--- a/purchases-js-hybrid-mappings/src/purchases-common.ts
+++ b/purchases-js-hybrid-mappings/src/purchases-common.ts
@@ -244,7 +244,7 @@ export class PurchasesCommon {
         rcPackage: rcPackage,
         purchaseOption: nativePurchaseOption,
         customerEmail: purchaseParams.customerEmail,
-        selectedLocale: purchaseParams.selectedLocale,
+        selectedLocale: purchaseParams.selectedLocale || navigator?.language,
         defaultLocale: purchaseParams.defaultLocale,
       };
       const purchaseResult: PurchaseResult = await this.purchases.purchase(nativePurchaseParams);

--- a/purchases-js-hybrid-mappings/tests/purchases-common.test.ts
+++ b/purchases-js-hybrid-mappings/tests/purchases-common.test.ts
@@ -150,6 +150,12 @@ describe('PurchasesCommon', () => {
       writable: true,
       configurable: true
     });
+
+    Object.defineProperty(navigator, 'language', {
+      value: 'es-US',
+      writable: true,
+      configurable: true
+    });
   });
 
   afterEach(() => {
@@ -397,7 +403,7 @@ describe('PurchasesCommon', () => {
         presentedOfferingContext: { offeringIdentifier: 'test_offering' },
         optionIdentifier: 'test_monthly_option',
         customerEmail: 'test@example.com',
-        selectedLocale: 'en-US',
+        selectedLocale: 'es-US',
         defaultLocale: 'en'
       };
 
@@ -407,7 +413,7 @@ describe('PurchasesCommon', () => {
         rcPackage: mockOffering.availablePackages[0],
         purchaseOption: mockOffering.availablePackages[0].webBillingProduct.subscriptionOptions['test_monthly_option'],
         customerEmail: 'test@example.com',
-        selectedLocale: 'en-US',
+        selectedLocale: 'es-US',
         defaultLocale: 'en'
       });
     });
@@ -430,7 +436,9 @@ describe('PurchasesCommon', () => {
       expect(mockPurchasesInstance.purchase).toHaveBeenCalledWith({
         rcPackage: mockOffering.availablePackages[0],
         purchaseOption: null,
-        customerEmail: 'test@example.com'
+        customerEmail: 'test@example.com',
+        selectedLocale: 'es-US',
+        defaultLocale: undefined,
       });
     });
 
@@ -460,7 +468,9 @@ describe('PurchasesCommon', () => {
       expect(mockPurchasesInstance.purchase).toHaveBeenCalledWith({
         rcPackage: mockOffering.availablePackages[0],
         purchaseOption: null,
-        customerEmail: 'test@example.com'
+        customerEmail: 'test@example.com',
+        selectedLocale: 'es-US',
+        defaultLocale: undefined,
       });
     });
 


### PR DESCRIPTION
The purchases-js SDK defaults to English if no locale is passed. We should pass the navigator language as default if none given
