### PR TITLE
Added presentedOfferingContext parameter to the hybrid APIs for presenting paywalls

### DIFF
--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCPaywallProxyAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCPaywallProxyAPITest.m
@@ -50,8 +50,10 @@ NS_ASSUME_NONNULL_BEGIN
 
         __unused RCPaywallViewController *view1 = [proxy createPaywallView];
         __unused RCPaywallViewController *view2 = [proxy createPaywallViewWithOfferingIdentifier:@"offering"];
+        __unused RCPaywallViewController *view3 = [proxy createPaywallViewWithOfferingIdentifier:@"offering" presentedOfferingContext:@{}];
         __unused RCPaywallFooterViewController *footer1 = [proxy createFooterPaywallView];
         __unused RCPaywallFooterViewController *footer2 = [proxy createFooterPaywallViewWithOfferingIdentifier:@"offering"];
+        __unused RCPaywallFooterViewController *footer3 = [proxy createFooterPaywallViewWithOfferingIdentifier:@"offering" presentedOfferingContext:@{}];
     }
 }
 


### PR DESCRIPTION
Adds the `presentedOfferingContext` parameter implemented in the native SDKs (for context, [iOS](https://github.com/RevenueCat/purchases-ios/pull/5491) and [Android](https://github.com/RevenueCat/purchases-android/pull/2610) PRs)

Also deprecated the old APIs and added the new APIs to the API test.