### PR TITLE
Add `PaywallSource` with `PresentedOfferingContext` in Android

### DIFF
--- a/android/api-tests/src/test/java/com/revenuecat/apitests/java/PaywallApiTests.java
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/java/PaywallApiTests.java
@@ -4,8 +4,11 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
 
 import com.revenuecat.purchases.Offering;
+import com.revenuecat.purchases.PresentedOfferingContext;
 import com.revenuecat.purchases.hybridcommon.ui.PaywallHelpersKt;
 import com.revenuecat.purchases.hybridcommon.ui.PaywallResultListener;
+import com.revenuecat.purchases.hybridcommon.ui.PaywallSource;
+import com.revenuecat.purchases.hybridcommon.ui.PresentPaywallOptions;
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult;
 
 @SuppressWarnings({"unused"})
@@ -23,12 +26,30 @@ class PaywallApiTests {
         };
     }
 
+    private void checkPaywallSource(PaywallSource source) {
+        if (source instanceof PaywallSource.DefaultOffering) {
+            PaywallSource.DefaultOffering defaultOffering = (PaywallSource.DefaultOffering) source;
+        } else if (source instanceof PaywallSource.OfferingIdentifier) {
+            PaywallSource.OfferingIdentifier offeringIdentifier = (PaywallSource.OfferingIdentifier) source;
+            String identifier = offeringIdentifier.getValue();
+        } else if (source instanceof PaywallSource.Offering) {
+            PaywallSource.Offering offering = (PaywallSource.Offering) source;
+            Offering internalOffering = offering.getValue();
+        } else if (source instanceof PaywallSource.OfferingIdentifierWithPresentedOfferingContext) {
+            PaywallSource.OfferingIdentifierWithPresentedOfferingContext offeringWithContext
+                    = (PaywallSource.OfferingIdentifierWithPresentedOfferingContext) source;
+            String identifier = offeringWithContext.getOfferingIdentifier();
+            PresentedOfferingContext context = offeringWithContext.getPresentedOfferingContext();
+        }
+    }
+
     private void checkPresentPaywall(
             FragmentActivity fragmentActivity,
             String requiredEntitlementIdentifier,
             PaywallResultListener listener,
             Boolean shouldDisplayDismissButton,
-            Offering offering
+            Offering offering,
+            PresentPaywallOptions presentPaywallOptions
     ) {
         PaywallHelpersKt.presentPaywallFromFragment(
                 fragmentActivity, listener
@@ -41,6 +62,9 @@ class PaywallApiTests {
         );
         PaywallHelpersKt.presentPaywallFromFragment(
                 fragmentActivity, listener, requiredEntitlementIdentifier, shouldDisplayDismissButton, offering
+        );
+        PaywallHelpersKt.presentPaywallFromFragment(
+                fragmentActivity, presentPaywallOptions
         );
     }
 }

--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/PaywallApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/PaywallApiTests.kt
@@ -2,7 +2,10 @@ package com.revenuecat.apitests.kotlin
 
 import androidx.fragment.app.FragmentActivity
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.hybridcommon.ui.PaywallResultListener
+import com.revenuecat.purchases.hybridcommon.ui.PaywallSource
+import com.revenuecat.purchases.hybridcommon.ui.PresentPaywallOptions
 import com.revenuecat.purchases.hybridcommon.ui.presentPaywallFromFragment
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult
 
@@ -19,12 +22,31 @@ private class PaywallApiTests {
         }
     }
 
+    fun checkPaywallSource(paywallSource: PaywallSource) {
+        when (paywallSource) {
+            is PaywallSource.Offering -> {
+                val offering: Offering = paywallSource.value
+            }
+            PaywallSource.DefaultOffering -> {
+            }
+            is PaywallSource.OfferingIdentifier -> {
+                val identifier: String = paywallSource.value
+            }
+            is PaywallSource.OfferingIdentifierWithPresentedOfferingContext -> {
+                val identifier: String = paywallSource.offeringIdentifier
+                val context: PresentedOfferingContext = paywallSource.presentedOfferingContext
+            }
+        }
+    }
+
+    @Suppress("LongParameterList")
     fun checkPresentPaywall(
         fragmentActivity: FragmentActivity,
         requiredEntitlementIdentifier: String?,
         paywallResultListener: PaywallResultListener,
         shouldDisplayDismissButton: Boolean?,
         offering: Offering?,
+        presentPaywallOptions: PresentPaywallOptions,
     ) {
         presentPaywallFromFragment(
             activity = fragmentActivity,
@@ -47,6 +69,10 @@ private class PaywallApiTests {
             paywallResultListener = paywallResultListener,
             shouldDisplayDismissButton = shouldDisplayDismissButton,
             offering = offering,
+        )
+        presentPaywallFromFragment(
+            activity = fragmentActivity,
+            options = presentPaywallOptions,
         )
     }
 }

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallFragment.kt
@@ -48,13 +48,14 @@ internal class PaywallFragment : Fragment(), PaywallResultHandler {
                     putString(OptionKey.REQUEST_KEY.key, requestKey)
                     putString(OptionKey.REQUIRED_ENTITLEMENT_IDENTIFIER.key, requiredEntitlementIdentifier)
                     shouldDisplayDismissButton?.let { putBoolean(OptionKey.SHOULD_DISPLAY_DISMISS_BUTTON.key, it) }
+                    @Suppress("DEPRECATION")
                     when (paywallSource) {
                         is PaywallSource.Offering -> {
                             putString(
                                 OptionKey.OFFERING_IDENTIFIER.key,
                                 paywallSource.value.identifier,
                             )
-                            paywallSource.value.availablePackages.firstOrNull()?.presentedOfferingContext?.let {
+                            paywallSource.presentedOfferingContext?.let {
                                 putParcelable(
                                     OptionKey.PRESENTED_OFFERING_CONTEXT.key,
                                     it,
@@ -92,7 +93,15 @@ internal class PaywallFragment : Fragment(), PaywallResultHandler {
         get() = arguments?.getString(OptionKey.REQUIRED_ENTITLEMENT_IDENTIFIER.key)
 
     private val presentedOfferingContextArg: PresentedOfferingContext?
-        get() = arguments?.getParcelable(OptionKey.PRESENTED_OFFERING_CONTEXT.key)
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arguments?.getParcelable(
+                OptionKey.PRESENTED_OFFERING_CONTEXT.key,
+                PresentedOfferingContext::class.java,
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            arguments?.getParcelable(OptionKey.PRESENTED_OFFERING_CONTEXT.key)
+        }
 
     private val shouldDisplayDismissButtonArg: Boolean?
         get() {

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallSource.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallSource.kt
@@ -1,9 +1,16 @@
 package com.revenuecat.purchases.hybridcommon.ui
 
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.Offering as PurchasesOffering
 
 sealed class PaywallSource {
     class Offering(val value: PurchasesOffering) : PaywallSource()
     object DefaultOffering : PaywallSource()
+
+    @Deprecated("Use OfferingIdentifierWithPresentedOfferingContext instead")
     class OfferingIdentifier(val value: String) : PaywallSource()
+    class OfferingIdentifierWithPresentedOfferingContext(
+        val offeringIdentifier: String,
+        val presentedOfferingContext: PresentedOfferingContext,
+    ) : PaywallSource()
 }

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallSource.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallSource.kt
@@ -10,7 +10,10 @@ sealed class PaywallSource {
     }
     object DefaultOffering : PaywallSource()
 
-    @Deprecated("Use OfferingIdentifierWithPresentedOfferingContext instead")
+    @Deprecated(
+        "Use OfferingIdentifierWithPresentedOfferingContext instead",
+        ReplaceWith("OfferingIdentifierWithPresentedOfferingContext(value, PresentedOfferingContext(value))"),
+    )
     class OfferingIdentifier(val value: String) : PaywallSource()
     class OfferingIdentifierWithPresentedOfferingContext(
         val offeringIdentifier: String,

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallSource.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallSource.kt
@@ -4,7 +4,10 @@ import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.Offering as PurchasesOffering
 
 sealed class PaywallSource {
-    class Offering(val value: PurchasesOffering) : PaywallSource()
+    class Offering(val value: PurchasesOffering) : PaywallSource() {
+        internal val presentedOfferingContext: PresentedOfferingContext?
+            get() = value.availablePackages.firstOrNull()?.presentedOfferingContext
+    }
     object DefaultOffering : PaywallSource()
 
     @Deprecated("Use OfferingIdentifierWithPresentedOfferingContext instead")


### PR DESCRIPTION
This is the android counterpart of #1246 

This adds a way to pass the `PresentedOfferingContext` from the hybrids to the native SDK when presenting a paywall so we don't lose this information.