### PR TITLE
Use `preferredUILocaleOverride` name in `PurchasesConfiguration`

### DIFF
--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -331,7 +331,7 @@ export interface PurchasesConfiguration {
     automaticDeviceIdentifierCollectionEnabled?: boolean;
     diagnosticsEnabled?: boolean;
     entitlementVerificationMode?: ENTITLEMENT_VERIFICATION_MODE;
-    overridePreferredLocale?: string;
+    preferredUILocaleOverride?: string;
     pendingTransactionsForPrepaidPlansEnabled?: boolean;
     purchasesAreCompletedBy?: PurchasesAreCompletedBy;
     shouldShowInAppMessagesAutomatically?: boolean;

--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -331,8 +331,8 @@ export interface PurchasesConfiguration {
     automaticDeviceIdentifierCollectionEnabled?: boolean;
     diagnosticsEnabled?: boolean;
     entitlementVerificationMode?: ENTITLEMENT_VERIFICATION_MODE;
-    preferredUILocaleOverride?: string;
     pendingTransactionsForPrepaidPlansEnabled?: boolean;
+    preferredUILocaleOverride?: string;
     purchasesAreCompletedBy?: PurchasesAreCompletedBy;
     shouldShowInAppMessagesAutomatically?: boolean;
     storeKitVersion?: STOREKIT_VERSION;

--- a/typescript/src/purchasesConfiguration.ts
+++ b/typescript/src/purchasesConfiguration.ts
@@ -93,6 +93,7 @@ export interface PurchasesConfiguration {
 
   /**
    * Override the preferred UI locale for RevenueCat UI components at runtime. This affects both API requests and UI rendering.
+   * This will automatically clear the offerings cache and trigger a background refetch to get paywall templates with the correct localizations.
    *
    * @param localeString - The locale string (e.g., "es-ES", "en-US") or null to use system default
    */

--- a/typescript/src/purchasesConfiguration.ts
+++ b/typescript/src/purchasesConfiguration.ts
@@ -93,9 +93,8 @@ export interface PurchasesConfiguration {
 
   /**
    * Override the preferred UI locale for RevenueCat UI components at runtime. This affects both API requests and UI rendering.
-   * If the locale changes, this will automatically clear the offerings cache and trigger a background refetch to get paywall templates with the correct localizations.
    *
    * @param localeString - The locale string (e.g., "es-ES", "en-US") or null to use system default
    */
-  overridePreferredLocale?: string;
+  preferredUILocaleOverride?: string;
 }


### PR DESCRIPTION
This PR renames the property `overridePreferredLocale` of `PurchasesConfiguration` to `preferredUILocaleOverride` to make it the same as in the iOS and Android SDKs