### PR TITLE
Add `PurchaseParams` interface

### DIFF
--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -236,6 +236,15 @@ export enum PURCHASE_TYPE {
 }
 
 // @public
+export interface PurchaseParams {
+    discount?: PurchasesPromotionalOffer | null;
+    googleIsPersonalizedPrice?: boolean | null;
+    googleProductChangeInfo?: GoogleProductChangeInfo | null;
+    itemToPurchase: PurchasesPackage | PurchasesStoreProduct | SubscriptionOption;
+    winBackOffer?: PurchasesWinBackOffer | null;
+}
+
+// @public
 export enum PURCHASES_ARE_COMPLETED_BY_TYPE {
     MY_APP = "MY_APP",
     REVENUECAT = "REVENUECAT"

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -2,6 +2,7 @@ export * from './errors';
 export * from './customerInfo';
 export * from './offerings';
 export * from './enums';
+export * from './purchaseParams';
 export * from './purchasesConfiguration';
 export * from './callbackTypes';
 export * from './webRedemption';

--- a/typescript/src/purchaseParams.ts
+++ b/typescript/src/purchaseParams.ts
@@ -1,0 +1,38 @@
+import {
+  GoogleProductChangeInfo,
+  PurchasesPackage, PurchasesPromotionalOffer,
+  PurchasesStoreProduct,
+  PurchasesWinBackOffer,
+  SubscriptionOption
+} from "./offerings";
+
+/**
+ * Holds parameters to initialize a purchase in our SDK.
+ * @public
+ */
+export interface PurchaseParams {
+  /**
+   * The {@link PurchasesPackage}, {@link PurchasesStoreProduct} or {@link SubscriptionOption} to purchase.
+   */
+  itemToPurchase: PurchasesPackage | PurchasesStoreProduct | SubscriptionOption;
+  /**
+   * Google Play only. Optional {@link GoogleProductChangeInfo} you
+   * wish to upgrade from containing the oldProductIdentifier and the optional prorationMode.
+   */
+  googleProductChangeInfo?: GoogleProductChangeInfo | null;
+  /**
+   * Google Play only. Optional boolean indicates personalized pricing on products available for purchase in the EU.
+   * For compliance with EU regulations. User will see "This price has been customized for you" in the purchase dialog when true.
+   * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
+   */
+  googleIsPersonalizedPrice?: boolean | null;
+  /**
+   * iOS only, requires iOS 18.0 or greater with StoreKit 2. Win-back offer to apply to this purchase.
+   * Retrieve this using getEligibleWinBackOffersForPackage.
+   */
+  winBackOffer?: PurchasesWinBackOffer | null;
+  /**
+   * iOS only. Discount to apply to this purchase. Retrieve this discount using getPromotionalOffer.
+   */
+  discount?: PurchasesPromotionalOffer | null;
+}


### PR DESCRIPTION
This adds an interface with all mandatory and optional parameters to initiate a purchase. Adding it here so it can be shared between RN and Capacitor.