### PR TITLE
Trigger hybrid updates after PHC UI finishes deploying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -526,6 +526,8 @@ workflows:
             - deploy-typescript
             - deploy-typescript-esm
             - deploy-js-mappings
+            - deploy-ios-phc
+            - deploy-ios-phcui
       - trigger-dependent-updates:
           <<: *stable-release-tags
           requires:


### PR DESCRIPTION
We modified this [a while back](https://github.com/RevenueCat/purchases-hybrid-common/pull/1030) because deploying to cocoapods was actually very flaky and was causing delays... However, we've since improve that flakyness and seems to be relatively reliable. This also is better since tests in hybrids usually fail until PHC cocoapods deployment finishes anyway, so bringing this back