### PR TITLE
Deprecate onManagementOptionSelectedWrapper overflow

### DIFF
--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/CustomerCenterListenerWrapper.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/CustomerCenterListenerWrapper.kt
@@ -35,6 +35,11 @@ abstract class CustomerCenterListenerWrapper : CustomerCenterListener {
         if (action is CustomerCenterManagementOption.CustomUrl) {
             this.onManagementOptionSelectedWrapper(action.optionName, action.uri.toString())
         } else if (action is CustomerCenterManagementOption.CustomAction) {
+            this.onCustomerCenterCustomActionSelectedWrapper(
+                actionId = action.actionIdentifier,
+                purchaseIdentifier = action.purchaseIdentifier,
+            )
+            @Suppress("DEPRECATION")
             this.onManagementOptionSelectedWrapper(
                 action.optionName,
                 action.actionIdentifier,
@@ -51,7 +56,9 @@ abstract class CustomerCenterListenerWrapper : CustomerCenterListener {
     abstract fun onRestoreStartedWrapper()
     abstract fun onShowingManageSubscriptionsWrapper()
     abstract fun onManagementOptionSelectedWrapper(action: String, url: String?)
+    @Deprecated("Use onCustomerCenterCustomActionSelectedWrapper instead.")
     abstract fun onManagementOptionSelectedWrapper(action: String, customAction: String?, purchaseIdentifier: String?)
+    abstract fun onCustomerCenterCustomActionSelectedWrapper(actionId: String, purchaseIdentifier: String?)
 }
 
 private val CustomerCenterManagementOption.optionName: String

--- a/android/hybridcommon-ui/src/test/java/com/revenuecat/purchases/hybridcommon/ui/CustomerCenterListenerWrapperTest.kt
+++ b/android/hybridcommon-ui/src/test/java/com/revenuecat/purchases/hybridcommon/ui/CustomerCenterListenerWrapperTest.kt
@@ -1,0 +1,65 @@
+package com.revenuecat.purchases.hybridcommon.ui
+
+import com.revenuecat.purchases.customercenter.CustomerCenterManagementOption
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomerCenterListenerWrapperTest {
+
+    @Test
+    fun `onManagementOptionSelected triggers custom action callback`() {
+        val listener = TestCustomerCenterListenerWrapper()
+
+        val action = CustomerCenterManagementOption.CustomAction(
+            actionIdentifier = "custom_action_id",
+            purchaseIdentifier = "product_id",
+        )
+
+        listener.onManagementOptionSelected(action)
+
+        assertTrue(listener.customActionInvoked)
+        assertEquals("custom_action_id", listener.lastActionId)
+        assertEquals("product_id", listener.lastPurchaseIdentifier)
+
+        // Ensure the deprecated method remains invoked for backwards compatibility until removal.
+        assertTrue(listener.deprecatedCustomActionInvoked)
+    }
+
+    private class TestCustomerCenterListenerWrapper : CustomerCenterListenerWrapper() {
+        var customActionInvoked: Boolean = false
+        var deprecatedCustomActionInvoked: Boolean = false
+        var lastActionId: String? = null
+        var lastPurchaseIdentifier: String? = null
+
+        override fun onFeedbackSurveyCompletedWrapper(feedbackSurveyOptionId: String) = Unit
+
+        override fun onRestoreCompletedWrapper(customerInfo: Map<String, Any?>) = Unit
+
+        override fun onRestoreFailedWrapper(error: Map<String, Any?>) = Unit
+
+        override fun onRestoreStartedWrapper() = Unit
+
+        override fun onShowingManageSubscriptionsWrapper() = Unit
+
+        override fun onManagementOptionSelectedWrapper(action: String, url: String?) = Unit
+
+        @Deprecated("Use onCustomerCenterCustomActionSelectedWrapper instead.")
+        override fun onManagementOptionSelectedWrapper(
+            action: String,
+            customAction: String?,
+            purchaseIdentifier: String?,
+        ) {
+            deprecatedCustomActionInvoked = true
+        }
+
+        override fun onCustomerCenterCustomActionSelectedWrapper(
+            actionId: String,
+            purchaseIdentifier: String?,
+        ) {
+            customActionInvoked = true
+            lastActionId = actionId
+            lastPurchaseIdentifier = purchaseIdentifier
+        }
+    }
+}


### PR DESCRIPTION

- Deprecates `onManagementOptionSelectedWrapper(action: String, customAction: String?, purchaseIdentifier: String?)` and introduces the new `onCustomerCenterCustomActionSelectedWrapper(actionId: String, purchaseIdentifier: String?)` callback in `CustomerCenterListenerWrapper.` based on https://github.com/RevenueCat/react-native-purchases/pull/1442/files/85864aaecf887d8e06e4dae34afb1aa0659d6ec4#r2411031435