### PR TITLE
Fix missing onCloseHandler in CustomerCenterProxy

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/CustomerCenter/CustomerCenterProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/CustomerCenter/CustomerCenterProxy.swift
@@ -141,6 +141,9 @@ private extension CustomerCenterProxy {
         let vc = CustomerCenterUIViewController()
         vc.delegate = self
         vc.shouldShowCloseButton = shouldShowCloseButton
+        vc.onCloseHandler = { [weak vc] in
+            vc?.dismiss(animated: true)
+        }
 
         return vc
     }


### PR DESCRIPTION
## Summary

- `CustomerCenterProxy.createCustomerCenterViewController()` never set `onCloseHandler` on the `CustomerCenterUIViewController` it created
- When `onCloseHandler` is `nil`, `CustomerCenterView` falls back to SwiftUI's `@Environment(\.dismiss)` action
- On iOS 15, calling `dismiss()` at the root of a `NavigationView` is a **no-op** (there's even a comment in `DismissCircleButton` calling this out explicitly)
- This meant the X close button had **no effect** when the Customer Center was presented via `presentCustomerCenter()` on iOS 15

The fix sets `onCloseHandler` to call `vc.dismiss(animated: true)`, which:
1. Properly dismisses via UIKit on all iOS versions
2. Triggers `viewDidDisappear` with `isBeingDismissed = true`
3. Calls `customerCenterViewControllerWasDismissed` on the delegate → resolves the RN/Flutter/etc. Promise

Note: the embedded `CustomerCenterViewManager` already set `onCloseHandler` correctly — this only affected the modal proxy path.

## Test plan

- [ ] Present Customer Center via `presentCustomerCenter()` on iOS 15 device/simulator
- [ ] Navigate to "Display Purchase History"
- [ ] Tap the X close button — should dismiss the entire Customer Center
- [ ] Confirm the Promise resolves and `onDismiss` fires

Fixes [CC-647](https://linear.app/revenuecat/issue/CC-647)

🤖 Generated with [Claude Code](https://claude.com/claude-code)