### PR TITLE
Replace unauthenticated SDKMAN install with SHA-pinned orb command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 
 orbs:
   android: circleci/android@2.4.0
-  revenuecat: revenuecat/sdks-common-config@3.16.0
+  revenuecat: revenuecat/sdks-common-config@3.20.0
   macos: circleci/macos@2.0.1
   node: circleci/node@5.1.0
 
@@ -49,17 +49,9 @@ parameters:
 
 commands:
   install-sdkman:
-    description: Install SDKMAN
+    description: Install SDKMAN and set up Java environment
     steps:
-      - run:
-          name: Installing SDKMAN
-          command: |
-            if curl -s "https://get.sdkman.io?rcupdate=false" | bash; then
-              echo -e '\nsource "/home/circleci/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
-              source $BASH_ENV
-            else
-              echo "Error installing SDKMAN, continuing with default Java" >&2
-            fi
+      - revenuecat/install-sdkman
       - run:
           name: Setup Java environment
           command: |


### PR DESCRIPTION
Bumps `revenuecat/sdks-common-config` to `3.20.0` and replaces the local `install-sdkman` command (which used unauthenticated `curl https://get.sdkman.io | bash`) with the new `revenuecat/install-sdkman` orb command, which pins SDKMAN to a SHA256-verified GitHub release.

Mirrors the pattern from [sdks-circleci-orb#55](https://github.com/RevenueCat/sdks-circleci-orb/pull/55).

The prior soft-fail wrapper around the SDKMAN install ("continuing with default Java") is dropped — the orb command intentionally fails hard on a SHA-256 mismatch, which is the security guarantee. The downstream `sdk env install` Java setup is preserved as its own run-step at each invocation site, with its existing soft-fail kept intact.