### PR TITLE
PRORATION_MODE docstring fix

### DIFF
--- a/typescript/src/offerings.ts
+++ b/typescript/src/offerings.ts
@@ -534,7 +534,7 @@ export enum PRORATION_MODE {
 
   /**
    * Replacement takes effect immediately, and the remaining time will be
-   * prorated and credited to the user. This is the current default behavior.
+   * prorated and credited to the user.
    */
   IMMEDIATE_WITH_TIME_PRORATION = 1,
 
@@ -548,6 +548,8 @@ export enum PRORATION_MODE {
   /**
    * Replacement takes effect immediately, and the new price will be charged on
    * next recurrence time. The billing cycle stays the same.
+   *
+   * This is the current default behavior.
    */
   IMMEDIATE_WITHOUT_PRORATION = 3,
 


### PR DESCRIPTION
`PRORATION_MODE`'s docs mention that `IMMEDIATE_WITH_TIME_PRORATION` is the default proration mode, but the default is actually `IMMEDIATE_WITHOUT_PRORATION`.

This PR updates the docs to correct this.