### PR TITLE
make integration tests compile

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/BaseIntegrationTests.swift
@@ -8,7 +8,7 @@
 
 import PurchasesHybridCommon
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import SnapshotTesting
 import StoreKitTest
 import XCTest


### PR DESCRIPTION
Fixes compilation of the iOS integration tests, which was broken by the changes in https://github.com/RevenueCat/purchases-ios/pull/6690