### PR TITLE
Revert inline dynamic imports for esm bundle

### DIFF
--- a/purchases-js-hybrid-mappings/api-report/api.json
+++ b/purchases-js-hybrid-mappings/api-report/api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.53.0",
+    "toolVersion": "7.58.7",
     "schemaVersion": 1011,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
@@ -113,6 +113,22 @@
         {
           "tagName": "@virtual",
           "syntaxKind": "modifier"
+        },
+        {
+          "tagName": "@jsx",
+          "syntaxKind": "block"
+        },
+        {
+          "tagName": "@jsxRuntime",
+          "syntaxKind": "block"
+        },
+        {
+          "tagName": "@jsxFrag",
+          "syntaxKind": "block"
+        },
+        {
+          "tagName": "@jsxImportSource",
+          "syntaxKind": "block"
         },
         {
           "tagName": "@betaDocumentation",

--- a/purchases-js-hybrid-mappings/package.json
+++ b/purchases-js-hybrid-mappings/package.json
@@ -30,7 +30,7 @@
     "allchecks": "npm run format && npm run lint:fix && npm run api-test && npm run test"
   },
   "dependencies": {
-    "@revenuecat/purchases-js": "1.38.0"
+    "@revenuecat/purchases-js": "file:../../purchases-js"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.42.3",

--- a/purchases-js-hybrid-mappings/package.json
+++ b/purchases-js-hybrid-mappings/package.json
@@ -30,7 +30,7 @@
     "allchecks": "npm run format && npm run lint:fix && npm run api-test && npm run test"
   },
   "dependencies": {
-    "@revenuecat/purchases-js": "file:../../purchases-js"
+    "@revenuecat/purchases-js": "1.38.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.42.3",

--- a/purchases-js-hybrid-mappings/rollup.config.js
+++ b/purchases-js-hybrid-mappings/rollup.config.js
@@ -11,13 +11,11 @@ export default defineConfig([
       {
         file: 'dist/index.js',
         format: 'esm',
-        inlineDynamicImports: true,
         sourcemap: true
       },
       {
         file: 'dist/index.umd.js',
         format: 'umd',
-        inlineDynamicImports: true,
         name: 'PurchasesHybridMappings',
         sourcemap: true
       }

--- a/purchases-js-hybrid-mappings/rollup.config.js
+++ b/purchases-js-hybrid-mappings/rollup.config.js
@@ -4,33 +4,40 @@ import { defineConfig } from 'rollup';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 
+const jsPlugins = () => [
+  nodeResolve(),
+  typescript({
+    tsconfig: './tsconfig.json',
+    declaration: false,
+    declarationMap: false,
+    sourceMap: true,
+    inlineSources: true
+  }),
+  terser()
+];
+
 export default defineConfig([
   {
     input: 'src/index.ts',
-    output: [
-      {
-        file: 'dist/index.js',
-        format: 'esm',
-        sourcemap: true
-      },
-      {
-        file: 'dist/index.umd.js',
-        format: 'umd',
-        name: 'PurchasesHybridMappings',
-        sourcemap: true
-      }
-    ],
-    plugins: [
-      nodeResolve(),
-      typescript({
-        tsconfig: './tsconfig.json',
-        declaration: false,
-        declarationMap: false,
-        sourceMap: true,
-        inlineSources: true
-      }),
-      terser()
-    ]
+    output: {
+      dir: 'dist',
+      format: 'esm',
+      entryFileNames: 'index.js',
+      chunkFileNames: 'chunks/[name]-[hash].js',
+      sourcemap: true
+    },
+    plugins: jsPlugins()
+  },
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/index.umd.js',
+      format: 'umd',
+      name: 'PurchasesHybridMappings',
+      inlineDynamicImports: true,
+      sourcemap: true
+    },
+    plugins: jsPlugins()
   },
   {
     input: 'src/index.ts',


### PR DESCRIPTION
We originally added a setting to inline dynamic imports since it wasn't an issue to do so and we needed it to make it work with some formats like umd used in purchases-flutter, but we want to avoid loading stripe until it's actually needed. purchases-js changes already do so, but in hybrids, this does not happen because of this setting.

For now, we're reverting this option for the esm bundle export, which is what's used by react-native-purchases, but keeping the umd export as is to avoid issues in purchases-flutter