### PR TITLE
Deprecate PRORATION_MODE and GoogleProductChangeInfo

### DIFF
--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -52,7 +52,7 @@ export interface ErrorInfo {
     readableErrorCode: string;
 }
 
-// @public
+// @public @deprecated
 export interface GoogleProductChangeInfo {
     readonly oldProductIdentifier: string;
     readonly prorationMode?: PRORATION_MODE;
@@ -218,7 +218,7 @@ export enum PRODUCT_TYPE {
     UNKNOWN = "UNKNOWN"
 }
 
-// @public
+// @public @deprecated
 export enum PRORATION_MODE {
     DEFERRED = 6,
     IMMEDIATE_AND_CHARGE_FULL_PRICE = 5,

--- a/typescript/src/offerings.ts
+++ b/typescript/src/offerings.ts
@@ -479,6 +479,7 @@ export interface UpgradeInfo {
 
 /**
  * Holds the information used when upgrading from another sku. For Android use only.
+ * @deprecated Use StoreProductChangeInfo
  * @public
  */
 export interface GoogleProductChangeInfo {
@@ -542,6 +543,7 @@ export interface PurchasesWinBackOffer extends PurchasesStoreProductDiscount {}
 
 /**
  * Enum with possible proration modes in a subscription upgrade or downgrade in the Play Store. Used only for Google.
+ * @deprecated Use STORE_REPLACEMENT_MODE
  * @public
  */
 export enum PRORATION_MODE {


### PR DESCRIPTION
Deprecates the Typescript `PRORATION_MODE` and `GoogleProductChangeInfo` types in favor of `STORE_REPLACEMENT_MODE` and `StoreProductChangeInfo`. New APIs using those new types are almost ready to go in both the React Native and Capacitor SDKs. This will not be merged and released until those PRs are approved.