### PR TITLE
Fix web purchase cancellation error mapping

### DIFF
--- a/purchases-js-hybrid-mappings/src/mappers/purchases_error_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/purchases_error_mapper.ts
@@ -1,10 +1,14 @@
-import { PurchasesError } from '@revenuecat/purchases-js';
+import { ErrorCode, PurchasesError } from '@revenuecat/purchases-js';
 
 export function mapPurchasesError(error: PurchasesError): Record<string, unknown> {
+  const userCancelled = error.errorCode === ErrorCode.UserCancelledError;
+  const message = error.message || (userCancelled ? 'Purchase was cancelled.' : 'Unknown error.');
+
   return {
-    code: error.errorCode,
-    message: error.message,
+    code: userCancelled ? String(error.errorCode) : error.errorCode,
+    message,
     underlyingErrorMessage: error.underlyingErrorMessage,
+    userCancelled,
     info: {
       statusCode: error.extra?.statusCode,
       backendErrorCode: error.extra?.backendErrorCode,

--- a/purchases-js-hybrid-mappings/src/mappers/purchases_error_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/purchases_error_mapper.ts
@@ -5,9 +5,9 @@ export function mapPurchasesError(error: PurchasesError): Record<string, unknown
   const message = error.message || (userCancelled ? 'Purchase was cancelled.' : 'Unknown error.');
 
   return {
-    code: userCancelled ? String(error.errorCode) : error.errorCode,
+    code: String(error.errorCode),
     message,
-    underlyingErrorMessage: error.underlyingErrorMessage,
+    underlyingErrorMessage: error.underlyingErrorMessage ?? '',
     userCancelled,
     info: {
       statusCode: error.extra?.statusCode,

--- a/purchases-js-hybrid-mappings/tests/mappers/purchases_error_mapper.test.ts
+++ b/purchases-js-hybrid-mappings/tests/mappers/purchases_error_mapper.test.ts
@@ -20,9 +20,27 @@ describe('mapPurchasesError', () => {
       code: error.errorCode,
       message: error.message,
       underlyingErrorMessage: error.underlyingErrorMessage,
+      userCancelled: false,
       info: {
         statusCode: error.extra?.statusCode,
         backendErrorCode: error.extra?.backendErrorCode
+      }
+    });
+  });
+
+  it('maps cancelled errors to hybrid-compatible shape', () => {
+    const error = new PurchasesError(ErrorCode.UserCancelledError);
+
+    const result = mapPurchasesError(error);
+
+    expect(result).toEqual({
+      code: "1",
+      message: "Purchase was cancelled.",
+      underlyingErrorMessage: undefined,
+      userCancelled: true,
+      info: {
+        statusCode: undefined,
+        backendErrorCode: undefined
       }
     });
   });

--- a/purchases-js-hybrid-mappings/tests/mappers/purchases_error_mapper.test.ts
+++ b/purchases-js-hybrid-mappings/tests/mappers/purchases_error_mapper.test.ts
@@ -17,7 +17,7 @@ describe('mapPurchasesError', () => {
     const result = mapPurchasesError(error);
 
     expect(result).toEqual({
-      code: error.errorCode,
+      code: String(error.errorCode),
       message: error.message,
       underlyingErrorMessage: error.underlyingErrorMessage,
       userCancelled: false,
@@ -36,7 +36,7 @@ describe('mapPurchasesError', () => {
     expect(result).toEqual({
       code: "1",
       message: "Purchase was cancelled.",
-      underlyingErrorMessage: undefined,
+      underlyingErrorMessage: "",
       userCancelled: true,
       info: {
         statusCode: undefined,

--- a/purchases-js-hybrid-mappings/tests/purchases-common.test.ts
+++ b/purchases-js-hybrid-mappings/tests/purchases-common.test.ts
@@ -531,7 +531,7 @@ describe('PurchasesCommon', () => {
       };
 
       await expect(purchasesCommon.purchasePackage(purchaseParams)).rejects.toMatchObject({
-        code: ErrorCode.UserCancelledError,
+        code: String(ErrorCode.UserCancelledError),
         message: 'Purchase cancelled',
         info: {
           backendErrorCode: undefined,

--- a/purchases-js-hybrid-mappings/tests/purchases-common.test.ts
+++ b/purchases-js-hybrid-mappings/tests/purchases-common.test.ts
@@ -349,13 +349,13 @@ describe('PurchasesCommon', () => {
       };
 
       await expect(purchasesCommon.purchasePackage(purchaseParams)).rejects.toMatchObject({
-        code: ErrorCode.PurchaseInvalidError,
+        code: String(ErrorCode.PurchaseInvalidError),
         message: 'Need to provide a valid offering identifier',
         info: {
           backendErrorCode: undefined,
           statusCode: undefined,
         },
-        underlyingErrorMessage: undefined,
+        underlyingErrorMessage: '',
       });
     });
 
@@ -372,14 +372,14 @@ describe('PurchasesCommon', () => {
       };
 
       await expect(purchasesCommon.purchasePackage(purchaseParams)).rejects.toMatchObject({
-        code: ErrorCode.PurchaseInvalidError,
+        code: String(ErrorCode.PurchaseInvalidError),
         message:
           'Could not find offering with identifier: non_existent_offering. Found offering ids: ',
         info: {
           backendErrorCode: undefined,
           statusCode: undefined,
         },
-        underlyingErrorMessage: undefined,
+        underlyingErrorMessage: '',
       });
     });
 
@@ -396,14 +396,14 @@ describe('PurchasesCommon', () => {
       };
 
       await expect(purchasesCommon.purchasePackage(purchaseParams)).rejects.toMatchObject({
-        code: ErrorCode.PurchaseInvalidError,
+        code: String(ErrorCode.PurchaseInvalidError),
         message:
           'Could not find package with id: non_existent_package in offering with id: test_offering',
         info: {
           backendErrorCode: undefined,
           statusCode: undefined,
         },
-        underlyingErrorMessage: undefined,
+        underlyingErrorMessage: '',
       });
     });
 
@@ -420,14 +420,14 @@ describe('PurchasesCommon', () => {
       };
 
       await expect(purchasesCommon.purchasePackage(purchaseParams)).rejects.toMatchObject({
-        code: ErrorCode.PurchaseInvalidError,
+        code: String(ErrorCode.PurchaseInvalidError),
         message:
           'Could not find option with id: non_existent_option in package with id: test_package',
         info: {
           backendErrorCode: undefined,
           statusCode: undefined,
         },
-        underlyingErrorMessage: undefined,
+        underlyingErrorMessage: '',
       });
     });
 
@@ -537,7 +537,7 @@ describe('PurchasesCommon', () => {
           backendErrorCode: undefined,
           statusCode: undefined,
         },
-        underlyingErrorMessage: undefined,
+        underlyingErrorMessage: '',
       });
     });
   });
@@ -572,13 +572,13 @@ describe('PurchasesCommon', () => {
       mockPurchasesInstance.getVirtualCurrencies.mockRejectedValue(mockError);
 
       await expect(purchasesCommon.getVirtualCurrencies()).rejects.toMatchObject({
-        code: ErrorCode.NetworkError,
+        code: String(ErrorCode.NetworkError),
         message: 'Network error',
         info: {
           backendErrorCode: undefined,
           statusCode: undefined,
         },
-        underlyingErrorMessage: undefined,
+        underlyingErrorMessage: '',
       });
     });
   });


### PR DESCRIPTION
- stringify mapped error codes so they match the hybrid SDK contract
- set userCancelled for web UserCancelledError cases
- provide a fallback cancellation message when the web error message is empty
- add a regression test for cancelled web errors

Part of react-native-purchases#1756. Tracked in SDK-4450.

### Checklist

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.

<details><summary>Agent description</summary>

### Motivation

Both enums are generated from `purchases-error-codes`, but `purchases-js` emits numbers and `purchases-hybrid-common/typescript` emits strings. That is deliberate on the hybrid side: `RCTPromiseRejectBlock` types the code as `NSString` and `CAPPluginCall.reject` as `String?`, so nothing numeric can cross a native bridge. `purchases-js` has no bridge, and this mapper passed its number straight through. Every other consumer of the mapper converts at its own boundary (Flutter does `code: '$code'`); React Native browser mode has no boundary, so the number reached app code.

### Description

- `code: String(error.errorCode)` for every code, not only cancellation. Reviewers on the original round asked for this so `NetworkError` and the rest stop diverging too.
- `userCancelled` derived from `ErrorCode.UserCancelledError` in the mapper, which gives RN's `.catch` blocks a value to agree with instead of re-deriving from a mistyped code.
- `underlyingErrorMessage ?? ''`, matching the native mappers. `PurchasesError` declares it as `string`.
- Fallback `message` for cancellations and for the unknown case, since `purchases-js` rejects cancellations with an empty message.

**Not visible in the diff:** the Flutter check was a standalone Dart probe reproducing `_convertJsRecordToMap` and the relevant half of `_processError` verbatim, run with `dart test -p chrome` and again with `--compiler dart2wasm`. Before this change `code` dartified to `int` on `dart2js` and `double` on `dart2wasm`; after it is a `String` on both. `getErrorCode` had been masking the wasm case because `num.parse("1.0").round()` is still `1`.

**Regression gate:** `maps cancelled errors to hybrid-compatible shape` in `purchases_error_mapper.test.ts`, which asserts the exact object the mapper returns for a bare `UserCancelledError`.

**Limitations:**

- `readableErrorCode` is still not emitted for web, so web errors get `""` where native gets a code name. This mapper has the `ErrorCode` in hand and is the right place for it.
- Flutter's `finalMessage` is `'$message. $underlyingErrorMessage'`, so with the new fallback a cancellation renders as `Purchase was cancelled.. ` (double period). Previously it rendered as `. null`. Dropping the trailing period from the fallback would fix it.
- react-native-purchases#1759 wrapped RN's comparisons in `String(...)` as a defence against the numeric code. With this change no numeric code can reach that layer, and its regression test asserts `code` stays numeric, which #1838's normalizer contradicts. It should be closed rather than rebased.

**Rejected:**

- Stringifying only the cancellation path, the original shape of this PR. Leaves every other web code inconsistent with the declared type.
- Fixing it in `react-native-purchases` alone (#1759). Treats the symptom one layer up and leaves Flutter's `dart2wasm` case in place.

</details>
