### PR TITLE
Remove KMP from trigger-dependent-updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,10 +369,6 @@ jobs:
           name: Kick off Capacitor automatic dependency update
           command: bundle exec fastlane bump_hybrid_dependencies repo_name:purchases-capacitor
           when: always
-      - run:
-          name: Kick off KMP automatic dependency update
-          command: bundle exec fastlane bump_hybrid_dependencies repo_name:purchases-kmp
-          when: always
 
   typescript-lint:
     executor: node/default


### PR DESCRIPTION
## Summary

`purchases-kmp` no longer depends on `purchases-hybrid-common` as of its [v3.0.0 release](https://github.com/RevenueCat/purchases-kmp/releases/tag/3.0.0), so we no longer need to kick off automatic dependency update PRs for it from this repo.

This removes the `Kick off KMP automatic dependency update` step from the `trigger-dependent-updates` job in `.circleci/config.yml`.

## Test plan

- [ ] CI passes

Made with [Cursor](https://cursor.com)