### PR TITLE
docs(offerings): clarify when PurchasesStoreProduct.description can be empty

### DIFF
--- a/typescript/src/offerings.ts
+++ b/typescript/src/offerings.ts
@@ -82,7 +82,21 @@ export interface PurchasesStoreProduct {
    */
   readonly identifier: string;
   /**
-   * Description of the product.
+   * Description of the product, sourced from the underlying store.
+   *
+   * Platform behavior:
+   * - **iOS:** sourced from StoreKit's product description
+   *   (`SKProduct.localizedDescription` for StoreKit 1, `Product.description`
+   *   for StoreKit 2 on iOS 15+). Both reflect the App Store Connect
+   *   description field.
+   * - **Android:** sourced from Google Play Billing's
+   *   `ProductDetails.getDescription()`. Returns an empty string when no
+   *   description is set in the Play Console.
+   * - **Web (RevenueCat Test Store):** may be empty even for live products.
+   *
+   * Treat this as effectively optional even though the type is `string`:
+   * in some store configurations it can be empty even for live products.
+   * See https://github.com/RevenueCat/react-native-purchases/issues/1753.
    */
   readonly description: string;
   /**


### PR DESCRIPTION
## Why

`PurchasesStoreProduct.description` is documented as `* Description of the product.` with no further detail. Users who see an empty string have no way to know whether that's expected, an SDK bug, or misconfiguration on their end.

This came up in https://github.com/RevenueCat/react-native-purchases/issues/1753, where the reporter saw an empty string on web (RC Test Store) and on Android Play products without a description configured.

## What this changes

Expands the JSDoc on `PurchasesStoreProduct.description` to:

1. Name the underlying source per platform (verified against `purchases-ios` and `purchases-android` source).
2. Call out the cases where an empty string is expected (Web Test Store, Android products with no Play Console description).
3. Tell consumers to treat the field as effectively optional even though the type is `string`.

## Verification of platform claims

- **iOS (StoreKit 1):** `SK1StoreProduct.swift` exposes `localizedDescription` from `SKProduct.localizedDescription`.
- **iOS (StoreKit 2):** `SK2StoreProduct.swift` exposes `localizedDescription` from `Product.description`. Both reflect the App Store Connect description field.
- **Android:** `storeProductConversions.kt` (`ProductDetails.toStoreProduct(...)`) populates `description` from `ProductDetails.description` (Java `getDescription()`). Returns `\"\"` when no description is set in Play Console.
- **Web:** confirmed in #1753 that the RC Test Store can return empty.

## What this does NOT change

No code or behavior changes. Pure JSDoc improvement on a single field.