### PR TITLE
Fix paid introductory price not mapped for Web Billing

### DIFF
--- a/purchases-js-hybrid-mappings/src/mappers/offerings_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/offerings_mapper.ts
@@ -87,8 +87,9 @@ function mapProduct(product: Product): Record<string, unknown> {
 
 function mapIntroPrice(product: Product): Record<string, unknown> | null {
   const option = product.defaultSubscriptionOption;
-  // Prefer the paid introductory phase; fall back to the free trial.
-  const introPhase = option?.introPrice ?? option?.trial;
+  // Give priority to the free trial, falling back to the paid introductory
+  // phase. This matches the precedence used by the native Android mapper.
+  const introPhase = option?.trial ?? option?.introPrice;
   if (!introPhase) {
     return null;
   }

--- a/purchases-js-hybrid-mappings/src/mappers/offerings_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/offerings_mapper.ts
@@ -60,7 +60,7 @@ function mapProduct(product: Product): Record<string, unknown> {
     price: product.currentPrice.amountMicros / 1_000_000,
     priceString: product.currentPrice.formattedPrice,
     currencyCode: product.currentPrice.currency,
-    introPrice: mapIntroPrice(product), // Not supported in web yet
+    introPrice: mapIntroPrice(product),
     discounts: null,
     pricePerWeek: defaultOptionBasePricingPhase?.pricePerWeek?.amountMicros ?? null,
     pricePerMonth: defaultOptionBasePricingPhase?.pricePerMonth?.amountMicros ?? null,
@@ -86,17 +86,19 @@ function mapProduct(product: Product): Record<string, unknown> {
 }
 
 function mapIntroPrice(product: Product): Record<string, unknown> | null {
-  const trialPhase = product.defaultSubscriptionOption?.trial;
-  if (!trialPhase) {
+  const option = product.defaultSubscriptionOption;
+  // Prefer the paid introductory phase; fall back to the free trial.
+  const introPhase = option?.introPrice ?? option?.trial;
+  if (!introPhase) {
     return null;
   }
 
   return {
-    price: 0,
-    priceString: trialPhase.price?.formattedPrice ?? '0.00', // TODO: Improve how we get a formatted price for trials
-    period: trialPhase.periodDuration,
-    cycles: trialPhase.cycleCount,
-    ...mapPeriodForStoreProduct(trialPhase.period),
+    price: (introPhase.price?.amountMicros ?? 0) / 1_000_000,
+    priceString: introPhase.price?.formattedPrice ?? '0.00',
+    period: introPhase.periodDuration,
+    cycles: introPhase.cycleCount,
+    ...mapPeriodForStoreProduct(introPhase.period),
   };
 }
 
@@ -112,10 +114,17 @@ function mapSubscriptionOption(
   if (option.trial) {
     trialPhase = mapPricingPhase(option.trial);
   }
+  let introPhase: Record<string, unknown> | null = null;
+  if (option.introPrice) {
+    introPhase = mapPricingPhase(option.introPrice);
+  }
   const basePhase = mapPricingPhase(option.base);
   const pricingPhases = [];
   if (trialPhase) {
     pricingPhases.push(trialPhase);
+  }
+  if (introPhase) {
+    pricingPhases.push(introPhase);
   }
   pricingPhases.push(basePhase);
   return {
@@ -124,12 +133,12 @@ function mapSubscriptionOption(
     productId: product.identifier,
     pricingPhases: pricingPhases,
     tags: [],
-    isBasePlan: option.trial === null,
+    isBasePlan: option.trial === null && option.introPrice === null,
     billingPeriod: period,
     isPrepaid: false,
     fullPricePhase: basePhase,
     freePhase: trialPhase,
-    introPhase: null,
+    introPhase: introPhase,
     presentedOfferingIdentifier: product.presentedOfferingContext.offeringIdentifier,
     presentedOfferingContext: mapPresentedOfferingContext(product.presentedOfferingContext),
     installmentsInfo: null,

--- a/purchases-js-hybrid-mappings/tests/mappers/offerings_mapper.test.ts
+++ b/purchases-js-hybrid-mappings/tests/mappers/offerings_mapper.test.ts
@@ -687,6 +687,165 @@ describe('mapOfferings', () => {
     expect(mappedOption.pricingPhases).toEqual([introPhase, basePhase]);
   });
 
+  it('prioritizes the free trial over a paid intro for product.introPrice when both exist', () => {
+    const basePrice: Price = {
+      amount: 2000,
+      amountMicros: 20000000,
+      currency: 'USD',
+      formattedPrice: '$20.00',
+    };
+
+    const introPrice: Price = {
+      amount: 1000,
+      amountMicros: 10000000,
+      currency: 'USD',
+      formattedPrice: '$10.00',
+    };
+
+    const trialPrice: Price = {
+      amount: 0,
+      amountMicros: 0,
+      currency: 'USD',
+      formattedPrice: 'Free',
+    };
+
+    const yearlyPeriod: Period = { unit: PeriodUnit.Year, number: 1 };
+    const weeklyTrialPeriod: Period = { unit: PeriodUnit.Day, number: 7 };
+
+    const basePricingPhase: PricingPhase = {
+      price: basePrice,
+      period: yearlyPeriod,
+      periodDuration: 'P1Y',
+      cycleCount: 0,
+      pricePerMonth: null,
+      pricePerYear: basePrice,
+      pricePerWeek: null,
+    };
+
+    const introPricingPhase: PricingPhase = {
+      price: introPrice,
+      period: yearlyPeriod,
+      periodDuration: 'P1Y',
+      cycleCount: 1,
+      pricePerMonth: null,
+      pricePerYear: introPrice,
+      pricePerWeek: null,
+    };
+
+    const trialPricingPhase: PricingPhase = {
+      price: trialPrice,
+      period: weeklyTrialPeriod,
+      periodDuration: 'P7D',
+      cycleCount: 1,
+      pricePerMonth: trialPrice,
+      pricePerYear: trialPrice,
+      pricePerWeek: trialPrice,
+    };
+
+    const optionId = 'option_with_trial_and_intro';
+    const presentedOfferingContext: PresentedOfferingContext = {
+      offeringIdentifier: 'intro_offering',
+      placementIdentifier: null,
+      targetingContext: null,
+    };
+
+    const option = {
+      id: optionId,
+      priceId: 'price_with_trial_and_intro',
+      base: basePricingPhase,
+      trial: trialPricingPhase,
+      introPrice: introPricingPhase,
+    } as SubscriptionOption;
+
+    const product: Product = {
+      identifier: 'product_with_trial_and_intro',
+      title: 'Annually',
+      displayName: 'Annually',
+      description: 'Annually',
+      productType: ProductType.Subscription,
+      currentPrice: basePrice,
+      normalPeriodDuration: 'P1Y',
+      subscriptionOptions: { [optionId]: option },
+      defaultSubscriptionOption: option,
+      defaultNonSubscriptionOption: null,
+      defaultPurchaseOption: option,
+      presentedOfferingIdentifier: 'intro_offering',
+      presentedOfferingContext: presentedOfferingContext,
+    };
+
+    const pkg: Package = {
+      identifier: 'annual_pkg',
+      packageType: PackageType.Annual,
+      webBillingProduct: product,
+      rcBillingProduct: product,
+    };
+
+    const offering: Offering = {
+      identifier: 'intro_offering',
+      serverDescription: 'Intro offering description',
+      metadata: {},
+      availablePackages: [pkg],
+      lifetime: null,
+      annual: pkg,
+      sixMonth: null,
+      threeMonth: null,
+      twoMonth: null,
+      monthly: null,
+      weekly: null,
+      packagesById: {},
+      paywall_components: null,
+    };
+
+    const offerings: Offerings = {
+      all: { 'intro_offering': offering },
+      current: offering,
+    };
+
+    const result = mapOfferings(offerings);
+
+    const mappedProduct = (
+      (result.current as Record<string, unknown>).annual as Record<string, unknown>
+    ).product as Record<string, unknown>;
+
+    // product.introPrice reflects the free trial, matching the native Android precedence.
+    expect(mappedProduct.introPrice).toEqual({
+      price: 0,
+      priceString: 'Free',
+      period: 'P7D',
+      cycles: 1,
+      periodUnit: 'DAY',
+      periodNumberOfUnits: 7,
+    });
+
+    // The subscription option still exposes both phases separately.
+    const mappedOption = (mappedProduct.defaultOption as Record<string, unknown>);
+    const freePhase = {
+      billingCycleCount: 1,
+      billingPeriod: { iso8601: 'P7D', unit: 'DAY', value: 7 },
+      offerPaymentMode: 'FREE_TRIAL',
+      price: { amountMicros: 0, currencyCode: 'USD', formatted: 'Free' },
+      recurrenceMode: 3,
+    };
+    const introPhase = {
+      billingCycleCount: 1,
+      billingPeriod: { iso8601: 'P1Y', unit: 'YEAR', value: 1 },
+      offerPaymentMode: null,
+      price: { amountMicros: 10000000, currencyCode: 'USD', formatted: '$10.00' },
+      recurrenceMode: 3,
+    };
+    const basePhase = {
+      billingCycleCount: 0,
+      billingPeriod: { iso8601: 'P1Y', unit: 'YEAR', value: 1 },
+      offerPaymentMode: null,
+      price: { amountMicros: 20000000, currencyCode: 'USD', formatted: '$20.00' },
+      recurrenceMode: 1,
+    };
+
+    expect(mappedOption.freePhase).toEqual(freePhase);
+    expect(mappedOption.introPhase).toEqual(introPhase);
+    expect(mappedOption.pricingPhases).toEqual([freePhase, introPhase, basePhase]);
+  });
+
   function createPackage(identifier: string, offeringId: string, packageType: PackageType): Package {
     const presentedOfferingContext: PresentedOfferingContext = {
       offeringIdentifier: offeringId,

--- a/purchases-js-hybrid-mappings/tests/mappers/offerings_mapper.test.ts
+++ b/purchases-js-hybrid-mappings/tests/mappers/offerings_mapper.test.ts
@@ -554,6 +554,139 @@ describe('mapOfferings', () => {
     });
   });
 
+  it('maps a paid introductory price with no free trial correctly', () => {
+    const basePrice: Price = {
+      amount: 2000,
+      amountMicros: 20000000,
+      currency: 'USD',
+      formattedPrice: '$20.00',
+    };
+
+    const introPrice: Price = {
+      amount: 1000,
+      amountMicros: 10000000,
+      currency: 'USD',
+      formattedPrice: '$10.00',
+    };
+
+    const yearlyPeriod: Period = { unit: PeriodUnit.Year, number: 1 };
+
+    const basePricingPhase: PricingPhase = {
+      price: basePrice,
+      period: yearlyPeriod,
+      periodDuration: 'P1Y',
+      cycleCount: 0,
+      pricePerMonth: null,
+      pricePerYear: basePrice,
+      pricePerWeek: null,
+    };
+
+    const introPricingPhase: PricingPhase = {
+      price: introPrice,
+      period: yearlyPeriod,
+      periodDuration: 'P1Y',
+      cycleCount: 1,
+      pricePerMonth: null,
+      pricePerYear: introPrice,
+      pricePerWeek: null,
+    };
+
+    const optionId = 'offerc65d4f2ee1564261a912a746ea43ba21';
+    const presentedOfferingContext: PresentedOfferingContext = {
+      offeringIdentifier: 'intro_offering',
+      placementIdentifier: null,
+      targetingContext: null,
+    };
+
+    const option = {
+      id: optionId,
+      priceId: 'prcd147abef16984a7791f2',
+      base: basePricingPhase,
+      trial: null,
+      introPrice: introPricingPhase,
+    } as SubscriptionOption;
+
+    const product: Product = {
+      identifier: 'bookwise.mindlab.ai.intro_price_not_show',
+      title: 'Annually',
+      displayName: 'Annually',
+      description: 'Annually',
+      productType: ProductType.Subscription,
+      currentPrice: basePrice,
+      normalPeriodDuration: 'P1Y',
+      subscriptionOptions: { [optionId]: option },
+      defaultSubscriptionOption: option,
+      defaultNonSubscriptionOption: null,
+      defaultPurchaseOption: option,
+      presentedOfferingIdentifier: 'intro_offering',
+      presentedOfferingContext: presentedOfferingContext,
+    };
+
+    const pkg: Package = {
+      identifier: 'annual_pkg',
+      packageType: PackageType.Annual,
+      webBillingProduct: product,
+      rcBillingProduct: product,
+    };
+
+    const offering: Offering = {
+      identifier: 'intro_offering',
+      serverDescription: 'Intro offering description',
+      metadata: {},
+      availablePackages: [pkg],
+      lifetime: null,
+      annual: pkg,
+      sixMonth: null,
+      threeMonth: null,
+      twoMonth: null,
+      monthly: null,
+      weekly: null,
+      packagesById: {},
+      paywall_components: null,
+    };
+
+    const offerings: Offerings = {
+      all: { 'intro_offering': offering },
+      current: offering,
+    };
+
+    const result = mapOfferings(offerings);
+
+    const mappedProduct = (
+      (result.current as Record<string, unknown>).annual as Record<string, unknown>
+    ).product as Record<string, unknown>;
+
+    expect(mappedProduct.introPrice).toEqual({
+      price: 10,
+      priceString: '$10.00',
+      period: 'P1Y',
+      cycles: 1,
+      periodUnit: 'YEAR',
+      periodNumberOfUnits: 1,
+    });
+
+    const mappedOption = (mappedProduct.defaultOption as Record<string, unknown>);
+    const introPhase = {
+      billingCycleCount: 1,
+      billingPeriod: { iso8601: 'P1Y', unit: 'YEAR', value: 1 },
+      offerPaymentMode: null,
+      price: { amountMicros: 10000000, currencyCode: 'USD', formatted: '$10.00' },
+      recurrenceMode: 3,
+    };
+    const basePhase = {
+      billingCycleCount: 0,
+      billingPeriod: { iso8601: 'P1Y', unit: 'YEAR', value: 1 },
+      offerPaymentMode: null,
+      price: { amountMicros: 20000000, currencyCode: 'USD', formatted: '$20.00' },
+      recurrenceMode: 1,
+    };
+
+    expect(mappedOption.introPhase).toEqual(introPhase);
+    expect(mappedOption.freePhase).toBeNull();
+    expect(mappedOption.isBasePlan).toBe(false);
+    expect(mappedOption.pricingPhases).toEqual([introPhase, basePhase]);
+  });
+
   function createPackage(identifier: string, offeringId: string, packageType: PackageType): Package {
     const presentedOfferingContext: PresentedOfferingContext = {
       offeringIdentifier: offeringId,


### PR DESCRIPTION
### Motivation

Web Billing products with a **paid** introductory price (e.g. $10 the first year, then $20/year) were reported by hybrid SDKs with `introPrice: null`. The API returns the intro price correctly, but the `purchases-js` hybrid offerings mapper dropped it.

### Summary

- `mapIntroPrice` only considered the free `trial` phase and hardcoded `price: 0`; it now falls back from `trial` to `introPrice` and uses the real amount.
- The subscription option's `introPhase` was hardcoded to `null` and the paid intro phase was missing from `pricingPhases`; both are now populated from `option.introPrice`.
- Precedence (`trial` before `introPrice`) matches the native Android mapper, so the two stay consistent.
- Added unit tests for a paid intro with no trial, and for the trial+intro case.

### Notes

Free-trial mapping is unchanged.