### PR TITLE
Add presentedOfferingContext parameter support to custom paywall impression events

### DIFF
--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -1303,10 +1303,18 @@ fun trackAdFailedToLoad(adData: Map<String, Any?>) {
 
 // region Custom Paywall Tracking
 
+@OptIn(InternalRevenueCatAPI::class)
 fun trackCustomPaywallImpression(data: Map<String, Any?>) {
     val paywallId = data["paywallId"] as? String
     val offeringId = data["offeringId"] as? String
-    val params = CustomPaywallImpressionParams(paywallId = paywallId, offeringId = offeringId)
+    val presentedOfferingContext = castWildcardMapToStringToOptionalAnyMap(
+        data["presentedOfferingContext"] as? Map<*, *>,
+    )?.toPresentedOfferingContext()
+    val params = CustomPaywallImpressionParams(
+        paywallId = paywallId,
+        offeringId = offeringId,
+        presentedOfferingContext = presentedOfferingContext,
+    )
     Purchases.sharedInstance.trackCustomPaywallImpression(params)
 }
 

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/FeatureEventMapper.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/FeatureEventMapper.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.events.FeatureEvent
 import com.revenuecat.purchases.customercenter.events.CustomerCenterImpressionEvent
 import com.revenuecat.purchases.customercenter.events.CustomerCenterSurveyOptionChosenEvent
+import com.revenuecat.purchases.paywalls.events.CustomPaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 
 @OptIn(InternalRevenueCatAPI::class)
@@ -44,6 +45,17 @@ fun FeatureEvent.toMap(): Map<String, Any?> {
             "url" to data.url,
             "revision_id" to data.revisionID,
         )
+        is CustomPaywallEvent.Impression -> buildMap {
+            put("discriminator", "custom_paywall_event")
+            put("type", "custom_paywall_impression")
+            put("id", creationData.id.toString())
+            put("timestamp", creationData.date.time)
+            data.paywallId?.let { put("paywall_id", it) }
+            data.offeringId?.let { put("offering_id", it) }
+            data.placementIdentifier?.let { put("placement_identifier", it) }
+            data.targetingRevision?.let { put("targeting_revision", it) }
+            data.targetingRuleId?.let { put("targeting_rule_id", it) }
+        }
         else -> mapOf(
             "discriminator" to "unknown",
             "type" to "unknown",

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -863,7 +863,14 @@ import StoreKit
     @objc static func trackCustomPaywallImpression(_ data: [String: Any]) {
         let paywallId = data["paywallId"] as? String
         let offeringId = data["offeringId"] as? String
-        let params = CustomPaywallImpressionParams(paywallId: paywallId, offeringId: offeringId)
+        let presentedOfferingContext = Self.toPresentedOfferingContext(
+            presentedOfferingContext: data["presentedOfferingContext"] as? [String: Any]
+        )
+        let params = CustomPaywallImpressionParams(
+            paywallId: paywallId,
+            offeringId: offeringId,
+            presentedOfferingContext: presentedOfferingContext
+        )
         Purchases.shared.trackCustomPaywallImpression(params)
     }
 


### PR DESCRIPTION
Builds on native PRs https://github.com/RevenueCat/purchases-ios/pull/6707 and https://github.com/RevenueCat/purchases-android/pull/3424

Adds the `presentedOfferingContext` (optional) parameter support to the custom paywall impression event API. When present the value will be read from the passed map as `[string: any]` and parses it using existing helpers like in other places.