### PR TITLE
[android] Skip Galaxy module during bc7 publishing

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -16,8 +16,12 @@ dependencyResolutionManagement {
 rootProject.name = "purchases-hybrid-common"
 include(":api-tests")
 include(":hybridcommon")
-include(":hybridcommon-store-galaxy")
 include(":hybridcommon-ui")
+
+// Galaxy only publishes bc8. Avoid configuring it when publishing legacy bc7 artifacts.
+if (settings.extra.properties["ANDROID_VARIANT_TO_PUBLISH"] != "bc7Release") {
+    include(":hybridcommon-store-galaxy")
+}
 
 // Run enableLocalBuild task to enable building purchases-android from your local copy
 if (file(".composite-enable").exists()) {


### PR DESCRIPTION
The Galaxy module does not support the bc7 flavor. Deploying to maven failed because it did expect the bc7 flavor to be there. This should ensure module is only added when not explicitly using the bc7 flavor.