### PR TITLE
[android] Add Android deploy dry-run CI check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,10 @@ jobs:
       name: android/android-machine
       resource-class: large
       tag: default
+    parameters:
+      dry_run:
+        type: boolean
+        default: false
     steps:
       - checkout
       - install-sdkman
@@ -275,7 +279,7 @@ jobs:
       - android/restore-build-cache
       - run:
           name: Deployment
-          command: bundle exec fastlane android deploy
+          command: bundle exec fastlane android deploy dry_run:<< parameters.dry_run >>
 
   deploy-typescript:
     docker:
@@ -472,6 +476,9 @@ workflows:
       - check-pods
       - integration-test-ios
       - test-android
+      - deploy-android:
+          name: android-deploy-dry-run
+          dry_run: true
       - detekt-android
       - typescript-lint
       - typescript-apitests

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -444,7 +444,9 @@ platform :android do
   desc "Upload and close a release"
   lane :deploy do |options|
     version = current_version_number
-    gradleProperties = {
+    dry_run = options[:dry_run] || false
+    dry_run_flag = dry_run ? " --dry-run" : ""
+    gradleProperties = dry_run ? {} : {
       "signing.keyId" => ENV['GPG_SIGNING_KEY_ID'],
       "signing.password" => ENV['GPG_SIGNING_KEY_PW'],
       "signing.secretKeyRingFile" => "#{File.expand_path('android', get_root_folder)}/secring.gpg",
@@ -452,11 +454,11 @@ platform :android do
       "mavenCentralPassword" => ENV['MAVEN_CENTRAL_PORTAL_PASSWORD'],
       "RELEASE_SIGNING_ENABLED" => true
     }
-    UI.verbose("Deploying #{version}")
+    UI.verbose("#{dry_run ? "Dry-run deploying" : "Deploying"} #{version}")
 
     gradle(
       tasks: [
-        "publish --no-daemon --no-parallel"
+        "publish --no-daemon --no-parallel#{dry_run_flag}"
       ],
       properties: gradleProperties,
       project_dir: 'android'
@@ -468,7 +470,7 @@ platform :android do
     # Publish hybridcommon with -bc7 suffix
     gradle(
       tasks: [
-        ":hybridcommon:publish --no-daemon --no-parallel"
+        ":hybridcommon:publish --no-daemon --no-parallel#{dry_run_flag}"
       ],
       properties: gradleProperties.merge({"POM_ARTIFACT_ID" => "purchases-hybrid-common-bc7"}),
       project_dir: 'android'
@@ -477,7 +479,7 @@ platform :android do
     # Publish hybridcommon-ui with -bc7 suffix
     gradle(
       tasks: [
-        ":hybridcommon-ui:publish --no-daemon --no-parallel"
+        ":hybridcommon-ui:publish --no-daemon --no-parallel#{dry_run_flag}"
       ],
       properties: gradleProperties.merge({"POM_ARTIFACT_ID" => "purchases-hybrid-common-ui-bc7"}),
       project_dir: 'android'


### PR DESCRIPTION
Deploying to Maven [recently](https://github.com/RevenueCat/purchases-hybrid-common/pull/1679) failed, which was only discovered during release, breaking PHC deploys. This PR adds a `dry-run` option and corresponding CI job that runs on every PR and should catch these issues early.