### PR TITLE
Allow custom paywall impressions without event data

### DIFF
--- a/android/api-tests/src/test/java/com/revenuecat/apitests/java/CommonApiTests.java
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/java/CommonApiTests.java
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.hybridcommon.OnResultAny;
 import com.revenuecat.purchases.hybridcommon.OnResultList;
 import com.revenuecat.purchases.models.InAppMessageType;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -427,6 +428,15 @@ class CommonApiTests {
 
     private void checkOverridePreferredLocale(String locale) {
         CommonKt.overridePreferredLocale(locale);
+    }
+
+    private void checkTrackCustomPaywallImpression(Map<String, Object> data) {
+        CommonKt.trackCustomPaywallImpression(null);
+        CommonKt.trackCustomPaywallImpression(data);
+
+        Map<String, Object> dataWithPaywallId = new HashMap<>();
+        dataWithPaywallId.put("paywallId", "my-paywall");
+        CommonKt.trackCustomPaywallImpression(dataWithPaywallId);
     }
 
     private void checkSetAppstackAttributionParams(Map<String, Object> data, OnResult onResult) {

--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
@@ -42,6 +42,7 @@ import com.revenuecat.purchases.hybridcommon.setProxyURLString
 import com.revenuecat.purchases.hybridcommon.setPurchasesAreCompletedBy
 import com.revenuecat.purchases.hybridcommon.showInAppMessagesIfNeeded
 import com.revenuecat.purchases.hybridcommon.syncPurchases
+import com.revenuecat.purchases.hybridcommon.trackCustomPaywallImpression
 import com.revenuecat.purchases.models.InAppMessageType
 
 @Suppress("unused", "DEPRECATION", "LongParameterList", "UNUSED_VARIABLE")
@@ -502,6 +503,12 @@ private class CommonApiTests {
 
     private fun checkOverridePreferredLocale(locale: String?) {
         overridePreferredLocale(locale)
+    }
+
+    private fun checkTrackCustomPaywallImpression(data: Map<String, Any?>) {
+        trackCustomPaywallImpression(null)
+        trackCustomPaywallImpression(data)
+        trackCustomPaywallImpression(mapOf("paywallId" to "my-paywall"))
     }
 
     private fun checkSetAppstackAttributionParams(data: Map<String, Any>, onResult: OnResult) {

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -1328,11 +1328,12 @@ fun trackAdFailedToLoad(adData: Map<String, Any?>) {
 // region Custom Paywall Tracking
 
 @OptIn(InternalRevenueCatAPI::class)
-fun trackCustomPaywallImpression(data: Map<String, Any?>) {
-    val paywallId = data["paywallId"] as? String
-    val offeringId = data["offeringId"] as? String
+fun trackCustomPaywallImpression(data: Map<String, Any?>?) {
+    val eventData = data.orEmpty()
+    val paywallId = eventData["paywallId"] as? String
+    val offeringId = eventData["offeringId"] as? String
     val presentedOfferingContext = castWildcardMapToStringToOptionalAnyMap(
-        data["presentedOfferingContext"] as? Map<*, *>,
+        eventData["presentedOfferingContext"] as? Map<*, *>,
     )?.toPresentedOfferingContext()
     val params = CustomPaywallImpressionParams(
         paywallId = paywallId,

--- a/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
+++ b/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/CommonKtTests.kt
@@ -40,6 +40,7 @@ import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreReplacementMode
 import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.SubscriptionOptions
+import com.revenuecat.purchases.paywalls.events.CustomPaywallImpressionParams
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrency
 import io.mockk.Runs
@@ -2233,6 +2234,75 @@ internal class CommonKtTests {
         }
 
         assertThat(actualCachedVirtualCurrenciesMap).isNull()
+    }
+
+    @Test
+    @OptIn(InternalRevenueCatAPI::class)
+    fun `trackCustomPaywallImpression with null data passes empty params to native`() {
+        val capturedParams = slot<CustomPaywallImpressionParams>()
+        every { mockPurchases.trackCustomPaywallImpression(capture(capturedParams)) } just Runs
+
+        trackCustomPaywallImpression(null)
+
+        assertThat(capturedParams.captured.paywallId).isNull()
+        assertThat(capturedParams.captured.offeringId).isNull()
+        assertThat(capturedParams.captured.presentedOfferingContext).isNull()
+        verify(exactly = 1) {
+            mockPurchases.trackCustomPaywallImpression(any<CustomPaywallImpressionParams>())
+        }
+    }
+
+    @Test
+    @OptIn(InternalRevenueCatAPI::class)
+    fun `trackCustomPaywallImpression with paywallId only passes no offering params to native`() {
+        val capturedParams = slot<CustomPaywallImpressionParams>()
+        every { mockPurchases.trackCustomPaywallImpression(capture(capturedParams)) } just Runs
+
+        trackCustomPaywallImpression(
+            mapOf(
+                "paywallId" to "my_paywall",
+            ),
+        )
+
+        assertThat(capturedParams.captured.paywallId).isEqualTo("my_paywall")
+        assertThat(capturedParams.captured.offeringId).isNull()
+        assertThat(capturedParams.captured.presentedOfferingContext).isNull()
+        verify(exactly = 1) {
+            mockPurchases.trackCustomPaywallImpression(any<CustomPaywallImpressionParams>())
+        }
+    }
+
+    @Test
+    @OptIn(InternalRevenueCatAPI::class)
+    fun `trackCustomPaywallImpression with data passes params to native`() {
+        val capturedParams = slot<CustomPaywallImpressionParams>()
+        every { mockPurchases.trackCustomPaywallImpression(capture(capturedParams)) } just Runs
+
+        trackCustomPaywallImpression(
+            mapOf(
+                "paywallId" to "my_paywall",
+                "offeringId" to "my_offering",
+                "presentedOfferingContext" to mapOf(
+                    "offeringIdentifier" to "my_offering",
+                    "placementIdentifier" to "onboarding",
+                    "targetingContext" to mapOf(
+                        "revision" to 7,
+                        "ruleId" to "rule_7",
+                    ),
+                ),
+            ),
+        )
+
+        assertThat(capturedParams.captured.paywallId).isEqualTo("my_paywall")
+        assertThat(capturedParams.captured.offeringId).isEqualTo("my_offering")
+        val presentedOfferingContext = capturedParams.captured.presentedOfferingContext
+        assertThat(presentedOfferingContext?.offeringIdentifier).isEqualTo("my_offering")
+        assertThat(presentedOfferingContext?.placementIdentifier).isEqualTo("onboarding")
+        assertThat(presentedOfferingContext?.targetingContext?.revision).isEqualTo(7)
+        assertThat(presentedOfferingContext?.targetingContext?.ruleId).isEqualTo("rule_7")
+        verify(exactly = 1) {
+            mockPurchases.trackCustomPaywallImpression(any<CustomPaywallImpressionParams>())
+        }
     }
 
     @OptIn(InternalRevenueCatAPI::class)

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -243,6 +243,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Test Custom Paywall Tracking
     if (@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)) {
+        [RCCommonFunctionality trackCustomPaywallImpression:nil];
         [RCCommonFunctionality trackCustomPaywallImpression:@{@"paywallId": @"my-paywall"}];
     }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -863,7 +863,8 @@ import StoreKit
 @objc public extension CommonFunctionality {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-    @objc static func trackCustomPaywallImpression(_ data: [String: Any]) {
+    @objc static func trackCustomPaywallImpression(_ data: [String: Any]?) {
+        let data = data ?? [:]
         let paywallId = data["paywallId"] as? String
         let offeringId = data["offeringId"] as? String
         let presentedOfferingContext = Self.toPresentedOfferingContext(


### PR DESCRIPTION
Previously the PHC APIs did not support `nil` values for the params, which required the hybrids to send an empty object instead, which in turn caused the native side to treat it as valid data and not use the fallback (aka using the current offering).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow API signature change on analytics bridging with added tests; behavior fix for hybrid callers that omit event data.
> 
> **Overview**
> **`trackCustomPaywallImpression`** on Purchases Hybrid Common (Android Kotlin and iOS `CommonFunctionality`) now accepts **optional / nil event data** instead of requiring a map.
> 
> When hybrids pass **no data** (`null` / `nil`), the bridge normalizes to an empty payload and forwards **`CustomPaywallImpressionParams` with null `paywallId`, `offeringId`, and `presentedOfferingContext`**, so the native SDK can apply its **current-offering fallback** instead of treating a forced `{}` as explicit (empty) event fields.
> 
> API compile tests (Java/Kotlin/ObjC) and Android unit tests cover null, partial (`paywallId` only), and full maps including `presentedOfferingContext`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71ef12fb3509269576833267703a235e88e24769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->