### PR TITLE
feat: Add `setAppsFlyerConversionData` attribute method

### DIFF
--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/SubscriberAttributesApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/SubscriberAttributesApiTests.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.hybridcommon.setAdGroup
 import com.revenuecat.purchases.hybridcommon.setAdjustID
 import com.revenuecat.purchases.hybridcommon.setAirbridgeDeviceID
 import com.revenuecat.purchases.hybridcommon.setAirshipChannelID
+import com.revenuecat.purchases.hybridcommon.setAppsFlyerConversionData
 import com.revenuecat.purchases.hybridcommon.setAppsflyerID
 import com.revenuecat.purchases.hybridcommon.setAttributes
 import com.revenuecat.purchases.hybridcommon.setCampaign
@@ -103,6 +104,11 @@ private class SubscriberAttributesApiTests {
 
     fun checkSetCreative(creative: String?) {
         setCreative(creative)
+    }
+
+    fun checkSetAppsFlyerConversionData(data: Map<*, *>?) {
+        setAppsFlyerConversionData(data)
+        setAppsFlyerConversionData(null)
     }
 
     // endregion

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/subscriberAttributes.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/subscriberAttributes.kt
@@ -91,6 +91,10 @@ fun setCreative(creative: String?) {
     Purchases.sharedInstance.setCreative(creative)
 }
 
+fun setAppsFlyerConversionData(data: Map<*, *>?) {
+    Purchases.sharedInstance.setAppsFlyerConversionData(data)
+}
+
 // endregion
 // region subscriber attributes
 

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -214,6 +214,8 @@ NS_ASSUME_NONNULL_BEGIN
     [RCCommonFunctionality setKeyword:nil];
     [RCCommonFunctionality setCreative:@""];
     [RCCommonFunctionality setCreative:nil];
+    [RCCommonFunctionality setAppsFlyerConversionData:@{@"media_source": @"", @"campaign": @""}];
+    [RCCommonFunctionality setAppsFlyerConversionData:nil];
 }
 
 - (void)testAdTrackingAPIs {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -713,6 +713,9 @@ import StoreKit
     @objc static func setCreative(_ creative: String?) {
         Self.sharedInstance.attribution.setCreative(creative)
     }
+    @objc static func setAppsFlyerConversionData(_ data: [AnyHashable: Any]?) {
+        Self.sharedInstance.attribution.setAppsFlyerConversionData(data)
+    }
 
 }
 


### PR DESCRIPTION
Adds a wrapper for `setAppsFlyerConversionData` so integration with appsflyer can become a simple one liner.