### PR TITLE
Pass purchases-js-hybrid-mappings sha256 to purchases-flutter bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,6 +316,15 @@ jobs:
       - run:
           name: Deploy js-mappings NPM package
           command: bundle exec fastlane web deploy_js_mappings
+      - run:
+          name: Compute js-mappings bundle sha256
+          command: |
+            sha256sum purchases-js-hybrid-mappings/dist/index.umd.js | awk '{ print $1 }' > js_mappings_sha.txt
+            echo "purchases-js-hybrid-mappings sha256: $(cat js_mappings_sha.txt)"
+      - persist_to_workspace:
+          root: .
+          paths:
+            - js_mappings_sha.txt
 
   make-github-release:
     docker:
@@ -349,13 +358,17 @@ jobs:
       - image: cimg/ruby:3.3.0
     steps:
       - checkout
+      - attach_workspace:
+          at: .
       - setup-git-credentials
       - revenuecat/trust-github-key
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - run:
           name: Kick off Flutter automatic dependency update
-          command: bundle exec fastlane bump_hybrid_dependencies repo_name:purchases-flutter
+          command: |
+            export JS_MAPPINGS_SHA="$(cat js_mappings_sha.txt 2>/dev/null || true)"
+            bundle exec fastlane bump_hybrid_dependencies repo_name:purchases-flutter
           when: always
       - run:
           name: Kick off React Native automatic dependency update

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -378,17 +378,29 @@ lane :bump_hybrid_dependencies do |options|
   require 'uri'
   require 'json'
 
+  parameters = {
+    "action" => "upgrade-hybrid-common",
+    "version" => "#{version_number_for_bump}",
+    "automatic" => true
+  }
+
+  # purchases-flutter vendors the purchases-js-hybrid-mappings web bundle, so it
+  # verifies the copy it downloads against the sha256 of the artifact we just
+  # built and published (computed in the deploy-js-mappings job and read from the
+  # workspace). Only forward it to repos that declare the pipeline parameter; an
+  # undeclared parameter makes the CircleCI trigger fail.
+  js_mappings_sha = ENV['JS_MAPPINGS_SHA'].to_s.strip
+  if repo_name == 'purchases-flutter' && !js_mappings_sha.empty?
+    parameters["js_mappings_sha"] = js_mappings_sha
+  end
+
   uri = URI.parse("https://circleci.com/api/v2/project/github/RevenueCat/#{repo_name}/pipeline")
   request = Net::HTTP::Post.new(uri)
   request.basic_auth(ENV['CIRCLECI_TOKEN'], "")
   request.content_type = "application/json"
   request.body = JSON.dump({
     "branch" => "main",
-    "parameters" => {
-      "action" => "upgrade-hybrid-common",
-      "version" => "#{version_number_for_bump}",
-      "automatic" => true
-    }
+    "parameters" => parameters
   })
 
   req_options = {


### PR DESCRIPTION
### Motivation

purchases-flutter now vendors the `purchases-js-hybrid-mappings` UMD bundle (RevenueCat/purchases-flutter#1785). To guard against tampering between our release and the downstream bump, Flutter should verify the bundle it downloads against a hash we control.

### Summary

- Compute the sha256 of the just-built bundle in `deploy-js-mappings` and persist it to the workspace.
- Forward it as a `js_mappings_sha` pipeline parameter when triggering the purchases-flutter bump.
- Only sent to `purchases-flutter` (the sole repo declaring the parameter); other hybrids are unaffected.

### Notes

- Consumer side: RevenueCat/purchases-flutter#1786.
- Merge order: the Flutter parameter declaration must reach `main` first, otherwise the trigger fails with a 400 on the undeclared parameter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and cross-repo pipeline triggers; a missing workspace file or Flutter parameter mismatch could break the Flutter bump until consumer config lands on main.
> 
> **Overview**
> Release CI now **fingerprints the published `purchases-js-hybrid-mappings` UMD bundle** and passes that hash into the automatic **purchases-flutter** dependency bump so Flutter can verify the vendored web artifact matches what this repo just built.
> 
> After `deploy-js-mappings`, a new step hashes `purchases-js-hybrid-mappings/dist/index.umd.js`, writes `js_mappings_sha.txt`, and **persists it to the CircleCI workspace**. `trigger-dependent-updates` **attaches that workspace** and, for the Flutter kickoff only, sets `JS_MAPPINGS_SHA` from that file before calling `bump_hybrid_dependencies`.
> 
> `bump_hybrid_dependencies` builds pipeline parameters in a variable and **adds `js_mappings_sha` only when** the target repo is `purchases-flutter` and the env value is non-empty—other hybrid bumps are unchanged, avoiding CircleCI 400s from undeclared parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd498ba04035ba4290fc73890ec723af952f9497. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->