### PR TITLE
chore: Add 3-day Dependabot cooldown, excluding fastlane plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
+      exclude:
+        - "fastlane-plugin-revenuecat_internal"


### PR DESCRIPTION
Adds a 3-day cooldown to Dependabot so we don't pick up dependency versions that were released less than 3 days ago. Our own `fastlane-plugin-revenuecat_internal` is excluded from the cooldown so it continues to update immediately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Dependabot scheduling; no runtime or application code is affected.
> 
> **Overview**
> **Dependabot** bundler updates now wait **3 days** after a new release before opening PRs, reducing churn from very fresh dependency versions.
> 
> **`fastlane-plugin-revenuecat_internal`** is listed under **`cooldown.exclude`** so that internal plugin bumps still run on the existing daily schedule without the delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7932383c35d682cb5e6d3805ba40823670585b33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->