### PR TITLE
Update sdks-common-config orb to 3.21.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 
 orbs:
   android: circleci/android@2.4.0
-  revenuecat: revenuecat/sdks-common-config@3.20.0
+  revenuecat: revenuecat/sdks-common-config@3.21.2
   macos: circleci/macos@2.0.1
   node: circleci/node@5.1.0
 


### PR DESCRIPTION
### Motivation
Pull in [sdks-circleci-orb#69](https://github.com/RevenueCat/sdks-circleci-orb/pull/69), which fixes the `merge-release-pr` job failing after a successful merge.

### Description
Bump the CircleCI orb to `3.21.2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only orb version bump with no application code changes; low risk aside from relying on upstream orb behavior for release automation.
> 
> **Overview**
> Updates the **`revenuecat/sdks-common-config`** CircleCI orb from **3.20.0** to **3.21.2** in `.circleci/config.yml`.
> 
> This picks up the orb fix for **`merge-release-pr`** incorrectly failing after a release PR merge succeeds (sdks-circleci-orb#69), which matters for the stable-release deploy workflow that runs that job after dependent SDK bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ac7e80473cbe6c6a61c13f67004cc423cd41ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->