### PR TITLE
Bump sdks-common-config orb to 4.1.0 and migrate output to outputs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 
 orbs:
   android: circleci/android@2.4.0
-  revenuecat: revenuecat/sdks-common-config@3.21.1
+  revenuecat: revenuecat/sdks-common-config@4.1.0
   macos: circleci/macos@2.0.1
   node: circleci/node@5.1.0
 
@@ -581,7 +581,7 @@ workflows:
     jobs:
       - revenuecat/update-error-codes:
           platform: hybridCommon
-          output: typescript/src/generated/error-codes.ts
+          outputs: "error-codes.ts:typescript/src/generated/error-codes.ts"
           commit_paths: "typescript/src/generated/error-codes.ts,typescript/api-report"
           update_api_steps:
             - node/install:


### PR DESCRIPTION
Bump common config orb to 4.1.0 to include error codes reminder

Also migrates `output` to multi-file `outputs`, was leftover when released

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration only; no application runtime or release artifact logic changes beyond how the automated error-codes job is invoked.
> 
> **Overview**
> Updates CircleCI to **`revenuecat/sdks-common-config@4.1.0`** (from 3.21.1), picking up orb changes such as the error-codes reminder behavior described in the PR.
> 
> The **`update-error-codes`** workflow job is adjusted for the orb’s v4 API: the single **`output`** parameter is replaced with **`outputs`**, using the mapping `error-codes.ts:typescript/src/generated/error-codes.ts`. **`commit_paths`** and the TypeScript build/API-report steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5df62b66d8bc3c076991f381931505130da0274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->