### PR TITLE
Expose `autoResumeDate`, `displayName`, `managementURL`, `productPlanIdentifier` on `SubscriptionInfo`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-ios-spm",
       "state" : {
-        "revision" : "f4e4b5c4a69919ccf1897b0671af336e40228d27",
-        "version" : "5.57.1"
+        "revision" : "e89cb027a472e5cf1c15435c4e690b9a3c170cdc",
+        "version" : "5.80.0"
       }
     }
   ],

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/SubscriptionInfoMapper.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/SubscriptionInfoMapper.kt
@@ -19,4 +19,8 @@ fun SubscriptionInfo.map(): Map<String, Any?> =
         "storeTransactionId" to storeTransactionId,
         "isActive" to isActive,
         "willRenew" to willRenew,
+        "autoResumeDate" to autoResumeDate?.toIso8601(),
+        "displayName" to displayName,
+        "managementURL" to managementURL?.toString(),
+        "productPlanIdentifier" to productPlanIdentifier,
     )

--- a/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/CustomerInfoMappersTests.kt
+++ b/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/CustomerInfoMappersTests.kt
@@ -102,6 +102,8 @@ internal class CustomerInfoMappersTests {
     @Test
     fun `a CustomerInfo with SubscriptionInfo, should map to a non empty map of subscription infos`() {
         val mockDate = Date()
+        val mockManagementURL = mockk<Uri>(relaxed = true)
+        every { mockManagementURL.toString() } returns "https://manage.url/"
         every { mockCustomerInfo.subscriptionsByProductIdentifier } returns mapOf(
             "productIdentifier" to SubscriptionInfo(
                 productIdentifier = "productIdentifier",
@@ -117,6 +119,11 @@ internal class CustomerInfoMappersTests {
                 periodType = PeriodType.NORMAL,
                 refundedAt = mockDate,
                 storeTransactionId = "storeTransactionId",
+                autoResumeDate = mockDate,
+                displayName = "displayName",
+                price = null,
+                productPlanIdentifier = "productPlanIdentifier",
+                managementURL = mockManagementURL,
                 requestDate = mockDate,
             ),
         )
@@ -140,5 +147,9 @@ internal class CustomerInfoMappersTests {
         assertThat(mappedSubscriptionInfo["storeTransactionId"]).isEqualTo("storeTransactionId")
         assertThat(mappedSubscriptionInfo["isActive"]).isEqualTo(false)
         assertThat(mappedSubscriptionInfo["willRenew"]).isEqualTo(false)
+        assertThat(mappedSubscriptionInfo["autoResumeDate"]).isEqualTo(mockDate.toIso8601())
+        assertThat(mappedSubscriptionInfo["displayName"]).isEqualTo("displayName")
+        assertThat(mappedSubscriptionInfo["managementURL"]).isEqualTo("https://manage.url/")
+        assertThat(mappedSubscriptionInfo["productPlanIdentifier"]).isEqualTo("productPlanIdentifier")
     }
 }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/SubscriptionInfo+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/SubscriptionInfo+HybridAdditions.swift
@@ -33,6 +33,10 @@ internal extension SubscriptionInfo {
             "price": priceObject ?? NSNull(),
             "isActive": isActive,
             "willRenew": willRenew,
+            "autoResumeDate": autoResumeDate?.rc_formattedAsISO8601() ?? NSNull(),
+            "displayName": displayName ?? NSNull(),
+            "managementURL": managementURL?.absoluteString ?? NSNull(),
+            "productPlanIdentifier": productPlanIdentifier ?? NSNull(),
         ]
     }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanPurchasePackage.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanPurchasePackage.1.json
@@ -52,14 +52,18 @@
     "originalApplicationVersion" : "1.0",
     "subscriptionsByProductIdentifier" : {
       "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro" : {
+        "autoResumeDate" : null,
         "billingIssuesDetectedAt" : null,
+        "displayName" : null,
         "gracePeriodExpiresDate" : null,
         "isActive" : true,
         "isSandbox" : true,
+        "managementURL" : null,
         "ownershipType" : "PURCHASED",
         "periodType" : "INTRO",
         "price" : null,
         "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+        "productPlanIdentifier" : null,
         "refundedAt" : null,
         "store" : "APP_STORE",
         "storeTransactionId" : "0",

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanPurchaseProduct.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK1-testCanPurchaseProduct.1.json
@@ -52,14 +52,18 @@
     "originalApplicationVersion" : "1.0",
     "subscriptionsByProductIdentifier" : {
       "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro" : {
+        "autoResumeDate" : null,
         "billingIssuesDetectedAt" : null,
+        "displayName" : null,
         "gracePeriodExpiresDate" : null,
         "isActive" : true,
         "isSandbox" : true,
+        "managementURL" : null,
         "ownershipType" : "PURCHASED",
         "periodType" : "INTRO",
         "price" : null,
         "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+        "productPlanIdentifier" : null,
         "refundedAt" : null,
         "store" : "APP_STORE",
         "storeTransactionId" : "0",

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanPurchasePackage.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanPurchasePackage.1.json
@@ -52,10 +52,13 @@
     "originalApplicationVersion" : "1",
     "subscriptionsByProductIdentifier" : {
       "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro" : {
+        "autoResumeDate" : null,
         "billingIssuesDetectedAt" : null,
+        "displayName" : null,
         "gracePeriodExpiresDate" : null,
         "isActive" : true,
         "isSandbox" : true,
+        "managementURL" : null,
         "ownershipType" : "PURCHASED",
         "periodType" : "TRIAL",
         "price" : {
@@ -63,6 +66,7 @@
           "currency" : "USD"
         },
         "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+        "productPlanIdentifier" : null,
         "refundedAt" : null,
         "store" : "APP_STORE",
         "storeTransactionId" : "0",

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanPurchaseProduct.1.json
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonIntegrationTests/__Snapshots__/StoreKitIntegrationTests/SK2-testCanPurchaseProduct.1.json
@@ -52,10 +52,13 @@
     "originalApplicationVersion" : "1",
     "subscriptionsByProductIdentifier" : {
       "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro" : {
+        "autoResumeDate" : null,
         "billingIssuesDetectedAt" : null,
+        "displayName" : null,
         "gracePeriodExpiresDate" : null,
         "isActive" : true,
         "isSandbox" : true,
+        "managementURL" : null,
         "ownershipType" : "PURCHASED",
         "periodType" : "TRIAL",
         "price" : {
@@ -63,6 +66,7 @@
           "currency" : "USD"
         },
         "productIdentifier" : "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+        "productPlanIdentifier" : null,
         "refundedAt" : null,
         "store" : "APP_STORE",
         "storeTransactionId" : "0",

--- a/purchases-js-hybrid-mappings/src/mappers/customer_info_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/customer_info_mapper.ts
@@ -175,6 +175,11 @@ function mapSubscriptionInfos(
         storeTransactionId: subscriptionInfo.storeTransactionId,
         isActive: subscriptionInfo.isActive,
         willRenew: subscriptionInfo.willRenew,
+        // Not modeled by purchases-js; web has no Play-paused subscriptions.
+        autoResumeDate: null,
+        displayName: subscriptionInfo.displayName,
+        managementURL: subscriptionInfo.managementURL,
+        productPlanIdentifier: subscriptionInfo.productPlanIdentifier,
       },
     ]),
   );

--- a/purchases-js-hybrid-mappings/tests/mappers/customer_info_mapper.test.ts
+++ b/purchases-js-hybrid-mappings/tests/mappers/customer_info_mapper.test.ts
@@ -99,7 +99,10 @@ describe('mapCustomerInfo', () => {
       refundedAt: null,
       storeTransactionId: 'transaction_123',
       isActive: true,
-      willRenew: true
+      willRenew: true,
+      displayName: 'Premium Plan',
+      managementURL: 'https://manage.url/',
+      productPlanIdentifier: 'plan_123'
     };
 
     const nonSubscriptionTransaction: NonSubscriptionTransaction = {
@@ -237,7 +240,11 @@ describe('mapCustomerInfo', () => {
           refundedAt: null,
           storeTransactionId: 'transaction_123',
           isActive: true,
-          willRenew: true
+          willRenew: true,
+          autoResumeDate: null,
+          displayName: 'Premium Plan',
+          managementURL: 'https://manage.url/',
+          productPlanIdentifier: 'plan_123'
         }
       }
     });

--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -513,15 +513,19 @@ export interface PurchasesStoreTransaction {
 
 // @public
 export interface PurchasesSubscriptionInfo {
+    readonly autoResumeDate: string | null;
     readonly billingIssuesDetectedAt: string | null;
+    readonly displayName: string | null;
     readonly expiresDate: string | null;
     readonly gracePeriodExpiresDate: string | null;
     readonly isActive: boolean;
     readonly isSandbox: boolean;
+    readonly managementURL: string | null;
     readonly originalPurchaseDate: string | null;
     readonly ownershipType: OwnershipType;
     readonly periodType: PeriodType;
     readonly productIdentifier: string;
+    readonly productPlanIdentifier: string | null;
     readonly purchaseDate: string;
     readonly refundedAt: string | null;
     readonly store: Store;

--- a/typescript/src/customerInfo.ts
+++ b/typescript/src/customerInfo.ts
@@ -322,4 +322,22 @@ export interface PurchasesSubscriptionInfo {
      * Whether the subscription will renew at the next billing period.
      */
     readonly willRenew: boolean;
+    /**
+     * Date when a paused subscription is expected to automatically resume.
+     * Only set for Google Play subscriptions that have been paused; null otherwise.
+     */
+    readonly autoResumeDate: string | null;
+    /**
+     * The display name of the subscription as configured in the RevenueCat dashboard.
+     */
+    readonly displayName: string | null;
+    /**
+     * The management URL for this subscription.
+     */
+    readonly managementURL: string | null;
+    /**
+     * The base plan identifier that unlocked this subscription (Google Play base plans
+     * and Apple purchases with non-upfront billing plans).
+     */
+    readonly productPlanIdentifier: string | null;
 }


### PR DESCRIPTION
Exposes several new fields from `SubscriptionInfo`

Closes SDK-4382


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, read-only CustomerInfo fields with cross-platform mapping and test coverage; no purchase or auth logic changes.
> 
> **Overview**
> Adds four **read-only** fields on per-product **`PurchasesSubscriptionInfo`** in `customerInfo.subscriptionsByProductIdentifier`: `autoResumeDate`, `displayName`, `managementURL`, and `productPlanIdentifier`, aligned with native RevenueCat `SubscriptionInfo`.
> 
> **Android** and **iOS** hybrid mappers now include these keys in the bridge dictionary (dates as ISO8601, management URL as string). **TypeScript** types and API report are updated with JSDoc describing Play pause resume, dashboard display name, per-subscription management link, and base/plan identifiers.
> 
> **Web** (`purchases-js-hybrid-mappings`) forwards `displayName`, `managementURL`, and `productPlanIdentifier` from purchases-js and always emits `autoResumeDate: null` because paused Play subscriptions are not modeled on web.
> 
> **iOS** `Package.resolved` bumps `purchases-ios-spm` **5.57.1 → 5.80.0**. Tests and StoreKit integration snapshots were updated for the new JSON shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f082e447425998477d863179d7198e8c588ddf8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->