### PR TITLE
Skip bump_hybrid_dependencies when version is older than latest published

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -372,6 +372,14 @@ lane :bump_hybrid_dependencies do |options|
   version_number_for_bump = current_version_number
   repo_name = options[:repo_name]
 
+  latest_published = latest_published_version_number
+  if latest_published && Gem::Version.new(version_number_for_bump) < latest_published
+    UI.important("Skipping #{repo_name} bump: purchases-hybrid-common #{version_number_for_bump} " \
+                 "is older than the latest published release #{latest_published}. " \
+                 "Not propagating a downgrade.")
+    next
+  end
+
   UI.message("Triggering pipeline to bump #{repo_name} dependency to #{version_number_for_bump}")
 
   require 'net/http'
@@ -577,6 +585,14 @@ end
 
 def current_version_number
   File.read("../.version").strip
+end
+
+def latest_published_version_number
+  Fastlane::Helper::RevenuecatInternalHelper
+    .get_github_release_tag_names("purchases-hybrid-common", ENV['GITHUB_TOKEN'])
+    .select { |tag_name| Gem::Version.correct?(tag_name) }
+    .map { |tag_name| Gem::Version.new(tag_name) }
+    .max
 end
 
 def check_pods


### PR DESCRIPTION
`bump_hybrid_dependencies` unconditionally propagated the just-released PHC version to all dependent repos, with no check against PHC's own published history. When a backport patch (e.g. 18.8.1) was released while main was already at 18.16.0, all dependents received a downgrade PR.

Fix: query PHC's own GitHub releases at bump time and skip the CircleCI trigger if the version being propagated is older than the latest published release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only Fastlane release propagation logic; no runtime SDK or customer-facing behavior.
> 
> **Overview**
> **`bump_hybrid_dependencies`** no longer always fires CircleCI `upgrade-hybrid-common` pipelines after a release. It now compares the version from **`.version`** against the **highest semver** among **`purchases-hybrid-common`** GitHub release tags (via **`RevenuecatInternalHelper.get_github_release_tag_names`**). If the version being propagated is **older** than that latest published release, the lane **exits early** with a log message instead of opening downgrade PRs in Flutter, React Native, Cordova, Unity, and Capacitor.
> 
> A new helper **`latest_published_version_number`** parses valid release tags with **`Gem::Version`** and returns **`.max`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e3a3e0f2ba4d09b664a1fa99d1ba358ff00a356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->