### PR TITLE
Fix Prettier 3.9.x formatting in purchases-common.ts

### DIFF
--- a/purchases-js-hybrid-mappings/src/purchases-common.ts
+++ b/purchases-js-hybrid-mappings/src/purchases-common.ts
@@ -385,8 +385,7 @@ export class PurchasesCommon {
     const placementIdentifier =
       (presentedOfferingContext['placementIdentifier'] as string | undefined) ?? null;
     const targetingContext = presentedOfferingContext['targetingContext'] as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
     let targetingContextObj: TargetingContext | null = null;
     if (targetingContext) {
       const targetingRevision = targetingContext['revision'] as number | undefined;


### PR DESCRIPTION
Blocking existing open PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic formatting only; `calculatePresentedOfferingContext` behavior is unchanged.
> 
> **Overview**
> Reformats the `targetingContext` type assertion in `calculatePresentedOfferingContext` so it matches **Prettier 3.9.x** output (union type on one line instead of a multi-line `as` cast). **No runtime or type behavior change**—only whitespace/layout to unblock CI or other PRs that fail format checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fed6a3bec18efe9ec6490cff70c46fb6b2d1e206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->