### PR TITLE
feat(ads): bridge reward-verification primitives to hybrids (Android)

### DIFF
--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
@@ -3,6 +3,7 @@ package com.revenuecat.apitests.kotlin
 import android.app.Activity
 import android.content.Context
 import com.revenuecat.purchases.DangerousSettings
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.hybridcommon.ErrorContainer
@@ -16,6 +17,7 @@ import com.revenuecat.purchases.hybridcommon.getAppUserID
 import com.revenuecat.purchases.hybridcommon.getCachedVirtualCurrencies
 import com.revenuecat.purchases.hybridcommon.getCustomerInfo
 import com.revenuecat.purchases.hybridcommon.getOfferings
+import com.revenuecat.purchases.hybridcommon.generateRewardVerificationToken
 import com.revenuecat.purchases.hybridcommon.getProductInfo
 import com.revenuecat.purchases.hybridcommon.getPromotionalOffer
 import com.revenuecat.purchases.hybridcommon.getProxyURLString
@@ -27,6 +29,7 @@ import com.revenuecat.purchases.hybridcommon.isAnonymous
 import com.revenuecat.purchases.hybridcommon.logIn
 import com.revenuecat.purchases.hybridcommon.logOut
 import com.revenuecat.purchases.hybridcommon.overridePreferredLocale
+import com.revenuecat.purchases.hybridcommon.pollRewardVerification
 import com.revenuecat.purchases.hybridcommon.purchase
 import com.revenuecat.purchases.hybridcommon.purchasePackage
 import com.revenuecat.purchases.hybridcommon.purchaseProduct
@@ -506,5 +509,15 @@ private class CommonApiTests {
 
     private fun checkSetAppstackAttributionParams(data: Map<String, Any>, onResult: OnResult) {
         setAppstackAttributionParams(data, onResult)
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    private fun checkGenerateRewardVerificationToken(impressionId: String) {
+        val token: Map<String, Any?> = generateRewardVerificationToken(impressionId)
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    private fun checkPollRewardVerification(clientTransactionId: String, onResult: OnResult) {
+        pollRewardVerification(clientTransactionId, onResult)
     }
 }

--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
@@ -13,11 +13,11 @@ import com.revenuecat.purchases.hybridcommon.OnResultList
 import com.revenuecat.purchases.hybridcommon.canMakePayments
 import com.revenuecat.purchases.hybridcommon.checkTrialOrIntroductoryPriceEligibility
 import com.revenuecat.purchases.hybridcommon.configure
+import com.revenuecat.purchases.hybridcommon.generateRewardVerificationToken
 import com.revenuecat.purchases.hybridcommon.getAppUserID
 import com.revenuecat.purchases.hybridcommon.getCachedVirtualCurrencies
 import com.revenuecat.purchases.hybridcommon.getCustomerInfo
 import com.revenuecat.purchases.hybridcommon.getOfferings
-import com.revenuecat.purchases.hybridcommon.generateRewardVerificationToken
 import com.revenuecat.purchases.hybridcommon.getProductInfo
 import com.revenuecat.purchases.hybridcommon.getPromotionalOffer
 import com.revenuecat.purchases.hybridcommon.getProxyURLString

--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
@@ -513,7 +513,7 @@ private class CommonApiTests {
 
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private fun checkGenerateRewardVerificationToken(impressionId: String) {
-        val token: Map<String, Any?> = generateRewardVerificationToken(impressionId)
+        val token: Map<String, Any> = generateRewardVerificationToken(impressionId)
     }
 
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -36,6 +36,8 @@ import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import com.revenuecat.purchases.ads.events.types.AdOpenedData
 import com.revenuecat.purchases.ads.events.types.AdRevenueData
 import com.revenuecat.purchases.ads.events.types.AdRevenuePrecision
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.galaxy.GalaxyBillingMode
 import com.revenuecat.purchases.getAmazonLWAConsentStatusWith
@@ -48,7 +50,9 @@ import com.revenuecat.purchases.hybridcommon.mappers.LogHandlerWithMapping
 import com.revenuecat.purchases.hybridcommon.mappers.MappedProductCategory
 import com.revenuecat.purchases.hybridcommon.mappers.map
 import com.revenuecat.purchases.hybridcommon.mappers.mapAsync
+import com.revenuecat.purchases.hybridcommon.mappers.toIso8601
 import com.revenuecat.purchases.hybridcommon.mappers.toMap
+import com.revenuecat.purchases.hybridcommon.mappers.toMillis
 import com.revenuecat.purchases.interfaces.RedeemWebPurchaseListener
 import com.revenuecat.purchases.interfaces.SyncAttributesAndOfferingsCallback
 import com.revenuecat.purchases.logInWith
@@ -1768,3 +1772,57 @@ internal fun convertToInt(value: Any?): Int? {
         else -> null
     }
 }
+
+// region Reward verification
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+fun generateRewardVerificationToken(impressionId: String): Map<String, Any?> {
+    val token = Purchases.sharedInstance.generateRewardVerificationToken(impressionId)
+    return mapOf(
+        "customData" to token.customData,
+        "clientTransactionId" to token.clientTransactionId,
+        "appUserID" to token.appUserID,
+    )
+}
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+fun pollRewardVerification(
+    clientTransactionId: String,
+    onResult: OnResult,
+) {
+    Purchases.sharedInstance.pollRewardVerification(clientTransactionId) { result ->
+        onResult.onReceived(result.encode())
+    }
+}
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+private fun RewardVerificationResult.encode(): Map<String, Any?> {
+    val reward = verifiedReward ?: return mapOf(
+        "failed" to true,
+        "moreRewards" to emptyList<Map<String, Any?>>(),
+    )
+    return mapOf(
+        "failed" to false,
+        "reward" to reward.encode(),
+        "moreRewards" to moreRewards.map { it.encode() },
+    )
+}
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+private fun VerifiedReward.encode(): Map<String, Any?> = when (this) {
+    is VerifiedReward.VirtualCurrency -> mapOf(
+        "type" to "virtual_currency",
+        "code" to code,
+        "amount" to amount,
+    )
+    is VerifiedReward.Entitlement -> mapOf(
+        "type" to "entitlement",
+        "identifier" to identifier,
+        "expiresAt" to expiresAt.toIso8601(),
+        "expiresAtMillis" to expiresAt.toMillis(),
+    )
+    VerifiedReward.NoReward -> mapOf("type" to "no_reward")
+    else -> mapOf("type" to "unsupported_reward")
+}
+
+// endregion

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -36,8 +36,6 @@ import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import com.revenuecat.purchases.ads.events.types.AdOpenedData
 import com.revenuecat.purchases.ads.events.types.AdRevenueData
 import com.revenuecat.purchases.ads.events.types.AdRevenuePrecision
-import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
-import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.galaxy.GalaxyBillingMode
 import com.revenuecat.purchases.getAmazonLWAConsentStatusWith
@@ -50,9 +48,7 @@ import com.revenuecat.purchases.hybridcommon.mappers.LogHandlerWithMapping
 import com.revenuecat.purchases.hybridcommon.mappers.MappedProductCategory
 import com.revenuecat.purchases.hybridcommon.mappers.map
 import com.revenuecat.purchases.hybridcommon.mappers.mapAsync
-import com.revenuecat.purchases.hybridcommon.mappers.toIso8601
 import com.revenuecat.purchases.hybridcommon.mappers.toMap
-import com.revenuecat.purchases.hybridcommon.mappers.toMillis
 import com.revenuecat.purchases.interfaces.RedeemWebPurchaseListener
 import com.revenuecat.purchases.interfaces.SyncAttributesAndOfferingsCallback
 import com.revenuecat.purchases.logInWith
@@ -1777,12 +1773,7 @@ internal fun convertToInt(value: Any?): Int? {
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 fun generateRewardVerificationToken(impressionId: String): Map<String, Any?> {
-    val token = Purchases.sharedInstance.generateRewardVerificationToken(impressionId)
-    return mapOf(
-        "customData" to token.customData,
-        "clientTransactionId" to token.clientTransactionId,
-        "appUserID" to token.appUserID,
-    )
+    return Purchases.sharedInstance.generateRewardVerificationToken(impressionId).map()
 }
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
@@ -1791,38 +1782,8 @@ fun pollRewardVerification(
     onResult: OnResult,
 ) {
     Purchases.sharedInstance.pollRewardVerification(clientTransactionId) { result ->
-        onResult.onReceived(result.encode())
+        onResult.onReceived(result.map())
     }
-}
-
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
-private fun RewardVerificationResult.encode(): Map<String, Any?> {
-    val reward = verifiedReward ?: return mapOf(
-        "failed" to true,
-        "moreRewards" to emptyList<Map<String, Any?>>(),
-    )
-    return mapOf(
-        "failed" to false,
-        "reward" to reward.encode(),
-        "moreRewards" to moreRewards.map { it.encode() },
-    )
-}
-
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
-private fun VerifiedReward.encode(): Map<String, Any?> = when (this) {
-    is VerifiedReward.VirtualCurrency -> mapOf(
-        "type" to "virtual_currency",
-        "code" to code,
-        "amount" to amount,
-    )
-    is VerifiedReward.Entitlement -> mapOf(
-        "type" to "entitlement",
-        "identifier" to identifier,
-        "expiresAt" to expiresAt.toIso8601(),
-        "expiresAtMillis" to expiresAt.toMillis(),
-    )
-    VerifiedReward.NoReward -> mapOf("type" to "no_reward")
-    else -> mapOf("type" to "unsupported_reward")
 }
 
 // endregion

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -1772,7 +1772,7 @@ internal fun convertToInt(value: Any?): Int? {
 // region Reward verification
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
-fun generateRewardVerificationToken(impressionId: String): Map<String, Any?> {
+fun generateRewardVerificationToken(impressionId: String): Map<String, Any> {
     return Purchases.sharedInstance.generateRewardVerificationToken(impressionId).map()
 }
 

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/RewardVerificationMapper.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/RewardVerificationMapper.kt
@@ -1,0 +1,43 @@
+package com.revenuecat.purchases.hybridcommon.mappers
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
+import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+fun RewardVerificationToken.map(): Map<String, Any?> = mapOf(
+    "customData" to customData,
+    "clientTransactionId" to clientTransactionId,
+    "appUserID" to appUserID,
+)
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+fun RewardVerificationResult.map(): Map<String, Any?> {
+    val reward = verifiedReward ?: return mapOf(
+        "failed" to true,
+        "moreRewards" to emptyList<Map<String, Any?>>(),
+    )
+    return mapOf(
+        "failed" to false,
+        "reward" to reward.map(),
+        "moreRewards" to moreRewards.map { it.map() },
+    )
+}
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+fun VerifiedReward.map(): Map<String, Any?> = when (this) {
+    is VerifiedReward.VirtualCurrency -> mapOf(
+        "type" to "virtual_currency",
+        "code" to code,
+        "amount" to amount,
+    )
+    is VerifiedReward.Entitlement -> mapOf(
+        "type" to "entitlement",
+        "identifier" to identifier,
+        "expiresAt" to expiresAt.toIso8601(),
+        "expiresAtMillis" to expiresAt.toMillis(),
+    )
+    VerifiedReward.NoReward -> mapOf("type" to "no_reward")
+    else -> mapOf("type" to "unsupported_reward")
+}

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/RewardVerificationMapper.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/RewardVerificationMapper.kt
@@ -6,17 +6,17 @@ import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
-fun RewardVerificationToken.map(): Map<String, Any?> = mapOf(
+fun RewardVerificationToken.map(): Map<String, Any> = mapOf(
     "customData" to customData,
     "clientTransactionId" to clientTransactionId,
     "appUserID" to appUserID,
 )
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
-fun RewardVerificationResult.map(): Map<String, Any?> {
+fun RewardVerificationResult.map(): Map<String, Any> {
     val reward = verifiedReward ?: return mapOf(
         "failed" to true,
-        "moreRewards" to emptyList<Map<String, Any?>>(),
+        "moreRewards" to emptyList<Map<String, Any>>(),
     )
     return mapOf(
         "failed" to false,
@@ -26,7 +26,7 @@ fun RewardVerificationResult.map(): Map<String, Any?> {
 }
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
-fun VerifiedReward.map(): Map<String, Any?> = when (this) {
+fun VerifiedReward.map(): Map<String, Any> = when (this) {
     is VerifiedReward.VirtualCurrency -> mapOf(
         "type" to "virtual_currency",
         "code" to code,

--- a/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/RewardVerificationMapperTests.kt
+++ b/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/RewardVerificationMapperTests.kt
@@ -1,0 +1,96 @@
+package com.revenuecat.purchases.hybridcommon.mappers
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
+import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
+import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.Date
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+class RewardVerificationMapperTests {
+
+    @Test
+    fun `RewardVerificationToken maps to expected map`() {
+        val token = RewardVerificationToken(
+            customData = "custom-data",
+            clientTransactionId = "client-transaction-id",
+            appUserID = "app-user-id",
+        )
+
+        val map = token.map()
+
+        assertThat(map.size).isEqualTo(3)
+        assertThat(map["customData"]).isEqualTo("custom-data")
+        assertThat(map["clientTransactionId"]).isEqualTo("client-transaction-id")
+        assertThat(map["appUserID"]).isEqualTo("app-user-id")
+    }
+
+    @Test
+    fun `failed RewardVerificationResult maps to expected map`() {
+        val map = RewardVerificationResult.failed.map()
+
+        assertThat(map.size).isEqualTo(2)
+        assertThat(map["failed"]).isEqualTo(true)
+        assertThat(map["moreRewards"]).isEqualTo(emptyList<Map<String, Any?>>())
+    }
+
+    @OptIn(InternalRevenueCatAPI::class)
+    @Test
+    fun `verified RewardVerificationResult maps to expected map`() {
+        val reward = VerifiedReward.VirtualCurrency(code = "GLD", amount = 100)
+        val moreReward = VerifiedReward.NoReward
+        val result = RewardVerificationResult.verified(reward = reward, moreRewards = listOf(moreReward))
+
+        val map = result.map()
+
+        assertThat(map.size).isEqualTo(3)
+        assertThat(map["failed"]).isEqualTo(false)
+        assertThat(map["reward"]).isEqualTo(reward.map())
+        assertThat(map["moreRewards"]).isEqualTo(listOf(moreReward.map()))
+    }
+
+    @Test
+    fun `VirtualCurrency reward maps to expected map`() {
+        val reward = VerifiedReward.VirtualCurrency(code = "GLD", amount = 100)
+
+        val map = reward.map()
+
+        assertThat(map.size).isEqualTo(3)
+        assertThat(map["type"]).isEqualTo("virtual_currency")
+        assertThat(map["code"]).isEqualTo("GLD")
+        assertThat(map["amount"]).isEqualTo(100)
+    }
+
+    @Test
+    fun `Entitlement reward maps to expected map`() {
+        val expiresAt = Date()
+        val reward = VerifiedReward.Entitlement(identifier = "premium", expiresAt = expiresAt)
+
+        val map = reward.map()
+
+        assertThat(map.size).isEqualTo(4)
+        assertThat(map["type"]).isEqualTo("entitlement")
+        assertThat(map["identifier"]).isEqualTo("premium")
+        assertThat(map["expiresAt"]).isEqualTo(expiresAt.toIso8601())
+        assertThat(map["expiresAtMillis"]).isEqualTo(expiresAt.toMillis())
+    }
+
+    @Test
+    fun `NoReward maps to expected map`() {
+        val map = VerifiedReward.NoReward.map()
+
+        assertThat(map.size).isEqualTo(1)
+        assertThat(map["type"]).isEqualTo("no_reward")
+    }
+
+    @Test
+    fun `UnsupportedReward maps to expected map`() {
+        val map = VerifiedReward.UnsupportedReward.map()
+
+        assertThat(map.size).isEqualTo(1)
+        assertThat(map["type"]).isEqualTo("unsupported_reward")
+    }
+}

--- a/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/RewardVerificationMapperTests.kt
+++ b/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/RewardVerificationMapperTests.kt
@@ -34,7 +34,7 @@ class RewardVerificationMapperTests {
 
         assertThat(map.size).isEqualTo(2)
         assertThat(map["failed"]).isEqualTo(true)
-        assertThat(map["moreRewards"]).isEqualTo(emptyList<Map<String, Any?>>())
+        assertThat(map["moreRewards"]).isEqualTo(emptyList<Map<String, Any>>())
     }
 
     @OptIn(InternalRevenueCatAPI::class)


### PR DESCRIPTION
Exposing rewarded ad primitives to be used from hybrid sdks.

Validated locally with e2e ad rewards flutter integration, with local Android simulator (with https://github.com/RevenueCat/purchases-flutter/pull/1802)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches experimental ad reward verification and entitlement/virtual-currency outcomes; scope is limited to hybrid bridging and mapping with no changes to core purchase auth.
> 
> **Overview**
> Adds **Android hybridcommon** bridges so Flutter and other hybrids can use rewarded-ad **reward verification** from the native Purchases SDK.
> 
> New **`generateRewardVerificationToken(impressionId)`** returns a map (`customData`, `clientTransactionId`, `appUserID`). **`pollRewardVerification(clientTransactionId, onResult)`** async polls and delivers a mapped result via `OnResult`.
> 
> **`RewardVerificationMapper`** serializes tokens, results (`failed`, `reward`, `moreRewards`), and reward variants (`virtual_currency`, `entitlement`, `no_reward`, `unsupported_reward`) to the same map shape hybrids already use elsewhere.
> 
> API compile tests and mapper unit tests cover the new surface. APIs are gated with **`ExperimentalPreviewRevenueCatPurchasesAPI`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 093b2a76a39675e23413c10cb4feb7d746e31cfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->