### PR TITLE
Add quantity support to purchases

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -306,6 +306,7 @@ import StoreKit
                         Self.purchase(package: packageIdentifier,
                                       presentedOfferingContext: presentedOfferingContext,
                                       signedDiscountTimestamp: validatedParams.signedDiscountTimestamp,
+                                      quantity: validatedParams.quantity.map { NSNumber(value: $0) },
                                       completion: completion)
                     }
                 } else {
@@ -320,6 +321,7 @@ import StoreKit
                 } else {
                     Self.purchase(product: productIdentifier,
                                   signedDiscountTimestamp: validatedParams.signedDiscountTimestamp,
+                                  quantity: validatedParams.quantity.map { NSNumber(value: $0) },
                                   completion: completion)
                 }
             }
@@ -332,6 +334,17 @@ import StoreKit
     static func purchase(product productIdentifier: String,
                          signedDiscountTimestamp: String?,
                          completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
+        Self.purchase(product: productIdentifier,
+                      signedDiscountTimestamp: signedDiscountTimestamp,
+                      quantity: nil,
+                      completion: completion)
+    }
+
+    @objc(purchaseProduct:signedDiscountTimestamp:quantity:completionBlock:)
+    static func purchase(product productIdentifier: String,
+                         signedDiscountTimestamp: String?,
+                         quantity: NSNumber?,
+                         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
         let hybridCompletion = Self.createPurchaseCompletionBlock(completion: completion)
 
         self.product(with: productIdentifier) { storeProduct in
@@ -340,21 +353,22 @@ import StoreKit
                 return
             }
 
+            let builder = PurchaseParams.Builder(product: storeProduct)
+            if let quantity = quantity {
+                _ = builder.with(quantity: quantity.intValue)
+            }
+
             if let signedDiscountTimestamp = signedDiscountTimestamp {
                 if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) {
                     guard let promotionalOffer = self.promoOffersByTimestamp[signedDiscountTimestamp] else {
                         completion(nil, productNotFoundError(description: "Couldn't find discount.", userCancelled: false))
                         return
                     }
-                    Self.sharedInstance.purchase(product: storeProduct,
-                                              promotionalOffer: promotionalOffer,
-                                              completion: hybridCompletion)
-                    return
+                    _ = builder.with(promotionalOffer: promotionalOffer)
                 }
-
             }
 
-            Self.sharedInstance.purchase(product: storeProduct, completion: hybridCompletion)
+            Self.sharedInstance.purchase(builder.build(), completion: hybridCompletion)
         }
     }
 
@@ -362,6 +376,19 @@ import StoreKit
     static func purchase(package packageIdentifier: String,
                          presentedOfferingContext: [String: Any],
                          signedDiscountTimestamp: String?,
+                         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
+        Self.purchase(package: packageIdentifier,
+                      presentedOfferingContext: presentedOfferingContext,
+                      signedDiscountTimestamp: signedDiscountTimestamp,
+                      quantity: nil,
+                      completion: completion)
+    }
+
+    @objc(purchasePackage:presentedOfferingContext:signedDiscountTimestamp:quantity:completionBlock:)
+    static func purchase(package packageIdentifier: String,
+                         presentedOfferingContext: [String: Any],
+                         signedDiscountTimestamp: String?,
+                         quantity: NSNumber?,
                          completion: @escaping ([String: Any]?, ErrorContainer?) -> Void) {
         let hybridCompletion = Self.createPurchaseCompletionBlock(completion: completion)
 
@@ -375,22 +402,23 @@ import StoreKit
                 return
             }
 
+            let builder = PurchaseParams.Builder(package: package)
+            if let quantity = quantity {
+                _ = builder.with(quantity: quantity.intValue)
+            }
+
             if let signedDiscountTimestamp = signedDiscountTimestamp {
                 if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) {
                     guard let promotionalOffer = self.promoOffersByTimestamp[signedDiscountTimestamp] else {
                         completion(nil, productNotFoundError(description: "Couldn't find discount.", userCancelled: false))
                         return
                     }
-                    Self.sharedInstance.purchase(package: package,
-                                                 promotionalOffer: promotionalOffer,
-                                                 completion: hybridCompletion)
-                    return
+                    _ = builder.with(promotionalOffer: promotionalOffer)
                 }
             }
 
-            Self.sharedInstance.purchase(package: package, completion: hybridCompletion)
+            Self.sharedInstance.purchase(builder.build(), completion: hybridCompletion)
         }
-
     }
 
     @objc(makeDeferredPurchase:completionBlock:)

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonPurchaseParams.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonPurchaseParams.swift
@@ -18,6 +18,7 @@ struct CommonPurchaseParams {
     let signedDiscountTimestamp: String?
     let winBackOfferID: String?
     let presentedOfferingContext: [String: Any]?
+    let quantity: Int?
 }
 
 extension CommonFunctionality {
@@ -29,6 +30,7 @@ extension CommonFunctionality {
         let presentedOfferingContext = options["presentedOfferingContext"] as? [String: Any]
         let signedDiscountTimestamp = options["signedDiscountTimestamp"] as? String
         let winBackOfferID = options["winBackOfferID"] as? String
+        let quantity = options["quantity"] as? Int
 
         let purchasableItem: PurchasableItem
 
@@ -45,7 +47,8 @@ extension CommonFunctionality {
             purchasableItem: purchasableItem,
             signedDiscountTimestamp: signedDiscountTimestamp,
             winBackOfferID: winBackOfferID,
-            presentedOfferingContext: presentedOfferingContext
+            presentedOfferingContext: presentedOfferingContext,
+            quantity: quantity
         )
     }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/CommonFunctionality+PurchaseTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/CommonFunctionality+PurchaseTests.swift
@@ -134,7 +134,7 @@ class CommonFunctionalityPurchaseTests: QuickSpec {
                         mockPurchases.invokedProductsParameters?.completion([storeProduct])
 
                         DispatchQueue.main.async {
-                            if let purchaseParams = mockPurchases.invokedPurchaseProductParameters {
+                            if let purchaseParams = mockPurchases.invokedPurchaseParamsCompletionParameters {
                                 purchaseParams.completion(mockTransaction, mockCustomerInfo, nil, false)
                             }
                         }
@@ -143,7 +143,9 @@ class CommonFunctionalityPurchaseTests: QuickSpec {
                     expect(receivedError).to(beNil())
                     expect(receivedResult).toNot(beNil())
                     expect(receivedResult?["productIdentifier"] as? String) == "test_product_id"
-                    expect(mockPurchases.invokedPurchaseProductCount) == 1
+                    expect(mockPurchases.invokedPurchaseParamsCompletionCount) == 1
+                    expect(mockPurchases.invokedPurchaseParamsCompletionParameters?.params.product?.productIdentifier)
+                        == "test_product_id"
                 }
 
                 it("successfully purchases a package") {
@@ -216,14 +218,15 @@ class CommonFunctionalityPurchaseTests: QuickSpec {
 
                         mockPurchases.invokedOfferingsParameters?.completion(mockOfferings, nil)
 
-                        let presentedOfferingContext = mockPurchases.invokedPurchasePackageParameters?.package.presentedOfferingContext
+                        let presentedOfferingContext = mockPurchases.invokedPurchaseParamsCompletionParameters?
+                            .params.package?.presentedOfferingContext
                         expect(presentedOfferingContext?.offeringIdentifier) == "default"
                         expect(presentedOfferingContext?.placementIdentifier) == "placement_id"
                         expect(presentedOfferingContext?.targetingContext).to(beNil())
 
                         // Simulate the purchase completion
                         DispatchQueue.main.async {
-                            if let purchaseParams = mockPurchases.invokedPurchasePackageParameters {
+                            if let purchaseParams = mockPurchases.invokedPurchaseParamsCompletionParameters {
                                 purchaseParams.completion(mockTransaction, mockCustomerInfo, nil, false)
                             }
                         }
@@ -232,7 +235,7 @@ class CommonFunctionalityPurchaseTests: QuickSpec {
                     expect(receivedError).to(beNil())
                     expect(receivedResult).toNot(beNil())
                     expect(receivedResult?["productIdentifier"] as? String) == "monthly_product_id"
-                    expect(mockPurchases.invokedPurchasePackageCount) == 1
+                    expect(mockPurchases.invokedPurchaseParamsCompletionCount) == 1
                 }
             }
         }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/CommonPurchaseParamsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/CommonPurchaseParamsTests.swift
@@ -38,7 +38,8 @@ class CommonPurchaseParamsTests: QuickSpec {
                         "packageIdentifier": "test_package",
                         "signedDiscountTimestamp": "123456",
                         "winBackOfferID": "winback_123",
-                        "presentedOfferingContext": presentedOfferingContext
+                        "presentedOfferingContext": presentedOfferingContext,
+                        "quantity": 3
                     ]
 
                     let result = try? CommonFunctionality.validatePurchaseParams(options)
@@ -47,6 +48,7 @@ class CommonPurchaseParamsTests: QuickSpec {
                     expect(result?.signedDiscountTimestamp) == "123456"
                     expect(result?.winBackOfferID) == "winback_123"
                     expect(result?.presentedOfferingContext?["offering_id"] as? String) == "test_offering"
+                    expect(result?.quantity) == 3
                 }
             }
 
@@ -73,7 +75,8 @@ class CommonPurchaseParamsTests: QuickSpec {
                         "productIdentifier": "test_product",
                         "signedDiscountTimestamp": "789012",
                         "winBackOfferID": "winback_456",
-                        "presentedOfferingContext": presentedOfferingContext
+                        "presentedOfferingContext": presentedOfferingContext,
+                        "quantity": 5
                     ]
 
                     let result = try? CommonFunctionality.validatePurchaseParams(options)
@@ -82,6 +85,30 @@ class CommonPurchaseParamsTests: QuickSpec {
                     expect(result?.signedDiscountTimestamp) == "789012"
                     expect(result?.winBackOfferID) == "winback_456"
                     expect(result?.presentedOfferingContext?["offering_id"] as? String) == "test_offering"
+                    expect(result?.quantity) == 5
+                }
+            }
+
+            context("quantity") {
+                it("defaults to nil when not provided") {
+                    let options: [String: Any] = ["packageIdentifier": "test_package"]
+
+                    let result = try? CommonFunctionality.validatePurchaseParams(options)
+
+                    expect(result).toNot(beNil())
+                    expect(result?.quantity).to(beNil())
+                }
+
+                it("ignores a non-integer quantity") {
+                    let options: [String: Any] = [
+                        "packageIdentifier": "test_package",
+                        "quantity": "not_a_number"
+                    ]
+
+                    let result = try? CommonFunctionality.validatePurchaseParams(options)
+
+                    expect(result).toNot(beNil())
+                    expect(result?.quantity).to(beNil())
                 }
             }
 


### PR DESCRIPTION
## Description

Adds an optional `quantity` to the package and product purchase paths, mapping to RevenueCat iOS's [`PurchaseParams.Builder.with(quantity:)`](https://revenuecat.github.io/purchases-ios-docs/5.80.0/documentation/revenuecat/purchaseparams/builder/with(quantity:)). This lets hybrid SDKs purchase multiple quantities of App Store consumable products (range 1–10).

This is the iOS-side dependency for adding `quantity` to the React Native SDK (companion PR in `react-native-purchases`). It is iOS-only by design: Google Play Billing has no API to set a purchase quantity ahead of time (the user selects quantity in Play's purchase UI), so there is no Android counterpart.

### Changes
- `CommonPurchaseParams`: new `quantity: Int?`, parsed from `options["quantity"]` and routed through `purchase(options:)`.
- New, non-breaking `@objc` overloads:
  - `purchaseProduct:signedDiscountTimestamp:quantity:completionBlock:`
  - `purchasePackage:presentedOfferingContext:signedDiscountTimestamp:quantity:completionBlock:`
  - The existing selectors are preserved and delegate with `quantity = nil`.
- The product/package purchase paths now build a `PurchaseParams` (matching the existing win-back path) instead of calling `purchase(product:)` / `purchase(package:)` directly. This removes duplication and keeps the quantity-aware code in one place.
  - **Behavioral note:** this means the non-win-back purchase paths now invoke `Purchases.purchase(_:completion:)` (params) rather than `purchase(product:completion:)` / `purchase(package:completion:)`. It routes through the same orchestrator call, but the two affected unit tests are updated accordingly.

### Testing
- `CommonPurchaseParamsTests`: `quantity` parsing — set, default-nil, and non-integer-ignored.
- `CommonFunctionalityPurchaseTests`: existing success tests updated to assert the `purchase(params:)` path.
- All 17 tests pass; library builds against RevenueCat 5.80.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core purchase orchestration and changes which RevenueCat API is invoked for standard product/package buys; behavior should be equivalent but warrants careful purchase QA.
> 
> **Overview**
> Adds optional **`quantity`** on iOS hybrid purchase flows so React Native and other wrappers can buy multiple units of App Store consumables (via RevenueCat `PurchaseParams.Builder.with(quantity:)`).
> 
> **`purchase(options:)`** now reads `quantity` from the options dictionary into `CommonPurchaseParams` and forwards it on product and package paths (win-back purchases unchanged). New **`@objc`** overloads accept `quantity` on the direct product/package purchase APIs; existing selectors remain and delegate with `quantity: nil`.
> 
> Product and package purchases (with or without promotional offers) are unified on **`PurchaseParams.Builder`** and **`Purchases.purchase(_:completion:)`** instead of separate `purchase(product:)` / `purchase(package:)` entry points—same pattern as win-back. Tests cover quantity parsing (present, absent, invalid type) and assert the params-based purchase path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dafca5fc791379d7eca7fb450ef48e5fe97f1ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->