### PR TITLE
Use mise for Java in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 
 orbs:
   android: circleci/android@2.4.0
-  revenuecat: revenuecat/sdks-common-config@4.1.0
+  revenuecat: revenuecat/sdks-common-config@4.2.0
   macos: circleci/macos@2.0.1
   node: circleci/node@5.1.0
 
@@ -48,16 +48,10 @@ parameters:
     default: build
 
 commands:
-  install-sdkman:
-    description: Install SDKMAN and set up Java environment
+  install-mise-tools:
+    description: Install mise tools from mise.toml (Java, etc.)
     steps:
-      - revenuecat/install-sdkman
-      - run:
-          name: Setup Java environment
-          command: |
-            if ! sdk env install; then
-              echo "Error installing Java SDK through SDKMAN, continuing with default Java" >&2
-            fi
+      - revenuecat/install-mise-tools
 
   setup-git-credentials:
      steps:
@@ -232,7 +226,7 @@ jobs:
     steps:
       - checkout:
           path: ~/purchases-hybrid-common
-      - install-sdkman
+      - install-mise-tools
       - android/restore-gradle-cache
       - run:
           name: Detekt
@@ -248,7 +242,7 @@ jobs:
     steps:
       - checkout:
           path: ~/purchases-hybrid-common
-      - install-sdkman
+      - install-mise-tools
       - android/restore-gradle-cache
       - run:
           name: Run Tests
@@ -270,7 +264,7 @@ jobs:
         default: false
     steps:
       - checkout
-      - install-sdkman
+      - install-mise-tools
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/accept-licenses

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,8 @@ jobs:
     steps:
       - checkout:
           path: ~/purchases-hybrid-common
-      - install-mise-tools
+      - install-mise-tools:
+          working_directory: ~/purchases-hybrid-common
       - android/restore-gradle-cache
       - run:
           name: Detekt
@@ -242,7 +243,8 @@ jobs:
     steps:
       - checkout:
           path: ~/purchases-hybrid-common
-      - install-mise-tools
+      - install-mise-tools:
+          working_directory: ~/purchases-hybrid-common
       - android/restore-gradle-cache
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,30 +48,6 @@ parameters:
     default: build
 
 commands:
-  install-mise-tools:
-    description: Install mise tools from mise.toml (Java, etc.)
-    parameters:
-      root:
-        type: string
-        default: "."
-    steps:
-      - revenuecat/install-mise
-      - run:
-          name: Install mise tools
-          working_directory: << parameters.root >>
-          command: |
-            if [ ! -f "mise.toml" ]; then
-              echo "❌ mise.toml not found. Please create a mise.toml file with tool versions."
-              exit 1
-            fi
-            mise settings set experimental true
-            mise install
-            if java_home="$(mise where java 2>/dev/null)"; then
-              echo "export JAVA_HOME=\"$java_home\"" >> "$BASH_ENV"
-              java -version || { echo "❌ Java did not install properly."; exit 1; }
-            fi
-            echo "✅ mise tools installation completed"
-
   setup-git-credentials:
      steps:
        - run:
@@ -240,16 +216,16 @@ jobs:
       name: android/android-machine
       resource-class: large
       tag: default
-    working_directory: ~/purchases-hybrid-common/android
+    working_directory: ~/purchases-hybrid-common
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout:
           path: ~/purchases-hybrid-common
-      - install-mise-tools:
-          root: ~/purchases-hybrid-common
+      - revenuecat/install-mise-tools
       - android/restore-gradle-cache
       - run:
           name: Detekt
+          working_directory: android
           command: ./gradlew detekt
       - android/save-gradle-cache
 
@@ -258,21 +234,21 @@ jobs:
       name: android/android-machine
       resource-class: large
       tag: default
-    working_directory: ~/purchases-hybrid-common/android
+    working_directory: ~/purchases-hybrid-common
     steps:
       - checkout:
           path: ~/purchases-hybrid-common
-      - install-mise-tools:
-          root: ~/purchases-hybrid-common
+      - revenuecat/install-mise-tools
       - android/restore-gradle-cache
       - run:
           name: Run Tests
+          working_directory: android
           command: ./gradlew lint test
       - android/save-build-cache
       - store_artifacts:
-          path: build/reports
+          path: android/build/reports
       - store_test_results:
-          path: build/test-results
+          path: android/build/test-results
 
   deploy-android:
     executor:
@@ -285,7 +261,7 @@ jobs:
         default: false
     steps:
       - checkout
-      - install-mise-tools
+      - revenuecat/install-mise-tools
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/accept-licenses

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,27 @@ parameters:
 commands:
   install-mise-tools:
     description: Install mise tools from mise.toml (Java, etc.)
+    parameters:
+      root:
+        type: string
+        default: "."
     steps:
-      - revenuecat/install-mise-tools
+      - revenuecat/install-mise
+      - run:
+          name: Install mise tools
+          working_directory: << parameters.root >>
+          command: |
+            if [ ! -f "mise.toml" ]; then
+              echo "❌ mise.toml not found. Please create a mise.toml file with tool versions."
+              exit 1
+            fi
+            mise settings set experimental true
+            mise install
+            if java_home="$(mise where java 2>/dev/null)"; then
+              echo "export JAVA_HOME=\"$java_home\"" >> "$BASH_ENV"
+              java -version || { echo "❌ Java did not install properly."; exit 1; }
+            fi
+            echo "✅ mise tools installation completed"
 
   setup-git-credentials:
      steps:
@@ -227,7 +246,7 @@ jobs:
       - checkout:
           path: ~/purchases-hybrid-common
       - install-mise-tools:
-          working_directory: ~/purchases-hybrid-common
+          root: ~/purchases-hybrid-common
       - android/restore-gradle-cache
       - run:
           name: Detekt
@@ -244,7 +263,7 @@ jobs:
       - checkout:
           path: ~/purchases-hybrid-common
       - install-mise-tools:
-          working_directory: ~/purchases-hybrid-common
+          root: ~/purchases-hybrid-common
       - android/restore-gradle-cache
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 
 orbs:
   android: circleci/android@2.4.0
-  revenuecat: revenuecat/sdks-common-config@4.2.0
+  revenuecat: revenuecat/sdks-common-config@4.3.0
   macos: circleci/macos@2.0.1
   node: circleci/node@5.1.0
 

--- a/android/.sdkmanrc
+++ b/android/.sdkmanrc
@@ -1,3 +1,6 @@
+# Deprecated: CI and local Java versions are managed in mise.toml.
+# This file is kept for reference only; do not add new SDKMAN pins here.
+#
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
 java=17.0.6-librca

--- a/mise.lock
+++ b/mise.lock
@@ -3,3 +3,31 @@
 [[tools.java]]
 version = "liberica-17.0.6+10"
 backend = "core:java"
+
+[tools.java."platforms.linux-arm64"]
+checksum = "sha1:3f35ee9fac9ab87b163333bc6c7802753730a680"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-linux-aarch64.tar.gz"
+
+[tools.java."platforms.linux-arm64-musl"]
+checksum = "sha1:95edb1e0015eac796053923234c12b665cd6b287"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-linux-aarch64-musl.tar.gz"
+
+[tools.java."platforms.linux-x64"]
+checksum = "sha1:3921ead0629aa003b3ec3afad7557bbea397fb1e"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-linux-amd64.tar.gz"
+
+[tools.java."platforms.linux-x64-musl"]
+checksum = "sha1:9c4f64693f71ca3c88c1321173887b1facda75e2"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-linux-x64-musl.tar.gz"
+
+[tools.java."platforms.macos-arm64"]
+checksum = "sha1:2af64f6f557c6cbf96cac7022eba2c9779a6be7a"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-macos-aarch64.tar.gz"
+
+[tools.java."platforms.macos-x64"]
+checksum = "sha1:e78e899e7a6449751c5431d53a9cb9ed001da90d"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-macos-amd64.tar.gz"
+
+[tools.java."platforms.windows-x64"]
+checksum = "sha1:04397d865b19e2d4b8102f4070b6c7a946846d6a"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-windows-amd64.zip"


### PR DESCRIPTION
Replaces the custom `install-sdkman` command with `revenuecat/install-mise-tools` across all Android CI jobs. The `sdks-common-config` orb is bumped to `4.3.0` to support this.   
  
The `.sdkmanrc` file is retained for reference but marked as deprecated. The `mise.lock` file is updated with platform-specific checksums and download URLs.  
  
Related: https://github.com/RevenueCat/sdks-circleci-orb/pull/75

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and toolchain wiring only; no application runtime or release logic changes beyond ensuring the same JDK version via mise.
> 
> **Overview**
> **Android CI** now installs Java via **`revenuecat/install-mise-tools`** instead of the removed **`install-sdkman`** flow, with **`sdks-common-config`** bumped to **4.3.0** to support that orb step.
> 
> **`detekt-android`**, **`test-android`**, and **`deploy-android`** run from the repo root (`~/purchases-hybrid-common`); Gradle steps use **`working_directory: android`**, and test artifact paths point at **`android/build/...`**. **`android/.sdkmanrc`** is documented as deprecated in favor of **`mise.toml`**, and **`mise.lock`** adds pinned Liberica JDK URLs and checksums per platform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89e30ee5ddc868cc0ae36634b9445dcecc1f41c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->