### PR TITLE
Regenerate Package.resolved via swift package resolve on iOS bumps

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,14 +26,12 @@ files_with_version_number_without_prerelease_modifiers = {
 }
 POD_VERSION_PATTERNS = ['\'RevenueCat\', \'{x}\'', '\'RevenueCatUI\', \'{x}\'']
 SPM_VERSION_PATTERNS = ['.package(url: "https://github.com/RevenueCat/purchases-ios-spm", exact: "{x}"),']
-SPM_RESOLVED_VERSION_PATTERNS = ['"version" : "{x}"']
 files_to_update_ios_dependency = {
     'PurchasesHybridCommon.podspec' => POD_VERSION_PATTERNS,
     'PurchasesHybridCommonUI.podspec' => POD_VERSION_PATTERNS,
     'ios/PurchasesHybridCommon/Podfile' => POD_VERSION_PATTERNS,
     'DEVELOPMENT.md' => POD_VERSION_PATTERNS,
     'Package.swift' => SPM_VERSION_PATTERNS,
-    'Package.resolved' => SPM_RESOLVED_VERSION_PATTERNS,
 }
 
 files_to_update_android_dependency = {
@@ -295,15 +293,13 @@ private_lane :update_ios_native_version do |options|
     files_to_update: files_to_update_ios_dependency
   )
 
-  # Updating the commit hash in Package.resolved.
-  ios_spm_repository = "https://github.com/RevenueCat/purchases-ios-spm"
-  previous_commit_hash = get_commit_hash_for_tag(ios_spm_repository, previous_version_number)
-  new_commit_hash = get_commit_hash_for_tag(ios_spm_repository, new_version_number)
-  replace_text_in_files(
-    previous_text: previous_commit_hash,
-    new_text: new_commit_hash,
-    paths_of_files_to_update: ["Package.resolved"]
-  )
+  # Regenerate Package.resolved from Package.swift instead of text-replacing
+  # the previous version, so an out-of-sync file self-heals on the next bump.
+  if previous_version_number != new_version_number
+    Dir.chdir(get_root_folder) do
+      sh("swift package resolve")
+    end
+  end
 end
 
 desc "Update purchases-android dependency version"
@@ -647,8 +643,4 @@ def detect_bump_type(a, b)
   else
     return :major
   end
-end
-
-def get_commit_hash_for_tag(repository, tag)
-  sh("git ls-remote --tags #{repository} | grep refs/tags/#{tag}^{} | cut -f 1 | tr -d '\n'")
 end


### PR DESCRIPTION
### Motivation

The automatic iOS bump updated `Package.resolved` by text-replacing the previous version and commit hash. If the file ever got out of sync (a manual bump in #1461 missed it), the pattern never matched again and every later bump silently skipped the file. It stayed pinned at 5.57.1 for 5 months until fixed by hand in #1698, where this automation fix was suggested: https://github.com/RevenueCat/purchases-hybrid-common/pull/1698#discussion_r3491490922

### Description

After bumping `Package.swift`, run `swift package resolve` to regenerate `Package.resolved` instead of pattern-matching its current content. Resolution rewrites the file from the `exact:` pin, so any drift self-heals on the next bump, and a resolution failure fails the lane loudly. 

Also removes the now-unused `SPM_RESOLVED_VERSION_PATTERNS` constant and `get_commit_hash_for_tag` helper.

Verified locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only fastlane release automation; no runtime app code, with clearer failure behavior if SPM resolution breaks.
> 
> **Overview**
> **iOS dependency bump automation** no longer text-replaces `Package.resolved` (version strings or commit hashes). After updating pins in `Package.swift` and related files, the lane runs **`swift package resolve`** at the repo root so the lockfile is rewritten from the `exact:` pin—out-of-sync locks self-heal on the next bump, and resolution errors fail the lane instead of silently skipping updates.
> 
> Removes unused **`SPM_RESOLVED_VERSION_PATTERNS`**, drops `Package.resolved` from the iOS bump file list, and deletes **`get_commit_hash_for_tag`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea6a8c15df6ee23fb337273cfb44955e60b4e92c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->