### PR TITLE
Map autoResumeDate from purchases-js SubscriptionInfo in JS hybrid mappings

### DIFF
--- a/purchases-js-hybrid-mappings/src/mappers/customer_info_mapper.ts
+++ b/purchases-js-hybrid-mappings/src/mappers/customer_info_mapper.ts
@@ -175,8 +175,9 @@ function mapSubscriptionInfos(
         storeTransactionId: subscriptionInfo.storeTransactionId,
         isActive: subscriptionInfo.isActive,
         willRenew: subscriptionInfo.willRenew,
-        // Not modeled by purchases-js; web has no Play-paused subscriptions.
-        autoResumeDate: null,
+        autoResumeDate: subscriptionInfo.autoResumeDate
+          ? subscriptionInfo.autoResumeDate.toISOString()
+          : null,
         displayName: subscriptionInfo.displayName,
         managementURL: subscriptionInfo.managementURL,
         productPlanIdentifier: subscriptionInfo.productPlanIdentifier,

--- a/purchases-js-hybrid-mappings/tests/mappers/customer_info_mapper.test.ts
+++ b/purchases-js-hybrid-mappings/tests/mappers/customer_info_mapper.test.ts
@@ -61,6 +61,7 @@ describe('mapCustomerInfo', () => {
   it('maps CustomerInfo with subs and non subs purchases correctly', () => {
     const purchaseDate = new Date('2024-01-15T12:00:00Z');
     const expirationDate = new Date('2024-02-15T12:00:00Z');
+    const autoResumeDate = new Date('2024-03-15T12:00:00Z');
 
     const entitlementInfo: EntitlementInfo = {
       identifier: 'premium',
@@ -100,6 +101,7 @@ describe('mapCustomerInfo', () => {
       storeTransactionId: 'transaction_123',
       isActive: true,
       willRenew: true,
+      autoResumeDate: autoResumeDate,
       displayName: 'Premium Plan',
       managementURL: 'https://manage.url/',
       productPlanIdentifier: 'plan_123'
@@ -241,7 +243,7 @@ describe('mapCustomerInfo', () => {
           storeTransactionId: 'transaction_123',
           isActive: true,
           willRenew: true,
-          autoResumeDate: null,
+          autoResumeDate: autoResumeDate.toISOString(),
           displayName: 'Premium Plan',
           managementURL: 'https://manage.url/',
           productPlanIdentifier: 'plan_123'


### PR DESCRIPTION
### Motivation

Follow-up to https://github.com/RevenueCat/purchases-hybrid-common/pull/1698#discussion_r3491495706: the JS mappings hardcoded `autoResumeDate: null` because purchases-js did not expose it yet.

### Description

purchases-js exposes `autoResumeDate` on `SubscriptionInfo` since 1.47.0 (https://github.com/RevenueCat/purchases-js/pull/957), which is already our pinned version. Map the real value instead of the hardcoded null.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small mapper and test change with no auth or payment logic; behavior only improves fidelity when the JS SDK provides a resume date.
> 
> **Overview**
> **Subscription mapping** now forwards **`autoResumeDate`** from purchases-js `SubscriptionInfo` into the hybrid `CustomerInfo` payload, using the same ISO-string-or-`null` pattern as other date fields, instead of always emitting **`null`**.
> 
> The mapper test was updated to set **`autoResumeDate`** on mock subscription data and assert the mapped value is the ISO string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea90cbadaf5682cf736b15e0b4944d472c780b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->