### PR TITLE
Use mise for Ruby, Node, and Yarn too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ orbs:
   android: circleci/android@2.4.0
   revenuecat: revenuecat/sdks-common-config@4.4.0
   macos: circleci/macos@2.0.1
-  node: circleci/node@5.1.0
 
 version: 2.1
 
@@ -221,7 +220,8 @@ jobs:
     steps:
       - checkout:
           path: ~/purchases-hybrid-common
-      - revenuecat/install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/restore-gradle-cache
       - run:
           name: Detekt
@@ -238,7 +238,8 @@ jobs:
     steps:
       - checkout:
           path: ~/purchases-hybrid-common
-      - revenuecat/install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - android/restore-gradle-cache
       - run:
           name: Run Tests
@@ -261,7 +262,8 @@ jobs:
         default: false
     steps:
       - checkout
-      - revenuecat/install-mise-tools
+      - revenuecat/install-mise-tools:
+          tools: java
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/accept-licenses
@@ -274,39 +276,57 @@ jobs:
 
   deploy-typescript:
     docker:
-      - image: cimg/ruby:3.3.0-node
+      - image: cimg/ruby:3.3.0
+    parameters:
+      dry_run:
+        type: boolean
+        default: false
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: node
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - copy-npm-rc
       - run:
           name: Deploy typescript interfaces NPM package
-          command: bundle exec fastlane typescript deploy
+          command: bundle exec fastlane typescript deploy dry_run:<< parameters.dry_run >>
 
   deploy-typescript-esm:
     docker:
-      - image: cimg/ruby:3.3.0-node
+      - image: cimg/ruby:3.3.0
+    parameters:
+      dry_run:
+        type: boolean
+        default: false
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: node
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - copy-npm-rc
       - run:
           name: Deploy typescript interfaces ESNext NPM package
-          command: bundle exec fastlane typescript deploy_esm
+          command: bundle exec fastlane typescript deploy_esm dry_run:<< parameters.dry_run >>
 
   deploy-js-mappings:
     docker:
-      - image: cimg/ruby:3.3.0-node
+      - image: cimg/ruby:3.3.0
+    parameters:
+      dry_run:
+        type: boolean
+        default: false
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: node
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - copy-npm-rc
       - run:
           name: Deploy js-mappings NPM package
-          command: bundle exec fastlane web deploy_js_mappings
+          command: bundle exec fastlane web deploy_js_mappings dry_run:<< parameters.dry_run >>
       - run:
           name: Compute js-mappings bundle sha256
           command: |
@@ -340,8 +360,8 @@ jobs:
       - revenuecat/trust-github-key
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
-      - node/install:
-          install-yarn: true
+      - revenuecat/install-mise-tools:
+          tools: node
       - run:
           name: Update dependencies to latest versions
           command: bundle exec fastlane open_pr_upgrading_dependencies
@@ -381,14 +401,14 @@ jobs:
           when: always
 
   typescript-lint:
-    executor: node/default
-    working_directory: ~/purchases-hybrid-common/typescript
+    docker:
+      - image: cimg/base:current
     steps:
-      - checkout:
-          path: ~/purchases-hybrid-common
-      - node/install:
-          install-yarn: true
+      - checkout
+      - revenuecat/install-mise-tools:
+          tools: node
       - run:
+          working_directory: typescript
           command: yarn install --frozen-lockfile && yarn eslint
 
   typescript-apitests:
@@ -396,8 +416,8 @@ jobs:
       - image: cimg/ruby:3.3.0-node
     steps:
       - checkout
-      - node/install:
-          install-yarn: true
+      - revenuecat/install-mise-tools:
+          tools: node
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - run:
@@ -409,8 +429,8 @@ jobs:
       - image: cimg/ruby:3.3.0-node
     steps:
       - checkout
-      - node/install:
-          install-yarn: true
+      - revenuecat/install-mise-tools:
+          tools: node
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - run:
@@ -422,8 +442,8 @@ jobs:
       - image: cimg/ruby:3.3.0-node
     steps:
       - checkout
-      - node/install:
-          install-yarn: true
+      - revenuecat/install-mise-tools:
+          tools: node
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - run:
@@ -435,8 +455,8 @@ jobs:
       - image: cimg/ruby:3.3.0-node
     steps:
       - checkout
-      - node/install:
-          install-yarn: true
+      - revenuecat/install-mise-tools:
+          tools: node
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - run:
@@ -487,6 +507,15 @@ workflows:
       - test-android
       - deploy-android:
           name: android-deploy-dry-run
+          dry_run: true
+      - deploy-typescript:
+          name: typescript-deploy-dry-run
+          dry_run: true
+      - deploy-typescript-esm:
+          name: typescript-esm-deploy-dry-run
+          dry_run: true
+      - deploy-js-mappings:
+          name: js-mappings-deploy-dry-run
           dry_run: true
       - detekt-android
       - typescript-lint
@@ -577,8 +606,8 @@ workflows:
           outputs: "error-codes.ts:typescript/src/generated/error-codes.ts"
           commit_paths: "typescript/src/generated/error-codes.ts,typescript/api-report"
           update_api_steps:
-            - node/install:
-                install-yarn: true
+            - revenuecat/install-mise-tools:
+                tools: node
             - revenuecat/install-gem-unix-dependencies:
                 cache-version: v1
             - run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ purchases-hybrid-common/
 
 ### Android
 
-JDK setup: install [mise](https://mise.jdx.dev/) and run `mise install` in project root to get the pinned Java version (sdkman via `sdk env install` is also supported).
+Tool setup: install [mise](https://mise.jdx.dev/) and run `mise install` in the project root (Java, Ruby, Node from `mise.toml`; Yarn via corepack).
 
 ```bash
 # Build

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install [mise](https://mise.jdx.dev/), then from the repo root:
 mise install
 ```
 
-That installs Java, Ruby, and Node from `mise.toml` / `mise.lock`. Yarn classic is provided via corepack (`[settings.node] corepack` and `packageManager` in `typescript/package.json`).
+That installs Java, Ruby, and Node from `mise.toml` / `mise.lock`. Yarn is provided via corepack.
 
 **Exceptions (not managed by mise):** Xcode for iOS work, Android SDK for local Android builds.
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ Contains mappings from purchases-js for use by hybrid frameworks that support we
 - **Package**: `@revenuecat/purchases-js-hybrid-mappings`
 - **Dependencies**: Built on top of `@revenuecat/purchases-js`
 - **Purpose**: Bridge between purchases-js and hybrid implementations
+
+## Development setup
+
+Install [mise](https://mise.jdx.dev/), then from the repo root:
+
+```bash
+mise install
+```
+
+That installs Java, Ruby, and Node from `mise.toml` / `mise.lock`. Yarn classic is provided via corepack (`[settings.node] corepack` and `packageManager` in `typescript/package.json`).
+
+**Exceptions (not managed by mise):** Xcode for iOS work, Android SDK for local Android builds.
+

--- a/android/.sdkmanrc
+++ b/android/.sdkmanrc
@@ -1,6 +1,2 @@
-# Deprecated: CI and local Java versions are managed in mise.toml.
-# This file is kept for reference only; do not add new SDKMAN pins here.
-#
-# Enable auto-env through the sdkman_auto_env config
-# Add key=value pairs of SDKs to use below
+# Deprecated: use `mise install` (see mise.toml).
 java=17.0.6-librca

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -490,13 +490,13 @@ end
 platform :typescript do
   desc "Deploy npm package to npm.js"
   lane :deploy do |options|
-    build_and_publish_npm_package("typescript")
+    build_and_publish_npm_package("typescript", dry_run: options[:dry_run])
   end
 
   desc "Deploy typescript interfaces ESNext NPM package"
   lane :deploy_esm do |options|
     make_typescript_package_esm
-    build_and_publish_npm_package("typescript")
+    build_and_publish_npm_package("typescript", dry_run: options[:dry_run])
   end
 end
 
@@ -524,7 +524,7 @@ platform :web do
 
   desc "Deploy purchases-js-hybrid-mappings to npm.js"
   lane :deploy_js_mappings do |options|
-    build_and_publish_npm_package("purchases-js-hybrid-mappings")
+    build_and_publish_npm_package("purchases-js-hybrid-mappings", dry_run: options[:dry_run])
   end
 end
 
@@ -541,7 +541,7 @@ def make_typescript_package_esm
   )
 end
 
-def build_and_publish_npm_package(folder)
+def build_and_publish_npm_package(folder, dry_run: false)
   version_number = current_version_number
   is_prerelease = Gem::Version.new(version_number).prerelease?
 
@@ -558,7 +558,12 @@ def build_and_publish_npm_package(folder)
 
   Dir.chdir(File.expand_path(folder, get_root_folder)) do
     sh(build_args)
-    sh(publish_args)
+    if dry_run
+      sh(['npm', 'pack'])
+      UI.message("ℹ️  npm pack dry-run for #{folder}; nothing published.")
+    else
+      sh(publish_args)
+    end
   end
 end
 

--- a/mise.lock
+++ b/mise.lock
@@ -31,3 +31,84 @@ url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsof
 [tools.java."platforms.windows-x64"]
 checksum = "sha1:04397d865b19e2d4b8102f4070b6c7a946846d6a"
 url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-windows-amd64.zip"
+
+[[tools.node]]
+version = "24.18.0"
+backend = "core:node"
+
+[tools.node."platforms.linux-arm64"]
+checksum = "sha256:6b4484c2190274175df9aa8f28e2d758a819cb1c1fe6ab481e2f95b463ab8508"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-arm64.tar.gz"
+
+[tools.node."platforms.linux-arm64-musl"]
+checksum = "sha256:b1c6c2dc31b46dd8fb2322f4fe75b07e775c5120bc37251deeea28f529d4567b"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-arm64-musl.tar.gz"
+
+[tools.node."platforms.linux-x64"]
+checksum = "sha256:783130984963db7ba9cbd01089eaf2c2efb055c7c1693c943174b967b3050cb8"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-x64.tar.gz"
+
+[tools.node."platforms.linux-x64-musl"]
+checksum = "sha256:ea58409911e141ec6b19d9178efa2d9185a13295005b1cbf5521b3157eed1d95"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-x64-musl.tar.gz"
+
+[tools.node."platforms.macos-arm64"]
+checksum = "sha256:e1a97e14c99c803e96c7339403282ea05a499c32f8d83defe9ef5ec66f979ed1"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-darwin-arm64.tar.gz"
+
+[tools.node."platforms.macos-x64"]
+checksum = "sha256:dfd0dbd3e721503434df7b7205e719f61b3a3a31b2bcf9729b8b91fea240f080"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-darwin-x64.tar.gz"
+
+[tools.node."platforms.windows-x64"]
+checksum = "sha256:0ae68406b42d7725661da979b1403ec9926da205c6770827f33aac9d8f26e821"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-win-x64.zip"
+
+[[tools.ruby]]
+version = "3.3.0"
+backend = "core:ruby"
+
+[tools.ruby.options]
+compile = "false"
+precompiled_url = "jdx/ruby"
+ruby_build_repo = "https://github.com/rbenv/ruby-build.git"
+ruby_install = "false"
+
+[tools.ruby."platforms.linux-arm64"]
+checksum = "sha256:d03e0e1dc566aa6512baffb9373be48d36d4fde3ca9b58e0184eb5113a507eda"
+url = "https://github.com/jdx/ruby/releases/download/3.3.0-4/ruby-3.3.0.arm64_linux.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruby."platforms.linux-arm64-musl"]
+checksum = "sha256:d03e0e1dc566aa6512baffb9373be48d36d4fde3ca9b58e0184eb5113a507eda"
+url = "https://github.com/jdx/ruby/releases/download/3.3.0-4/ruby-3.3.0.arm64_linux.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruby."platforms.linux-x64"]
+checksum = "sha256:7b2cec2a09b60b225b2b216938332ea009cf17dd21b9a2096aeaf963df957641"
+url = "https://github.com/jdx/ruby/releases/download/3.3.0-4/ruby-3.3.0.x86_64_linux.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruby."platforms.linux-x64-musl"]
+checksum = "sha256:7b2cec2a09b60b225b2b216938332ea009cf17dd21b9a2096aeaf963df957641"
+url = "https://github.com/jdx/ruby/releases/download/3.3.0-4/ruby-3.3.0.x86_64_linux.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruby."platforms.macos-arm64"]
+checksum = "sha256:0f3be0a98f46c6771f546ae753a6affd5f87dda4e5fbb222424c39a7fa82a99a"
+url = "https://github.com/jdx/ruby/releases/download/3.3.0-4/ruby-3.3.0.macos.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruby."platforms.macos-x64"]
+checksum = "sha256:96518814d9832bece92a85415a819d4893b307db5921ae1f0f751a9a89a56b7d"
+url = "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0.tar.gz"
+
+[tools.ruby."platforms.windows-x64"]
+url = "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.3.0-1/rubyinstaller-3.3.0-1-x64.7z"
+
+[[tools.ruby]]
+version = "3.3.0"
+backend = "core:ruby"
+
+[tools.ruby."platforms.windows-x64"]
+url = "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.3.0-1/rubyinstaller-3.3.0-1-x64.7z"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,13 @@
 [settings]
 lockfile = true
 
+[settings.node]
+corepack = true
+
+[settings.ruby]
+compile = false
+
 [tools]
 java = "liberica-17.0.6"
+ruby = "3.3.0"
+node = "24.18.0"


### PR DESCRIPTION
Mise for local dev (java, ruby, node 24.18.0, yarn via corepack). CI: `install-mise-tools` with selective `tools:` — `java` on android jobs, `node` everywhere we had `node/install` or npm deploy. Dropped `node` orb and Node cimgs on those jobs.

PR dry-runs: typescript / esm / js-mappings deploy lanes run `yarn build` + `npm pack` (`dry_run: true`). Real publish unchanged (release tags + hold).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release/CI paths (Node version, deploy jobs, and npm publish lanes); runtime SDK code is unchanged but a mise or Node mismatch could break builds or PR dry-runs.
> 
> **Overview**
> **Standardizes local and CI tooling on mise** for Java (existing), plus Ruby **3.3.0**, Node **24.18.0**, and Yarn via corepack (`mise.toml` / `mise.lock`). Docs (`README`, `AGENTS.md`) and `android/.sdkmanrc` point developers at `mise install` instead of SDKMAN-only Java notes.
> 
> **CircleCI** drops the `node` orb and `node/install` in favor of `revenuecat/install-mise-tools` with selective `tools:` (`java` on Android jobs, `node` on TypeScript/web/error-code jobs). NPM deploy jobs move from `cimg/ruby:3.3.0-node` to `cimg/ruby:3.3.0` plus mise Node; `typescript-lint` runs on `cimg/base` with mise Node.
> 
> **PR validation** adds dry-run deploy jobs for typescript, typescript-esm, and js-mappings in the `test` workflow. **Fastlane** `build_and_publish_npm_package` accepts `dry_run`: still runs `yarn build`, but uses `npm pack` instead of `npm publish` when dry-run is true (real release deploy lanes unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95afd63d9db32fda767ecac7474d88c89d37399b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->