### PR TITLE
Enable dependency-update auto-merge from CircleCI

### DIFF
--- a/.github/workflows/auto-merge-dependencies.yml
+++ b/.github/workflows/auto-merge-dependencies.yml
@@ -5,24 +5,23 @@ on:
     types: [labeled, opened, synchronize, reopened]
 
 jobs:
-  auto-merge:
-    # Only run for PRs created by RCGitBot with the dependencies label
+  approve:
+    # Only run for PRs created by RCGitBot with the dependencies label.
+    # Auto-merge itself is enabled from CircleCI using the RCGitBot token, which
+    # is authorized to merge into the protected `main` branch. This job only
+    # provides the required approval, since RCGitBot (the PR author) cannot
+    # approve its own PR. GitHub merges the PR automatically once this approval
+    # and the required status checks are in place.
     if: |
       contains(github.event.pull_request.labels.*.name, 'pr:dependencies') &&
       github.event.pull_request.user.login == 'RCGitBot'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     steps:
       - name: Approve PR
         run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable auto-merge (squash)
-        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge-dependencies.yml
+++ b/.github/workflows/auto-merge-dependencies.yml
@@ -6,12 +6,9 @@ on:
 
 jobs:
   approve:
-    # Only run for PRs created by RCGitBot with the dependencies label.
-    # Auto-merge itself is enabled from CircleCI using the RCGitBot token, which
-    # is authorized to merge into the protected `main` branch. This job only
-    # provides the required approval, since RCGitBot (the PR author) cannot
-    # approve its own PR. GitHub merges the PR automatically once this approval
-    # and the required status checks are in place.
+    # Approves RCGitBot dependency PRs so they satisfy the required review.
+    # Auto-merge is enabled separately from CircleCI (RCGitBot can't approve
+    # its own PR).
     if: |
       contains(github.event.pull_request.labels.*.name, 'pr:dependencies') &&
       github.event.pull_request.user.login == 'RCGitBot'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -214,6 +214,18 @@ lane :open_pr_upgrading_dependencies do |options|
       body: message,
       labels: labels
     )
+
+    # Enable auto-merge so the PR merges automatically once required checks pass
+    # and it has been approved. The GITHUB_TOKEN here belongs to RCGitBot, which
+    # is authorized to merge into the protected `main` branch (unlike the
+    # github-actions[bot] token available to GitHub Actions).
+    enable_auto_merge_for_pr(
+      github_token: ENV["GITHUB_TOKEN"],
+      repo_name: repo_name,
+      branch: branch,
+      base_branch: "main",
+      merge_method: "SQUASH"
+    )
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -215,10 +215,8 @@ lane :open_pr_upgrading_dependencies do |options|
       labels: labels
     )
 
-    # Enable auto-merge so the PR merges automatically once required checks pass
-    # and it has been approved. The GITHUB_TOKEN here belongs to RCGitBot, which
-    # is authorized to merge into the protected `main` branch (unlike the
-    # github-actions[bot] token available to GitHub Actions).
+    # Uses the RCGitBot GITHUB_TOKEN, which (unlike github-actions[bot]) is
+    # authorized to merge into the protected `main` branch.
     enable_auto_merge_for_pr(
       github_token: ENV["GITHUB_TOKEN"],
       repo_name: repo_name,


### PR DESCRIPTION
The auto-merge GitHub Actions job fails with `User is not authorized for this protected branch` because it enables auto-merge as `github-actions[bot]`, which isn't on the `main` branch protection allowlist (only `@RevenueCat/sdk` is).

Enable auto-merge from CircleCI instead, using the RCGitBot token already available there (RCGitBot is an SDK team member, so it's authorized to merge). The GitHub Actions workflow is trimmed to just approve the PR since RCGitBot can't approve itself. GitHub then merges once checks pass and the approval is in.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release automation only; no application runtime changes, though misconfiguration could affect how dependency PRs merge.
> 
> **Overview**
> Fixes dependency auto-merge failing on protected `main` because **GitHub Actions** ran `gh pr merge --auto` as `github-actions[bot]`, which isn’t allowed to merge.
> 
> The **auto-merge-dependencies** workflow is reduced to an **approve** job only (renamed from `auto-merge`, `contents: write` dropped to `read`). RCGitBot still can’t self-approve, so something else must satisfy the required review before merge.
> 
> After **`open_pr_upgrading_dependencies`** creates the dependency PR, **`enable_auto_merge_for_pr`** runs in the Fastfile using the CircleCI **`GITHUB_TOKEN`** (RCGitBot), which is authorized on `main`, with **squash** merge. Merge still waits on checks plus the Actions approval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23c15d341c1a8124db2aae26a35ae5ddaadd93da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->