### PR TITLE
Add internal DangerousSettings an `useWorkflows` to PurchasesConfiguration

### DIFF
--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -341,6 +341,10 @@ export interface PurchasesConfiguration {
     apiKey: string;
     appUserID?: string | null;
     automaticDeviceIdentifierCollectionEnabled?: boolean;
+    // @internal
+    dangerousSettings?: {
+        useWorkflows?: boolean;
+    };
     diagnosticsEnabled?: boolean;
     entitlementVerificationMode?: ENTITLEMENT_VERIFICATION_MODE;
     pendingTransactionsForPrepaidPlansEnabled?: boolean;

--- a/typescript/src/purchasesConfiguration.ts
+++ b/typescript/src/purchasesConfiguration.ts
@@ -98,4 +98,16 @@ export interface PurchasesConfiguration {
    * @param localeString - The locale string (e.g., "es-ES", "en-US") or null to use system default
    */
   preferredUILocaleOverride?: string;
+
+  /**
+   * @internal
+   * Dangerous settings for the SDK. Internal RevenueCat use only.
+   */
+  dangerousSettings?: {
+    /**
+     * Enables RevenueCat Workflows (multipage paywalls). Internal RevenueCat use only;
+     * not intended for public use and may change without warning.
+     */
+    useWorkflows?: boolean;
+  };
 }


### PR DESCRIPTION
## What changed

Adds an internal-only `dangerousSettings` object (carrying `useWorkflows`) to the shared `PurchasesConfiguration` TypeScript type, so hybrid SDKs can enable RevenueCat Workflows (multipage paywalls). The field and its contents are marked `@internal` and stay out of the public API report — no new public API.

No native (iOS/Android) changes: each hybrid builds the native `DangerousSettings` from this flag in its own bridge, using hybrid-common's existing `configure`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 83e4d31faa3556984ce5195f00a06ef77b58c09b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->