### PR TITLE
fix: revert purchases-js 1.47.3 => 1.47.2 to unblock React Native builds

### DIFF
--- a/purchases-js-hybrid-mappings/package.json
+++ b/purchases-js-hybrid-mappings/package.json
@@ -30,7 +30,7 @@
     "allchecks": "npm run format && npm run lint:fix && npm run api-test && npm run test"
   },
   "dependencies": {
-    "@revenuecat/purchases-js": "1.47.3"
+    "@revenuecat/purchases-js": "1.47.2"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.42.3",

--- a/purchases-js-hybrid-mappings/yarn.lock
+++ b/purchases-js-hybrid-mappings/yarn.lock
@@ -737,10 +737,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@revenuecat/purchases-js@1.47.3":
-  version "1.47.3"
-  resolved "https://registry.yarnpkg.com/@revenuecat/purchases-js/-/purchases-js-1.47.3.tgz#08476ba84b9ab304b99a6e5b1f49f110f299b4fd"
-  integrity sha512-CfM1BWBILcDVNwoAXtgYsGlpOxY7dFqioaToBWiK4UfZa4fqphHAeOcq1JUpHWrkNv8m25srB7qSBsaT1GEWJQ==
+"@revenuecat/purchases-js@1.47.2":
+  version "1.47.2"
+  resolved "https://registry.yarnpkg.com/@revenuecat/purchases-js/-/purchases-js-1.47.2.tgz#419b1a069611a1f8113dca07da1faee15fb4b65a"
+  integrity sha512-ihFKthXnKJjStDBJ6KkmyiJ+E/OjJ8vdq4G8hcvMEvyjz4T31NKdMMgcDeEzVbV4zPpFtTWNXdcPpdPbG6q6fw==
 
 "@rollup/plugin-node-resolve@^15.2.3":
   version "15.3.1"


### PR DESCRIPTION
### Description
Reverts #1748. purchases-js 1.47.3 bundles purchases-ui-js 4.8.6, whose `web_view` host loader added a bare dynamic `import(<variable>)`. Metro's `collectDependencies` rejects a non-static `import()` at build time with no escape hatch, so React Native/Expo **Release** builds that bundle `@revenuecat/purchases-js-hybrid-mappings` fail with `TransformError: Invalid call ... import(...)` (surfaced in RevenueCat/react-native-purchases#1849).

Pinning back to 1.47.2 (ui-js 4.8.4) removes the construct: verified the rebuilt `dist/index.js` and `dist/index.umd.js` contain zero `import(` calls, and all 54 mapping tests pass.

Interim mitigation while the root cause is fixed upstream in RevenueCat/purchases-ui-js#346.

### Checklist
- [x] Description of what and why
- [x] Related PRs linked (#1748, RevenueCat/purchases-ui-js#346, RevenueCat/react-native-purchases#1849)
- [x] Covered by existing unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only downgrade with no application source changes; main risk is missing fixes from 1.47.3 until the upstream Metro issue is resolved.
> 
> **Overview**
> **Reverts the `@revenuecat/purchases-js` bump from 1.47.3 to 1.47.2** in `purchases-js-hybrid-mappings` (and the matching `yarn.lock` entry).
> 
> 1.47.3 pulls in purchases-ui-js 4.8.6, whose `web_view` loader uses a non-static dynamic `import()`, which Metro rejects when bundling this package for React Native/Expo release builds. Pinning 1.47.2 restores a dependency tree without that pattern until upstream fixes it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0118ecf56674462a9176dc329c809c819f9fac2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->