### PR TITLE
ci: bump sdks-common-config orb to 4.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 
 orbs:
   android: circleci/android@2.4.0
-  revenuecat: revenuecat/sdks-common-config@4.4.0
+  revenuecat: revenuecat/sdks-common-config@4.5.0
   macos: circleci/macos@2.0.1
 
 version: 2.1


### PR DESCRIPTION
### Motivation

The `danger` job relied on the orb's old default Ruby `3.1.2`, which no longer satisfies gems requiring Ruby >= 3.2 — `bundle install` fails as Bundler backtracks to an unbuildable `nokogiri`. (`automatic-bump`/`tag` here already pin 3.3.0.)

### Summary

- Bump `revenuecat/sdks-common-config` to `4.5.0`, whose `danger` defaults to Ruby 3.2.0 (sdks-circleci-orb#81).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI orb version bump with no application or runtime code changes; only affects CI Ruby defaults for shared orb jobs like Danger.
> 
> **Overview**
> Bumps **`revenuecat/sdks-common-config`** from **4.4.0** to **4.5.0** in `.circleci/config.yml`.
> 
> That orb version raises the default Ruby for the **`revenuecat/danger`** job from **3.1.2** to **3.2.0**, so `bundle install` in Danger can satisfy gems that require Ruby **≥ 3.2** (avoiding Bundler backtracking to an unbuildable **nokogiri**). Other workflows that already pin Ruby **3.3.0** (e.g. `automatic-bump`, `tag`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 871ac60a3c78fdc35847c1509a9726d9e32b1e26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->