### PR TITLE
Expose workflows dangerous settings to Objective-C

### DIFF
--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -35,7 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSString *appUserID __unused = [RCCommonFunctionality appUserID];
     RCDangerousSettings *dangerousSettings __unused =
-        [RCCommonFunctionality createDangerousSettingsWithUseWorkflows:YES];
+        [RCCommonFunctionality createDangerousSettingsWithAutoSyncPurchases:NO
+                                                               useWorkflows:YES];
     [RCCommonFunctionality getStorefrontWithCompletion:^(NSDictionary<NSString *,id> * _Nullable storefront) {
     }];
     [RCCommonFunctionality logInWithAppUserID:@""

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -34,6 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
     }];
 
     NSString *appUserID __unused = [RCCommonFunctionality appUserID];
+    RCDangerousSettings *dangerousSettings __unused =
+        [RCCommonFunctionality createDangerousSettingsWithUseWorkflows:YES];
     [RCCommonFunctionality getStorefrontWithCompletion:^(NSDictionary<NSString *,id> * _Nullable storefront) {
     }];
     [RCCommonFunctionality logInWithAppUserID:@""

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -39,8 +39,9 @@ import StoreKit
     @objc public static var isAnonymous: Bool { Self.sharedInstance.isAnonymous }
     @objc public static var hybridCommonVersion: String { Constants.hybridCommonVersion }
 
-    @objc public static func createDangerousSettings(useWorkflows: Bool) -> DangerousSettings {
-        DangerousSettings(useWorkflows: useWorkflows)
+    @objc public static func createDangerousSettings(autoSyncPurchases: Bool,
+                                                     useWorkflows: Bool) -> DangerousSettings {
+        DangerousSettings(autoSyncPurchases: autoSyncPurchases, useWorkflows: useWorkflows)
     }
 
     @objc public static var proxyURLString: String? {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -39,6 +39,10 @@ import StoreKit
     @objc public static var isAnonymous: Bool { Self.sharedInstance.isAnonymous }
     @objc public static var hybridCommonVersion: String { Constants.hybridCommonVersion }
 
+    @objc public static func createDangerousSettings(useWorkflows: Bool) -> DangerousSettings {
+        DangerousSettings(useWorkflows: useWorkflows)
+    }
+
     @objc public static var proxyURLString: String? {
         get { Purchases.proxyURL?.absoluteString }
         set {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
@@ -42,6 +42,19 @@ class PurchasesHybridCommonTests: QuickSpec {
             Logger.internalLogHandler = Logger.defaultLogHandler
         }
 
+        context("dangerous settings") {
+            it("creates settings with workflows enabled") {
+                let settings = CommonFunctionality.createDangerousSettings(useWorkflows: true)
+
+                expect(settings.useWorkflows) == true
+            }
+
+            it("creates settings with workflows disabled") {
+                let settings = CommonFunctionality.createDangerousSettings(useWorkflows: false)
+
+                expect(settings.useWorkflows) == false
+            }
+        }
 
         context("proxy url string") {
             it("parses the string and sets the url if valid") {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
@@ -43,15 +43,23 @@ class PurchasesHybridCommonTests: QuickSpec {
         }
 
         context("dangerous settings") {
-            it("creates settings with workflows enabled") {
-                let settings = CommonFunctionality.createDangerousSettings(useWorkflows: true)
+            it("creates settings with auto-sync disabled and workflows enabled") {
+                let settings = CommonFunctionality.createDangerousSettings(
+                    autoSyncPurchases: false,
+                    useWorkflows: true
+                )
 
+                expect(settings.autoSyncPurchases) == false
                 expect(settings.useWorkflows) == true
             }
 
-            it("creates settings with workflows disabled") {
-                let settings = CommonFunctionality.createDangerousSettings(useWorkflows: false)
+            it("creates settings with auto-sync enabled and workflows disabled") {
+                let settings = CommonFunctionality.createDangerousSettings(
+                    autoSyncPurchases: true,
+                    useWorkflows: false
+                )
 
+                expect(settings.autoSyncPurchases) == true
                 expect(settings.useWorkflows) == false
             }
         }


### PR DESCRIPTION
Flutter and Unity need to create `DangerousSettings(autoSyncPurchases:useWorkflows:)` from Objective-C. That initializer is Swift SPI, so this exposes a small factory through `RCCommonFunctionality` instead of requiring each hybrid SDK to add its own Swift bridge. Both flags are forwarded so Unity keeps its existing auto-sync behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive hybrid-common API with tests; behavior only changes when callers pass the new settings into existing configure paths.
> 
> **Overview**
> Adds an Objective-C–callable factory on **`RCCommonFunctionality`** so Flutter and Unity can build **`DangerousSettings`** without each hybrid shipping its own Swift bridge, since the RevenueCat initializer is Swift-only/SPI.
> 
> **`createDangerousSettingsWithAutoSyncPurchases:useWorkflows:`** forwards both **`autoSyncPurchases`** and **`useWorkflows`** into **`DangerousSettings`**, so existing auto-sync behavior can stay the same while workflows can be toggled at configure time.
> 
> Coverage includes the ObjC API compile test and unit tests that assert both boolean combinations on the returned settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56797dfc00b6981e462f2d3d7c0e341d5c14baae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->