### PR TITLE
Move dangerous settings factory to dedicated extension

### DIFF
--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -35,8 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSString *appUserID __unused = [RCCommonFunctionality appUserID];
     RCDangerousSettings *dangerousSettings __unused =
-        [RCCommonFunctionality createDangerousSettingsWithAutoSyncPurchases:NO
-                                                               useWorkflows:YES];
+        [RCDangerousSettings createDangerousSettingsWithAutoSyncPurchases:NO
+                                                             useWorkflows:YES];
     [RCCommonFunctionality getStorefrontWithCompletion:^(NSDictionary<NSString *,id> * _Nullable storefront) {
     }];
     [RCCommonFunctionality logInWithAppUserID:@""

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1E6A6C292E8BEEEA006C69B9 /* CommonFunctionality+PurchaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E6A6C282E8BEEEA006C69B9 /* CommonFunctionality+PurchaseTests.swift */; };
 		1EF418B12D75E3F4005E6702 /* SubscriptionInfo+HybridAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF418B02D75E3F4005E6702 /* SubscriptionInfo+HybridAdditions.swift */; };
 		1EF418B32D75E5FE005E6702 /* Enums+HybridAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF418B22D75E5FE005E6702 /* Enums+HybridAdditions.swift */; };
+		A2F0C12D35254A2AA9E4718F /* DangerousSettings+HybridAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F0C12C35254A2AA9E4718F /* DangerousSettings+HybridAdditions.swift */; };
 		2CC09B252A27E35B0047DA34 /* Offering+HybridAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC09B242A27E35B0047DA34 /* Offering+HybridAdditionsTests.swift */; };
 		2D0D2080245797B900614E47 /* Date+HybridAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0D207F245797B900614E47 /* Date+HybridAdditionsTests.swift */; };
 		2D44523E2491198A006AA26F /* CustomerInfo+HybridAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D44523D2491198A006AA26F /* CustomerInfo+HybridAdditionsTests.swift */; };
@@ -157,6 +158,7 @@
 		1E6A6C282E8BEEEA006C69B9 /* CommonFunctionality+PurchaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommonFunctionality+PurchaseTests.swift"; sourceTree = "<group>"; };
 		1EF418B02D75E3F4005E6702 /* SubscriptionInfo+HybridAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SubscriptionInfo+HybridAdditions.swift"; sourceTree = "<group>"; };
 		1EF418B22D75E5FE005E6702 /* Enums+HybridAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Enums+HybridAdditions.swift"; sourceTree = "<group>"; };
+		A2F0C12C35254A2AA9E4718F /* DangerousSettings+HybridAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DangerousSettings+HybridAdditions.swift"; sourceTree = "<group>"; };
 		21013A2D5F7BCDB086F7B742 /* Pods-PurchasesHybridCommonSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommonSwift.release.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommonSwift/Pods-PurchasesHybridCommonSwift.release.xcconfig"; sourceTree = "<group>"; };
 		2CC09B242A27E35B0047DA34 /* Offering+HybridAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Offering+HybridAdditionsTests.swift"; sourceTree = "<group>"; };
 		2D0D207F245797B900614E47 /* Date+HybridAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+HybridAdditionsTests.swift"; sourceTree = "<group>"; };
@@ -401,6 +403,7 @@
 		2DD4B8BB24377B470070344F /* PurchasesHybridCommon */ = {
 			isa = PBXGroup;
 			children = (
+				A2F0C12C35254A2AA9E4718F /* DangerousSettings+HybridAdditions.swift */,
 				357C439D2D7F376700B96769 /* RefundRequestStatus+HybridAdditions.swift */,
 				FDA322972D3035CC005233C8 /* IOSAPIAvailabilityChecker.swift */,
 				35B0D31E2BEA4ABF000CDE3F /* PrivacyInfo.xcprivacy */,
@@ -949,6 +952,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A2F0C12D35254A2AA9E4718F /* DangerousSettings+HybridAdditions.swift in Sources */,
 				2DD3D18E2810AF5A00A19EC6 /* CustomerInfo+HybridAdditions.swift in Sources */,
 				357C439E2D7F376D00B96769 /* RefundRequestStatus+HybridAdditions.swift in Sources */,
 				77D5E72A2C233E2C002ECC77 /* Constants.swift in Sources */,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -39,11 +39,6 @@ import StoreKit
     @objc public static var isAnonymous: Bool { Self.sharedInstance.isAnonymous }
     @objc public static var hybridCommonVersion: String { Constants.hybridCommonVersion }
 
-    @objc public static func createDangerousSettings(autoSyncPurchases: Bool,
-                                                     useWorkflows: Bool) -> DangerousSettings {
-        DangerousSettings(autoSyncPurchases: autoSyncPurchases, useWorkflows: useWorkflows)
-    }
-
     @objc public static var proxyURLString: String? {
         get { Purchases.proxyURL?.absoluteString }
         set {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/DangerousSettings+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/DangerousSettings+HybridAdditions.swift
@@ -1,0 +1,23 @@
+//
+//  DangerousSettings+HybridAdditions.swift
+//  PurchasesHybridCommon
+//
+//  Copyright © 2025 RevenueCat. All rights reserved.
+//
+
+import Foundation
+@_spi(Internal) @_spi(Experimental) import RevenueCat
+
+@objc public extension DangerousSettings {
+
+    /// Creates a ``DangerousSettings`` with the given values.
+    ///
+    /// `useWorkflows` is only exposed through RevenueCat's `@_spi(Internal)` API, so hybrid SDKs can't
+    /// construct ``DangerousSettings`` with it directly. This bridges it into the Objective-C-visible surface.
+    @objc(createDangerousSettingsWithAutoSyncPurchases:useWorkflows:)
+    static func createDangerousSettings(autoSyncPurchases: Bool,
+                                        useWorkflows: Bool) -> DangerousSettings {
+        DangerousSettings(autoSyncPurchases: autoSyncPurchases, useWorkflows: useWorkflows)
+    }
+
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PurchasesHybridCommonTests.swift
@@ -44,7 +44,7 @@ class PurchasesHybridCommonTests: QuickSpec {
 
         context("dangerous settings") {
             it("creates settings with auto-sync disabled and workflows enabled") {
-                let settings = CommonFunctionality.createDangerousSettings(
+                let settings = DangerousSettings.createDangerousSettings(
                     autoSyncPurchases: false,
                     useWorkflows: true
                 )
@@ -54,7 +54,7 @@ class PurchasesHybridCommonTests: QuickSpec {
             }
 
             it("creates settings with auto-sync enabled and workflows disabled") {
-                let settings = CommonFunctionality.createDangerousSettings(
+                let settings = DangerousSettings.createDangerousSettings(
                     autoSyncPurchases: true,
                     useWorkflows: false
                 )


### PR DESCRIPTION
Cleanup from #1770.

`DangerousSettings` now owns the workflows factory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API surface relocation with equivalent factory logic; main risk is any external code still calling the removed CommonFunctionality factory.
> 
> **Overview**
> Moves **`createDangerousSettings(autoSyncPurchases:useWorkflows:)`** from `CommonFunctionality` onto a new **`DangerousSettings+HybridAdditions`** extension so `DangerousSettings` owns the hybrid factory (cleanup after #1770).
> 
> The factory behavior is unchanged: it still builds `DangerousSettings` with `useWorkflows`, which hybrid SDKs need because that flag is only available via RevenueCat’s internal SPI. The Objective-C selector **`createDangerousSettingsWithAutoSyncPurchases:useWorkflows:`** is preserved on `DangerousSettings`.
> 
> Call sites now use **`DangerousSettings.createDangerousSettings`** instead of **`RCCommonFunctionality`**, including ObjC API tests and unit tests. The new Swift file is wired into the PurchasesHybridCommon Xcode target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733555fc7dacb464f4c09714cae6f298a2a62764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->