### PR TITLE
Add onWebCheckoutOpened and onUrlOpened to paywall listener bridge

### DIFF
--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallListenerWrapper.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallListenerWrapper.kt
@@ -57,6 +57,10 @@ abstract class PaywallListenerWrapper : PaywallListener {
         this.onRestoreError(error = error.map().info)
     }
 
+    override fun onWebCheckoutOpened() {
+        // No native data to map; overridable directly since there's nothing to forward.
+    }
+
     abstract fun onPurchaseStarted(rcPackage: Map<String, Any?>)
     abstract fun onPurchaseCompleted(customerInfo: Map<String, Any?>, storeTransaction: Map<String, Any?>)
     abstract fun onPurchaseError(error: Map<String, Any?>)

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallListenerWrapper.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallListenerWrapper.kt
@@ -57,14 +57,6 @@ abstract class PaywallListenerWrapper : PaywallListener {
         this.onRestoreError(error = error.map().info)
     }
 
-    override fun onWebCheckoutOpened() {
-        // No native data to map; overridable directly since there's nothing to forward.
-    }
-
-    override fun onUrlOpened(url: String) {
-        // url is already a hybrid-friendly String; overridable directly since there's nothing to map.
-    }
-
     abstract fun onPurchaseStarted(rcPackage: Map<String, Any?>)
     abstract fun onPurchaseCompleted(customerInfo: Map<String, Any?>, storeTransaction: Map<String, Any?>)
     abstract fun onPurchaseError(error: Map<String, Any?>)

--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallListenerWrapper.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallListenerWrapper.kt
@@ -61,6 +61,10 @@ abstract class PaywallListenerWrapper : PaywallListener {
         // No native data to map; overridable directly since there's nothing to forward.
     }
 
+    override fun onUrlOpened(url: String) {
+        // url is already a hybrid-friendly String; overridable directly since there's nothing to map.
+    }
+
     abstract fun onPurchaseStarted(rcPackage: Map<String, Any?>)
     abstract fun onPurchaseCompleted(customerInfo: Map<String, Any?>, storeTransaction: Map<String, Any?>)
     abstract fun onPurchaseError(error: Map<String, Any?>)

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallProxy.swift
@@ -478,6 +478,10 @@ extension PaywallProxy: PaywallViewControllerDelegate {
         self.delegate?.paywallViewControllerDidOpenWebCheckout?(controller)
     }
 
+    public func paywallViewController(_ controller: PaywallViewController, didOpenURL url: URL) {
+        self.delegate?.paywallViewController?(controller, didOpenURL: url)
+    }
+
     public func paywallViewController(_ controller: PaywallViewController,
                                       didFailPurchasingWith error: NSError) {
         let errorContainer = ErrorContainer(error: error, extraPayload: [:])

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallProxy.swift
@@ -474,6 +474,10 @@ extension PaywallProxy: PaywallViewControllerDelegate {
         self.delegate?.paywallViewControllerDidCancelPurchase?(controller)
     }
 
+    public func paywallViewControllerDidOpenWebCheckout(_ controller: PaywallViewController) {
+        self.delegate?.paywallViewControllerDidOpenWebCheckout?(controller)
+    }
+
     public func paywallViewController(_ controller: PaywallViewController,
                                       didFailPurchasingWith error: NSError) {
         let errorContainer = ErrorContainer(error: error, extraPayload: [:])

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallProxy.swift
@@ -479,7 +479,7 @@ extension PaywallProxy: PaywallViewControllerDelegate {
     }
 
     public func paywallViewController(_ controller: PaywallViewController, didOpenURL url: URL) {
-        self.delegate?.paywallViewController?(controller, didOpenURL: url)
+        self.delegate?.paywallViewController?(controller, didOpenURL: url.absoluteString)
     }
 
     public func paywallViewController(_ controller: PaywallViewController,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallViewControllerDelegateWrapper.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallViewControllerDelegateWrapper.swift
@@ -39,6 +39,10 @@ public protocol PaywallViewControllerDelegateWrapper: AnyObject {
     @objc(paywallViewControllerDidCancelPurchase:)
     optional func paywallViewControllerDidCancelPurchase(_ controller: PaywallViewController)
 
+    /// Notifies that the user tapped a web checkout CTA and left the app to complete payment externally.
+    @objc(paywallViewControllerDidOpenWebCheckout:)
+    optional func paywallViewControllerDidOpenWebCheckout(_ controller: PaywallViewController)
+
     /// Notifies that the purchase operation has failed in a ``PaywallViewController``.
     @objc(paywallViewController:didFailPurchasingWithErrorDictionary:)
     optional func paywallViewController(_ controller: PaywallViewController,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallViewControllerDelegateWrapper.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallViewControllerDelegateWrapper.swift
@@ -43,6 +43,11 @@ public protocol PaywallViewControllerDelegateWrapper: AnyObject {
     @objc(paywallViewControllerDidOpenWebCheckout:)
     optional func paywallViewControllerDidOpenWebCheckout(_ controller: PaywallViewController)
 
+    /// Notifies that the paywall successfully opened a URL, either from a button with a URL destination
+    /// or from a link inside a text component. Not called for web checkout URLs.
+    @objc(paywallViewController:didOpenURL:)
+    optional func paywallViewController(_ controller: PaywallViewController, didOpenURL url: URL)
+
     /// Notifies that the purchase operation has failed in a ``PaywallViewController``.
     @objc(paywallViewController:didFailPurchasingWithErrorDictionary:)
     optional func paywallViewController(_ controller: PaywallViewController,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallViewControllerDelegateWrapper.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallViewControllerDelegateWrapper.swift
@@ -46,7 +46,7 @@ public protocol PaywallViewControllerDelegateWrapper: AnyObject {
     /// Notifies that the paywall successfully opened a URL, either from a button with a URL destination
     /// or from a link inside a text component. Not called for web checkout URLs.
     @objc(paywallViewController:didOpenURL:)
-    optional func paywallViewController(_ controller: PaywallViewController, didOpenURL url: URL)
+    optional func paywallViewController(_ controller: PaywallViewController, didOpenURL url: String)
 
     /// Notifies that the purchase operation has failed in a ``PaywallViewController``.
     @objc(paywallViewController:didFailPurchasingWithErrorDictionary:)


### PR DESCRIPTION
Exposes:
- `onWebCheckoutOpened`: RevenueCat/purchases-ios#7260, RevenueCat/purchases-android#3809
- `onUrlOpened`: RevenueCat/purchases-ios#7320, RevenueCat/purchases-android#3859

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional delegate forwarding with no changes to purchase, restore, or dismissal flows.
> 
> **Overview**
> Extends the iOS paywall hybrid bridge so **RevenueCatUI** callbacks for external web checkout and non-checkout URL opens reach hybrid SDK listeners.
> 
> **`PaywallViewControllerDelegateWrapper`** adds two optional `@objc` methods: `paywallViewControllerDidOpenWebCheckout` (user left the app via a web checkout CTA) and `paywallViewController(_:didOpenURL:)` with a **String** URL (button/link opens; not web-checkout URLs).
> 
> **`PaywallProxy`** implements the matching `PaywallViewControllerDelegate` methods and forwards them to the wrapper delegate, converting `URL` to `absoluteString` for the URL callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15a5184c73b2a8822fd2ec8e5f216fde53ae2373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->