### PR TITLE
Wait for CocoaPods before dependency updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,6 +350,16 @@ jobs:
           name: Make GitHub release for current version
           command: bundle exec fastlane github_release_current
 
+  wait-for-ios-pods:
+    docker:
+      - image: cimg/ruby:3.3.0
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Wait for RevenueCat pods to reach the CocoaPods CDN
+          command: ruby scripts/wait-for-cocoapods
+
   dependency-update:
     <<: *base-ios-job
     steps:
@@ -585,7 +595,10 @@ workflows:
             - equal: [ "update-native-dependencies", << pipeline.schedule.name >> ]
         - equal: [ dependency-update, << pipeline.parameters.action >> ]
     jobs:
-      - dependency-update
+      - wait-for-ios-pods
+      - dependency-update:
+          requires:
+            - wait-for-ios-pods
 
   danger:
     when:

--- a/docs/superpowers/plans/2026-07-31-cocoapods-propagation-retries.md
+++ b/docs/superpowers/plans/2026-07-31-cocoapods-propagation-retries.md
@@ -4,7 +4,7 @@
 
 **Goal:** Prevent `dependency-update` from failing while new RevenueCat pods propagate, without holding an expensive macOS executor for up to an hour.
 
-**Architecture:** A standalone Ruby preflight selects the latest stable `purchases-ios` release in the current major and polls the CocoaPods CDN version shards for both required pods. CircleCI runs it on a small Linux executor before the existing macOS job; a separate pure-Ruby helper gives the final `pod install` short retries and skips that command when iOS is unchanged.
+**Architecture:** A standalone Ruby preflight selects the latest stable `purchases-ios` release in the current major and polls the CocoaPods CDN version shards and exact podspec objects for both required pods. CircleCI runs it on a small Linux executor before the existing macOS job; a separate pure-Ruby helper gives the final `pod install` short retries and skips that command when iOS is unchanged.
 
 **Tech Stack:** Ruby 3.3 standard library (`net/http`, `json`, `digest`, `rubygems`, `minitest`), Fastlane, CocoaPods, CircleCI 2.1.
 
@@ -78,6 +78,7 @@ module CocoaPodsPropagation
   GITHUB_RELEASES_URI =
     URI("https://api.github.com/repos/RevenueCat/purchases-ios/releases?per_page=100")
   COCOAPODS_CDN_BASE = "https://cdn.cocoapods.org"
+  COCOAPODS_SPECS_BASE = "https://cdn.jsdelivr.net/cocoa/Specs"
   REQUIRED_PODS = %w[RevenueCat RevenueCatUI].freeze
 
   class ReleaseFinder
@@ -107,14 +108,30 @@ module CocoaPodsPropagation
       shard = Digest::MD5.hexdigest(pod_name).chars.first(3).join("_")
       body = @http.get(URI("#{COCOAPODS_CDN_BASE}/all_pods_versions_#{shard}.txt")).body
       line = body.lines.find { |entry| entry.start_with?("#{pod_name}/") }
-      line&.split("/")&.drop(1)&.map(&:strip)&.include?(version.to_s) || false
+      versions = line&.split("/")&.drop(1)&.map(&:strip) || []
+      return false unless versions.include?(version.to_s)
+
+      spec_response = @http.get(spec_uri(pod_name, version))
+      spec_response.code.to_i.between?(200, 299)
+    end
+
+    private
+
+    def spec_uri(pod_name, version)
+      path = Digest::MD5.hexdigest(pod_name).chars.first(3).join("/")
+      URI(
+        "#{COCOAPODS_SPECS_BASE}/#{path}/#{pod_name}/#{version}/" \
+        "#{pod_name}.podspec.json"
+      )
     end
   end
 end
 ```
 
 Add explicit non-success HTTP handling so GitHub and CDN response codes outside
-200–299 raise a descriptive error that the waiter can retry.
+200–299 raise a descriptive error that the waiter can retry. Add a test where
+the version is indexed but the exact podspec returns 404, and assert that the
+pod is still unavailable.
 
 - [ ] **Step 4: Run the focused test and verify release/CDN checks pass**
 

--- a/docs/superpowers/plans/2026-07-31-cocoapods-propagation-retries.md
+++ b/docs/superpowers/plans/2026-07-31-cocoapods-propagation-retries.md
@@ -1,0 +1,492 @@
+# CocoaPods Propagation Retries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent `dependency-update` from failing while new RevenueCat pods propagate, without holding an expensive macOS executor for up to an hour.
+
+**Architecture:** A standalone Ruby preflight selects the latest stable `purchases-ios` release in the current major and polls the CocoaPods CDN version shards for both required pods. CircleCI runs it on a small Linux executor before the existing macOS job; a separate pure-Ruby helper gives the final `pod install` short retries and skips that command when iOS is unchanged.
+
+**Tech Stack:** Ruby 3.3 standard library (`net/http`, `json`, `digest`, `rubygems`, `minitest`), Fastlane, CocoaPods, CircleCI 2.1.
+
+## Global Constraints
+
+- Poll CocoaPods every 300 seconds for up to 3,600 seconds.
+- Require both `RevenueCat` and `RevenueCatUI` before starting macOS work.
+- Keep the existing `pod install --repo-update` as the final source of truth.
+- Do not change public SDK APIs or any platform minimum version.
+- Do not update `fastlane-plugin-revenuecat_internal`; the lockfile already points at upstream `main`.
+- Do not split dependency updates into separate pull requests.
+
+---
+
+## File Structure
+
+- Create `fastlane/lib/cocoapods_propagation.rb`: release selection, CocoaPods CDN availability checks, and bounded polling.
+- Create `scripts/wait-for-cocoapods`: thin executable entry point for CircleCI.
+- Create `fastlane/test/cocoapods_propagation_test.rb`: deterministic tests with fake HTTP responses and no real sleep.
+- Create `fastlane/lib/dependency_update_resilience.rb`: bounded retry helper plus conditional execution when the iOS version changes.
+- Create `fastlane/test/dependency_update_resilience_test.rb`: deterministic retry and conditional-execution tests.
+- Modify `fastlane/Fastfile`: use the resilience helper around `pod install` and only invoke it for an iOS change.
+- Modify `.circleci/config.yml`: add the Linux preflight job and make the macOS dependency-update job depend on it.
+
+### Task 1: CocoaPods CDN Readiness Utility
+
+**Files:**
+- Create: `fastlane/lib/cocoapods_propagation.rb`
+- Create: `scripts/wait-for-cocoapods`
+- Create: `fastlane/test/cocoapods_propagation_test.rb`
+
+**Interfaces:**
+- Produces: `CocoaPodsPropagation::ReleaseFinder#latest_stable_same_major(current_version) -> Gem::Version`
+- Produces: `CocoaPodsPropagation::CdnChecker#available?(pod_name, version) -> Boolean`
+- Produces: `CocoaPodsPropagation::Waiter#wait(current_version) -> :current | :available`
+- Raises: `CocoaPodsPropagation::TimeoutError` after the configured attempt limit.
+- CLI environment: `COCOAPODS_WAIT_INTERVAL_SECONDS` defaults to `300`; `COCOAPODS_WAIT_MAX_SECONDS` defaults to `3600`; `GITHUB_TOKEN` is optional.
+
+- [ ] **Step 1: Write failing release-selection and CDN-shard tests**
+
+Create `fastlane/test/cocoapods_propagation_test.rb` with fake HTTP objects and tests that assert:
+
+```ruby
+finder = CocoaPodsPropagation::ReleaseFinder.new(http: fake_http)
+assert_equal Gem::Version.new("5.83.0"),
+             finder.latest_stable_same_major(Gem::Version.new("5.82.0"))
+
+checker = CocoaPodsPropagation::CdnChecker.new(http: fake_http)
+assert checker.available?("RevenueCat", Gem::Version.new("5.83.0"))
+refute checker.available?("RevenueCatUI", Gem::Version.new("5.83.0"))
+```
+
+The release fixture must include a draft, a prerelease, a stable `6.0.0`, and stable `5.82.0`/`5.83.0` releases so the test proves filtering and same-major selection. The CDN fixture for `RevenueCat` must include a single slash-delimited line containing `5.83.0`; the `RevenueCatUI` fixture must omit it.
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+ruby -Ifastlane/lib fastlane/test/cocoapods_propagation_test.rb
+```
+
+Expected: failure with `cannot load such file -- cocoapods_propagation`.
+
+- [ ] **Step 3: Implement release selection and CDN checks**
+
+Create `fastlane/lib/cocoapods_propagation.rb` with:
+
+```ruby
+module CocoaPodsPropagation
+  GITHUB_RELEASES_URI =
+    URI("https://api.github.com/repos/RevenueCat/purchases-ios/releases?per_page=100")
+  COCOAPODS_CDN_BASE = "https://cdn.cocoapods.org"
+  REQUIRED_PODS = %w[RevenueCat RevenueCatUI].freeze
+
+  class ReleaseFinder
+    def initialize(http:, github_token: nil)
+      @http = http
+      @github_token = github_token
+    end
+
+    def latest_stable_same_major(current_version)
+      releases = JSON.parse(@http.get(GITHUB_RELEASES_URI, headers).body)
+      versions = releases.filter_map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        version = Gem::Version.new(release.fetch("tag_name").delete_prefix("v"))
+        version if version.segments.first == current_version.segments.first
+      end
+      versions.max || current_version
+    end
+  end
+
+  class CdnChecker
+    def initialize(http:)
+      @http = http
+    end
+
+    def available?(pod_name, version)
+      shard = Digest::MD5.hexdigest(pod_name).chars.first(3).join("_")
+      body = @http.get(URI("#{COCOAPODS_CDN_BASE}/all_pods_versions_#{shard}.txt")).body
+      line = body.lines.find { |entry| entry.start_with?("#{pod_name}/") }
+      line&.split("/")&.drop(1)&.map(&:strip)&.include?(version.to_s) || false
+    end
+  end
+end
+```
+
+Add explicit non-success HTTP handling so GitHub and CDN response codes outside
+200–299 raise a descriptive error that the waiter can retry.
+
+- [ ] **Step 4: Run the focused test and verify release/CDN checks pass**
+
+Run:
+
+```bash
+ruby -Ifastlane/lib fastlane/test/cocoapods_propagation_test.rb
+```
+
+Expected: release-selection and CDN-check tests pass.
+
+- [ ] **Step 5: Add failing waiter tests**
+
+Extend `fastlane/test/cocoapods_propagation_test.rb` with:
+
+```ruby
+assert_equal :current, waiter.wait(Gem::Version.new("5.83.0"))
+assert_equal :available, waiter.wait(Gem::Version.new("5.82.0"))
+assert_equal [300, 300], sleeps
+assert_raises(CocoaPodsPropagation::TimeoutError) do
+  timeout_waiter.wait(Gem::Version.new("5.82.0"))
+end
+```
+
+Use fakes where both pod checks become true on the third attempt, and a second
+fake where at least one pod remains false for every attempt. Configure
+`max_seconds: 600` and `interval_seconds: 300`, which means an immediate check
+plus checks after two sleeps. Make the first release lookup raise a request
+error before returning normally so the same success test proves transient
+GitHub failures are retried.
+
+- [ ] **Step 6: Run the waiter tests and verify they fail**
+
+Run:
+
+```bash
+ruby -Ifastlane/lib fastlane/test/cocoapods_propagation_test.rb
+```
+
+Expected: failure because `CocoaPodsPropagation::Waiter` and
+`CocoaPodsPropagation::TimeoutError` are not defined.
+
+- [ ] **Step 7: Implement bounded polling and the CLI**
+
+Add `CocoaPodsPropagation::NetHttpClient`, `TimeoutError`, and `Waiter`. The
+waiter must recalculate the candidate release on each attempt, exit `:current`
+when it is not newer, check both `REQUIRED_PODS`, log missing pods, rescue
+request/parse errors as retryable, and perform exactly
+`max_seconds / interval_seconds` sleeps before raising `TimeoutError`.
+
+Create `scripts/wait-for-cocoapods`:
+
+```ruby
+#!/usr/bin/env ruby
+
+require_relative "../fastlane/lib/cocoapods_propagation"
+
+current_version_text = File.read(
+  File.expand_path("../PurchasesHybridCommon.podspec", __dir__)
+)[/s\.dependency 'RevenueCat', '([^']+)'/, 1]
+abort("Could not read the current RevenueCat version") unless current_version_text
+
+http = CocoaPodsPropagation::NetHttpClient.new
+finder = CocoaPodsPropagation::ReleaseFinder.new(
+  http: http,
+  github_token: ENV["GITHUB_TOKEN"]
+)
+checker = CocoaPodsPropagation::CdnChecker.new(http: http)
+waiter = CocoaPodsPropagation::Waiter.new(
+  release_finder: finder,
+  cdn_checker: checker,
+  interval_seconds: Integer(ENV.fetch("COCOAPODS_WAIT_INTERVAL_SECONDS", "300")),
+  max_seconds: Integer(ENV.fetch("COCOAPODS_WAIT_MAX_SECONDS", "3600")),
+  sleeper: ->(seconds) { sleep(seconds) },
+  logger: ->(message) { puts(message) }
+)
+
+waiter.wait(Gem::Version.new(current_version_text))
+```
+
+Rescue `CocoaPodsPropagation::TimeoutError` in the CLI, print its message with
+`warn`, and exit `1`.
+
+- [ ] **Step 8: Run utility tests and syntax checks**
+
+Run:
+
+```bash
+ruby -Ifastlane/lib fastlane/test/cocoapods_propagation_test.rb
+ruby -c fastlane/lib/cocoapods_propagation.rb
+ruby -c scripts/wait-for-cocoapods
+```
+
+Expected: all tests pass and both syntax checks print `Syntax OK`.
+
+- [ ] **Step 9: Commit the readiness utility**
+
+```bash
+git add fastlane/lib/cocoapods_propagation.rb \
+  fastlane/test/cocoapods_propagation_test.rb \
+  scripts/wait-for-cocoapods
+git commit -m "ci: wait for RevenueCat pods to propagate"
+```
+
+### Task 2: Fastlane Last-Mile Resilience
+
+**Files:**
+- Create: `fastlane/lib/dependency_update_resilience.rb`
+- Create: `fastlane/test/dependency_update_resilience_test.rb`
+- Modify: `fastlane/Fastfile:1-5`
+- Modify: `fastlane/Fastfile:234-252`
+- Modify: `fastlane/Fastfile:376-381`
+
+**Interfaces:**
+- Produces: `DependencyUpdateResilience.with_retries(max_attempts:, initial_delay:, sleeper:, logger:) { ... }`
+- Produces: `DependencyUpdateResilience.if_ios_changed(current_version:, new_version:) { ... } -> Boolean`
+- Consumes: Fastlane `sh("pod install --repo-update")` inside the retry block.
+
+- [ ] **Step 1: Write failing retry and conditional-execution tests**
+
+Create `fastlane/test/dependency_update_resilience_test.rb` with tests that:
+
+```ruby
+attempts = 0
+result = DependencyUpdateResilience.with_retries(
+  max_attempts: 3,
+  initial_delay: 30,
+  sleeper: ->(seconds) { sleeps << seconds },
+  logger: ->(message) { messages << message }
+) do
+  attempts += 1
+  raise "transient" if attempts < 3
+  :installed
+end
+assert_equal :installed, result
+assert_equal [30, 60], sleeps
+
+assert_raises(RuntimeError) do
+  DependencyUpdateResilience.with_retries(
+    max_attempts: 3,
+    initial_delay: 30,
+    sleeper: ->(_seconds) {},
+    logger: ->(_message) {}
+  ) { raise "permanent" }
+end
+
+refute DependencyUpdateResilience.if_ios_changed(
+  current_version: "5.83.0",
+  new_version: "5.83.0"
+) { flunk("must not yield") }
+
+assert DependencyUpdateResilience.if_ios_changed(
+  current_version: "5.82.0",
+  new_version: "5.83.0"
+) { yielded = true }
+assert yielded
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+ruby -Ifastlane/lib fastlane/test/dependency_update_resilience_test.rb
+```
+
+Expected: failure with
+`cannot load such file -- dependency_update_resilience`.
+
+- [ ] **Step 3: Implement the pure-Ruby helper**
+
+Create `fastlane/lib/dependency_update_resilience.rb`:
+
+```ruby
+module DependencyUpdateResilience
+  def self.with_retries(max_attempts:, initial_delay:, sleeper:, logger:)
+    attempt = 0
+    begin
+      attempt += 1
+      yield
+    rescue StandardError => error
+      raise if attempt >= max_attempts
+
+      delay = initial_delay * (2**(attempt - 1))
+      logger.call(
+        "pod install failed on attempt #{attempt}/#{max_attempts}: " \
+        "#{error.message}. Retrying in #{delay} seconds."
+      )
+      sleeper.call(delay)
+      retry
+    end
+  end
+
+  def self.if_ios_changed(current_version:, new_version:)
+    return false if current_version == new_version
+
+    yield
+    true
+  end
+end
+```
+
+- [ ] **Step 4: Run the helper tests and verify they pass**
+
+Run:
+
+```bash
+ruby -Ifastlane/lib fastlane/test/dependency_update_resilience_test.rb
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Wire the helper into Fastlane**
+
+At the top of `fastlane/Fastfile`, add:
+
+```ruby
+require_relative "lib/dependency_update_resilience"
+```
+
+Replace the unconditional call after native updates with:
+
+```ruby
+DependencyUpdateResilience.if_ios_changed(
+  current_version: current_ios_version,
+  new_version: latest_ios_release
+) do
+  run_pod_install
+end
+```
+
+Wrap `pod install` in:
+
+```ruby
+DependencyUpdateResilience.with_retries(
+  max_attempts: 3,
+  initial_delay: 30,
+  sleeper: ->(seconds) { sleep(seconds) },
+  logger: ->(message) { UI.important(message) }
+) do
+  sh("pod install --repo-update")
+end
+```
+
+- [ ] **Step 6: Run helper tests and Fastfile syntax validation**
+
+Run:
+
+```bash
+ruby -Ifastlane/lib fastlane/test/dependency_update_resilience_test.rb
+ruby -c fastlane/Fastfile
+```
+
+Expected: tests pass and syntax validation prints `Syntax OK`.
+
+- [ ] **Step 7: Commit Fastlane resilience**
+
+```bash
+git add fastlane/lib/dependency_update_resilience.rb \
+  fastlane/test/dependency_update_resilience_test.rb \
+  fastlane/Fastfile
+git commit -m "ci: retry dependency update pod install"
+```
+
+### Task 3: CircleCI Preflight Wiring and Full Verification
+
+**Files:**
+- Modify: `.circleci/config.yml:353-370`
+- Modify: `.circleci/config.yml:580-589`
+
+**Interfaces:**
+- Consumes: `scripts/wait-for-cocoapods`.
+- Produces: CircleCI job `wait-for-ios-pods`.
+- Changes: workflow job `dependency-update` requires `wait-for-ios-pods`.
+
+- [ ] **Step 1: Add the Linux readiness job**
+
+Before the existing `dependency-update` job, add:
+
+```yaml
+  wait-for-ios-pods:
+    docker:
+      - image: cimg/ruby:3.3.0
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Wait for RevenueCat pods to reach the CocoaPods CDN
+          command: ruby scripts/wait-for-cocoapods
+```
+
+- [ ] **Step 2: Gate the macOS job in the workflow**
+
+Change the dependency-update workflow jobs to:
+
+```yaml
+    jobs:
+      - wait-for-ios-pods
+      - dependency-update:
+          requires:
+            - wait-for-ios-pods
+```
+
+- [ ] **Step 3: Validate CircleCI configuration**
+
+Run:
+
+```bash
+circleci config validate .circleci/config.yml
+```
+
+Expected: `Config file at .circleci/config.yml is valid.`
+
+- [ ] **Step 4: Run all new tests and syntax checks**
+
+Run:
+
+```bash
+ruby -Ifastlane/lib fastlane/test/cocoapods_propagation_test.rb
+ruby -Ifastlane/lib fastlane/test/dependency_update_resilience_test.rb
+ruby -c fastlane/lib/cocoapods_propagation.rb
+ruby -c fastlane/lib/dependency_update_resilience.rb
+ruby -c scripts/wait-for-cocoapods
+ruby -c fastlane/Fastfile
+```
+
+Expected: all tests pass and every syntax check prints `Syntax OK`.
+
+- [ ] **Step 5: Exercise the preflight against current live metadata**
+
+Run:
+
+```bash
+COCOAPODS_WAIT_INTERVAL_SECONDS=1 \
+COCOAPODS_WAIT_MAX_SECONDS=2 \
+ruby scripts/wait-for-cocoapods
+```
+
+Expected: exit `0`; because the latest currently selected release is already on
+the CocoaPods CDN, the script exits on its first check without sleeping.
+
+- [ ] **Step 6: Review the complete diff**
+
+Run:
+
+```bash
+git diff --check origin/main...
+git diff --stat origin/main...
+git status --short
+```
+
+Expected: no whitespace errors; only the design, plan, readiness utility/tests,
+Fastlane helper/tests, Fastfile, executable, and CircleCI configuration differ
+from `origin/main`.
+
+- [ ] **Step 7: Commit CircleCI wiring**
+
+```bash
+git add .circleci/config.yml
+git commit -m "ci: gate dependency updates on CocoaPods CDN"
+```
+
+- [ ] **Step 8: Re-run verification from the committed tree**
+
+Run:
+
+```bash
+circleci config validate .circleci/config.yml
+ruby -Ifastlane/lib fastlane/test/cocoapods_propagation_test.rb
+ruby -Ifastlane/lib fastlane/test/dependency_update_resilience_test.rb
+git status --short
+```
+
+Expected: CircleCI configuration valid, all tests pass, and the worktree is
+clean.

--- a/docs/superpowers/specs/2026-07-31-cocoapods-propagation-retries-design.md
+++ b/docs/superpowers/specs/2026-07-31-cocoapods-propagation-retries-design.md
@@ -1,0 +1,107 @@
+# CocoaPods Propagation Retry Design
+
+## Problem
+
+The scheduled `dependency-update` workflow discovers the latest stable
+`purchases-ios` GitHub release and immediately updates this repository to use
+that version. CocoaPods CDN metadata can take significantly longer to expose a
+newly published `RevenueCat` or `RevenueCatUI` version. On 2026-07-31, this
+propagation took roughly 45 minutes.
+
+The workflow currently runs `pod install --repo-update` once on an
+`m4pro.medium` macOS executor. A missing CDN entry therefore fails the whole
+dependency update, while waiting for propagation directly in that job would
+hold an expensive macOS executor.
+
+The internal Fastlane plugin is already pinned to its upstream `main` revision,
+so no plugin update is available or required.
+
+## Design
+
+### CocoaPods readiness preflight
+
+Add a small Linux job before the existing macOS `dependency-update` job. The
+preflight will:
+
+1. Read the current iOS dependency version from the repository.
+2. Query GitHub for the latest stable `purchases-ios` release in the same major
+   version.
+3. Exit immediately when there is no newer iOS release.
+4. Poll the CocoaPods CDN version-index shards for both `RevenueCat` and
+   `RevenueCatUI`.
+5. Continue only when both pods list the selected version.
+
+The check will run immediately and then every five minutes for up to one hour.
+Transient GitHub or CDN request failures will be treated as unavailable and
+retried. On timeout, the job will report the selected version and which pods
+were still unavailable. The macOS dependency-update job will require this
+preflight and will not start if it times out.
+
+The preflight will use a repository-owned Ruby utility with injectable HTTP and
+sleep behavior. This keeps the CircleCI configuration small and allows the
+selection, availability, retry, success, and timeout behavior to be tested
+without real waits or network calls.
+
+### Last-mile `pod install` retries
+
+The Fastlane `run_pod_install` lane will retain the real
+`pod install --repo-update` as the source of truth. It will make up to three
+total attempts with short exponential delays between failures. These retries
+cover transient networking and the small interval between a successful CDN
+preflight and CocoaPods resolving its metadata.
+
+The final failure will remain visible and fail the dependency update. The retry
+loop will not swallow permanent CocoaPods errors.
+
+### Avoid unnecessary CocoaPods work
+
+`update_native_dependencies_to_latest` will call `run_pod_install` only when
+the selected iOS version differs from the current iOS version. Android-only and
+JavaScript-only dependency updates will no longer perform CocoaPods network
+work.
+
+## Data flow
+
+```text
+CircleCI schedule/manual trigger
+        |
+        v
+small Linux CocoaPods readiness job
+        |
+        +-- no new iOS version ----------------------+
+        |                                            |
+        +-- new version -> poll RevenueCat + UI CDN  |
+                             |                       |
+                             +-- timeout -> fail     |
+                             |                       |
+                             v                       v
+                    macOS dependency-update job
+                             |
+                             +-- update iOS files and SwiftPM resolution
+                             +-- update Android and JavaScript files
+                             +-- iOS changed? -> pod install with short retries
+                             +-- open dependency-update pull request
+```
+
+## Testing
+
+Automated tests will cover:
+
+- selecting the latest stable release within the current major version;
+- exiting immediately when the iOS dependency is already current;
+- waiting until both CocoaPods CDN entries become available;
+- retrying request failures;
+- reporting a timeout after the configured attempt limit;
+- retrying `pod install` and succeeding after a transient failure;
+- failing after the final `pod install` attempt;
+- skipping `pod install` when the iOS version is unchanged.
+
+The CircleCI configuration will be validated locally, and the Ruby/Fastlane
+tests will be run before completion.
+
+## Out of scope
+
+- Changing the `purchases-ios` release process.
+- Splitting iOS, Android, and JavaScript updates into separate pull requests.
+- Adding a general-purpose retry action to the internal Fastlane plugin.
+- Retrying unrelated permanent failures for an hour.

--- a/docs/superpowers/specs/2026-07-31-cocoapods-propagation-retries-design.md
+++ b/docs/superpowers/specs/2026-07-31-cocoapods-propagation-retries-design.md
@@ -27,8 +27,8 @@ preflight will:
 2. Query GitHub for the latest stable `purchases-ios` release in the same major
    version.
 3. Exit immediately when there is no newer iOS release.
-4. Poll the CocoaPods CDN version-index shards for both `RevenueCat` and
-   `RevenueCatUI`.
+4. Poll the CocoaPods CDN version-index shards and exact podspec objects for
+   both `RevenueCat` and `RevenueCatUI`.
 5. Continue only when both pods list the selected version.
 
 The check will run immediately and then every five minutes for up to one hour.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,6 +10,8 @@
 #     https://docs.fastlane.tools/plugins/available-plugins
 #
 
+require_relative "lib/dependency_update_resilience"
+
 files_with_version_number = {
     './.version' => ['{x}'],
     './PurchasesHybridCommon.podspec' => ['s.version          = "{x}"'],
@@ -248,7 +250,12 @@ lane :update_native_dependencies_to_latest do |options|
       sh("yarn install")
     end
   end
-  run_pod_install
+  DependencyUpdateResilience.if_ios_changed(
+    current_version: current_ios_version,
+    new_version: latest_ios_release
+  ) do
+    run_pod_install
+  end
 
   new_versions = {
     new_ios_version: latest_ios_release,
@@ -376,7 +383,14 @@ end
 desc "Run pod install"
 lane :run_pod_install do |options|
   Dir.chdir(File.expand_path('ios/PurchasesHybridCommon', get_root_folder)) do
-    sh("pod install --repo-update")
+    DependencyUpdateResilience.with_retries(
+      max_attempts: 3,
+      initial_delay: 30,
+      sleeper: ->(seconds) { sleep(seconds) },
+      logger: ->(message) { UI.important(message) }
+    ) do
+      sh("pod install --repo-update")
+    end
   end
 end
 

--- a/fastlane/lib/cocoapods_propagation.rb
+++ b/fastlane/lib/cocoapods_propagation.rb
@@ -1,0 +1,169 @@
+require "digest"
+require "json"
+require "net/http"
+require "rubygems"
+require "uri"
+
+module CocoaPodsPropagation
+  GITHUB_RELEASES_URI =
+    URI("https://api.github.com/repos/RevenueCat/purchases-ios/releases?per_page=100")
+  COCOAPODS_CDN_BASE = "https://cdn.cocoapods.org"
+  REQUIRED_PODS = %w[RevenueCat RevenueCatUI].freeze
+
+  class TimeoutError < StandardError; end
+
+  class NetHttpClient
+    def get(uri, headers = {})
+      request = Net::HTTP::Get.new(uri)
+      headers.each { |name, value| request[name] = value }
+
+      Net::HTTP.start(
+        uri.host,
+        uri.port,
+        use_ssl: uri.scheme == "https"
+      ) do |http|
+        http.request(request)
+      end
+    end
+  end
+
+  class ReleaseFinder
+    def initialize(http:, github_token: nil)
+      @http = http
+      @github_token = github_token
+    end
+
+    def latest_stable_same_major(current_version)
+      response = @http.get(GITHUB_RELEASES_URI, headers)
+      ensure_success!(response, GITHUB_RELEASES_URI)
+
+      releases = JSON.parse(response.body)
+      versions = releases.filter_map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        version = Gem::Version.new(release.fetch("tag_name").delete_prefix("v"))
+        version if version.segments.first == current_version.segments.first
+      end
+
+      versions.max || current_version
+    end
+
+    private
+
+    def headers
+      result = { "Accept" => "application/vnd.github+json" }
+      result["Authorization"] = "Bearer #{@github_token}" if @github_token
+      result
+    end
+
+    def ensure_success!(response, uri)
+      return if response.code.to_i.between?(200, 299)
+
+      raise "Request to #{uri} failed with HTTP #{response.code}"
+    end
+  end
+
+  class CdnChecker
+    def initialize(http:)
+      @http = http
+    end
+
+    def available?(pod_name, version)
+      uri = shard_uri(pod_name)
+      response = @http.get(uri)
+      ensure_success!(response, uri)
+
+      line = response.body.lines.find do |entry|
+        entry.start_with?("#{pod_name}/")
+      end
+      versions = line&.split("/")&.drop(1)&.map(&:strip) || []
+      versions.include?(version.to_s)
+    end
+
+    private
+
+    def shard_uri(pod_name)
+      shard = Digest::MD5.hexdigest(pod_name).chars.first(3).join("_")
+      URI("#{COCOAPODS_CDN_BASE}/all_pods_versions_#{shard}.txt")
+    end
+
+    def ensure_success!(response, uri)
+      return if response.code.to_i.between?(200, 299)
+
+      raise "Request to #{uri} failed with HTTP #{response.code}"
+    end
+  end
+
+  class Waiter
+    def initialize(
+      release_finder:,
+      cdn_checker:,
+      interval_seconds:,
+      max_seconds:,
+      sleeper:,
+      logger:
+    )
+      @release_finder = release_finder
+      @cdn_checker = cdn_checker
+      @interval_seconds = interval_seconds
+      @max_seconds = max_seconds
+      @sleeper = sleeper
+      @logger = logger
+    end
+
+    def wait(current_version)
+      attempts = (@max_seconds / @interval_seconds) + 1
+      latest_version = current_version
+      missing_pods = REQUIRED_PODS
+      last_error = nil
+
+      attempts.times do |attempt|
+        begin
+          latest_version =
+            @release_finder.latest_stable_same_major(current_version)
+          if latest_version <= current_version
+            @logger.call("iOS #{current_version} is already current.")
+            return :current
+          end
+
+          missing_pods = REQUIRED_PODS.reject do |pod_name|
+            @cdn_checker.available?(pod_name, latest_version)
+          end
+          if missing_pods.empty?
+            @logger.call(
+              "RevenueCat pods #{latest_version} are available on CocoaPods CDN."
+            )
+            return :available
+          end
+
+          last_error = nil
+          @logger.call(
+            "Waiting for #{missing_pods.join(', ')} #{latest_version} " \
+            "on CocoaPods CDN."
+          )
+        rescue StandardError => error
+          last_error = error
+          @logger.call(
+            "Could not check CocoaPods readiness: #{error.message}"
+          )
+        end
+
+        next if attempt == attempts - 1
+
+        @logger.call(
+          "Retrying CocoaPods readiness in #{@interval_seconds} seconds."
+        )
+        @sleeper.call(@interval_seconds)
+      end
+
+      detail =
+        if last_error
+          "Last error: #{last_error.message}"
+        else
+          "Still missing: #{missing_pods.join(', ')} #{latest_version}"
+        end
+      raise TimeoutError,
+            "CocoaPods CDN was not ready after #{@max_seconds} seconds. #{detail}"
+    end
+  end
+end

--- a/fastlane/lib/cocoapods_propagation.rb
+++ b/fastlane/lib/cocoapods_propagation.rb
@@ -8,6 +8,7 @@ module CocoaPodsPropagation
   GITHUB_RELEASES_URI =
     URI("https://api.github.com/repos/RevenueCat/purchases-ios/releases?per_page=100")
   COCOAPODS_CDN_BASE = "https://cdn.cocoapods.org"
+  COCOAPODS_SPECS_BASE = "https://cdn.jsdelivr.net/cocoa/Specs"
   REQUIRED_PODS = %w[RevenueCat RevenueCatUI].freeze
 
   class TimeoutError < StandardError; end
@@ -77,7 +78,10 @@ module CocoaPodsPropagation
         entry.start_with?("#{pod_name}/")
       end
       versions = line&.split("/")&.drop(1)&.map(&:strip) || []
-      versions.include?(version.to_s)
+      return false unless versions.include?(version.to_s)
+
+      spec_response = @http.get(spec_uri(pod_name, version))
+      spec_response.code.to_i.between?(200, 299)
     end
 
     private
@@ -85,6 +89,14 @@ module CocoaPodsPropagation
     def shard_uri(pod_name)
       shard = Digest::MD5.hexdigest(pod_name).chars.first(3).join("_")
       URI("#{COCOAPODS_CDN_BASE}/all_pods_versions_#{shard}.txt")
+    end
+
+    def spec_uri(pod_name, version)
+      path = Digest::MD5.hexdigest(pod_name).chars.first(3).join("/")
+      URI(
+        "#{COCOAPODS_SPECS_BASE}/#{path}/#{pod_name}/#{version}/" \
+        "#{pod_name}.podspec.json"
+      )
     end
 
     def ensure_success!(response, uri)

--- a/fastlane/lib/dependency_update_resilience.rb
+++ b/fastlane/lib/dependency_update_resilience.rb
@@ -1,0 +1,27 @@
+module DependencyUpdateResilience
+  def self.with_retries(max_attempts:, initial_delay:, sleeper:, logger:)
+    attempt = 0
+
+    begin
+      attempt += 1
+      yield
+    rescue StandardError => error
+      raise if attempt >= max_attempts
+
+      delay = initial_delay * (2**(attempt - 1))
+      logger.call(
+        "pod install failed on attempt #{attempt}/#{max_attempts}: " \
+        "#{error.message}. Retrying in #{delay} seconds."
+      )
+      sleeper.call(delay)
+      retry
+    end
+  end
+
+  def self.if_ios_changed(current_version:, new_version:)
+    return false if current_version == new_version
+
+    yield
+    true
+  end
+end

--- a/fastlane/test/cocoapods_propagation_test.rb
+++ b/fastlane/test/cocoapods_propagation_test.rb
@@ -1,0 +1,154 @@
+require "minitest/autorun"
+require "json"
+require "cocoapods_propagation"
+
+class CocoaPodsPropagationTest < Minitest::Test
+  FakeResponse = Struct.new(:code, :body)
+
+  class FakeHttp
+    def initialize(responses)
+      @responses = responses
+    end
+
+    def get(uri, _headers = {})
+      response = @responses.fetch(uri.to_s)
+      response = response.shift if response.is_a?(Array)
+      raise response if response.is_a?(Exception)
+
+      response
+    end
+  end
+
+  class SequenceReleaseFinder
+    def initialize(outcomes)
+      @outcomes = outcomes
+    end
+
+    def latest_stable_same_major(_current_version)
+      outcome = @outcomes.length > 1 ? @outcomes.shift : @outcomes.first
+      raise outcome if outcome.is_a?(Exception)
+
+      outcome
+    end
+  end
+
+  class SequenceCdnChecker
+    def initialize(outcomes)
+      @outcomes = outcomes
+    end
+
+    def available?(pod_name, _version)
+      pod_outcomes = @outcomes.fetch(pod_name)
+      pod_outcomes.length > 1 ? pod_outcomes.shift : pod_outcomes.first
+    end
+  end
+
+  def test_selects_latest_stable_release_in_current_major
+    releases = [
+      release("7.0.0", draft: true),
+      release("6.0.0"),
+      release("5.84.0-beta.1", prerelease: true),
+      release("5.83.0"),
+      release("5.82.0")
+    ]
+    http = FakeHttp.new(
+      CocoaPodsPropagation::GITHUB_RELEASES_URI.to_s =>
+        FakeResponse.new("200", JSON.generate(releases))
+    )
+    finder = CocoaPodsPropagation::ReleaseFinder.new(http: http)
+
+    selected = finder.latest_stable_same_major(Gem::Version.new("5.82.0"))
+
+    assert_equal Gem::Version.new("5.83.0"), selected
+  end
+
+  def test_checks_version_in_the_pods_cdn_shard
+    revenue_cat_url =
+      "https://cdn.cocoapods.org/all_pods_versions_e_9_b.txt"
+    revenue_cat_ui_url =
+      "https://cdn.cocoapods.org/all_pods_versions_c_3_7.txt"
+    http = FakeHttp.new(
+      revenue_cat_url =>
+        FakeResponse.new("200", "RevenueCat/5.81.3/5.82.0/5.83.0\n"),
+      revenue_cat_ui_url =>
+        FakeResponse.new("200", "RevenueCatUI/5.81.3/5.82.0\n")
+    )
+    checker = CocoaPodsPropagation::CdnChecker.new(http: http)
+
+    assert checker.available?("RevenueCat", Gem::Version.new("5.83.0"))
+    refute checker.available?("RevenueCatUI", Gem::Version.new("5.83.0"))
+  end
+
+  def test_exits_immediately_when_current_version_is_latest
+    current_version = Gem::Version.new("5.83.0")
+    waiter = CocoaPodsPropagation::Waiter.new(
+      release_finder: SequenceReleaseFinder.new([current_version]),
+      cdn_checker: Object.new,
+      interval_seconds: 300,
+      max_seconds: 600,
+      sleeper: ->(_seconds) { flunk("must not sleep") },
+      logger: ->(_message) {}
+    )
+
+    assert_equal :current, waiter.wait(current_version)
+  end
+
+  def test_retries_request_errors_and_waits_for_both_pods
+    current_version = Gem::Version.new("5.82.0")
+    new_version = Gem::Version.new("5.83.0")
+    sleeps = []
+    messages = []
+    waiter = CocoaPodsPropagation::Waiter.new(
+      release_finder: SequenceReleaseFinder.new(
+        [RuntimeError.new("GitHub unavailable"), new_version, new_version]
+      ),
+      cdn_checker: SequenceCdnChecker.new(
+        "RevenueCat" => [true, true],
+        "RevenueCatUI" => [false, true]
+      ),
+      interval_seconds: 300,
+      max_seconds: 600,
+      sleeper: ->(seconds) { sleeps << seconds },
+      logger: ->(message) { messages << message }
+    )
+
+    assert_equal :available, waiter.wait(current_version)
+    assert_equal [300, 300], sleeps
+    assert messages.any? { |message| message.include?("GitHub unavailable") }
+    assert messages.any? { |message| message.include?("RevenueCatUI") }
+  end
+
+  def test_times_out_after_configured_wait
+    current_version = Gem::Version.new("5.82.0")
+    new_version = Gem::Version.new("5.83.0")
+    sleeps = []
+    waiter = CocoaPodsPropagation::Waiter.new(
+      release_finder: SequenceReleaseFinder.new([new_version]),
+      cdn_checker: SequenceCdnChecker.new(
+        "RevenueCat" => [true],
+        "RevenueCatUI" => [false]
+      ),
+      interval_seconds: 300,
+      max_seconds: 600,
+      sleeper: ->(seconds) { sleeps << seconds },
+      logger: ->(_message) {}
+    )
+
+    error = assert_raises(CocoaPodsPropagation::TimeoutError) do
+      waiter.wait(current_version)
+    end
+    assert_equal [300, 300], sleeps
+    assert_includes error.message, "RevenueCatUI"
+    assert_includes error.message, "5.83.0"
+  end
+
+  private
+
+  def release(tag_name, draft: false, prerelease: false)
+    {
+      "tag_name" => tag_name,
+      "draft" => draft,
+      "prerelease" => prerelease
+    }
+  end
+end

--- a/fastlane/test/cocoapods_propagation_test.rb
+++ b/fastlane/test/cocoapods_propagation_test.rb
@@ -67,9 +67,12 @@ class CocoaPodsPropagationTest < Minitest::Test
       "https://cdn.cocoapods.org/all_pods_versions_e_9_b.txt"
     revenue_cat_ui_url =
       "https://cdn.cocoapods.org/all_pods_versions_c_3_7.txt"
+    revenue_cat_spec_url =
+      "https://cdn.jsdelivr.net/cocoa/Specs/e/9/b/RevenueCat/5.83.0/RevenueCat.podspec.json"
     http = FakeHttp.new(
       revenue_cat_url =>
         FakeResponse.new("200", "RevenueCat/5.81.3/5.82.0/5.83.0\n"),
+      revenue_cat_spec_url => FakeResponse.new("200", "{}"),
       revenue_cat_ui_url =>
         FakeResponse.new("200", "RevenueCatUI/5.81.3/5.82.0\n")
     )
@@ -77,6 +80,20 @@ class CocoaPodsPropagationTest < Minitest::Test
 
     assert checker.available?("RevenueCat", Gem::Version.new("5.83.0"))
     refute checker.available?("RevenueCatUI", Gem::Version.new("5.83.0"))
+  end
+
+  def test_is_unavailable_when_version_is_indexed_but_podspec_is_missing
+    shard_url = "https://cdn.cocoapods.org/all_pods_versions_e_9_b.txt"
+    spec_url =
+      "https://cdn.jsdelivr.net/cocoa/Specs/e/9/b/RevenueCat/5.83.0/RevenueCat.podspec.json"
+    http = FakeHttp.new(
+      shard_url =>
+        FakeResponse.new("200", "RevenueCat/5.81.3/5.82.0/5.83.0\n"),
+      spec_url => FakeResponse.new("404", "not found")
+    )
+    checker = CocoaPodsPropagation::CdnChecker.new(http: http)
+
+    refute checker.available?("RevenueCat", Gem::Version.new("5.83.0"))
   end
 
   def test_exits_immediately_when_current_version_is_latest

--- a/fastlane/test/dependency_update_resilience_test.rb
+++ b/fastlane/test/dependency_update_resilience_test.rb
@@ -1,0 +1,71 @@
+require "minitest/autorun"
+require "dependency_update_resilience"
+
+class DependencyUpdateResilienceTest < Minitest::Test
+  def test_retries_with_exponential_delays_until_operation_succeeds
+    attempts = 0
+    sleeps = []
+    messages = []
+
+    result = DependencyUpdateResilience.with_retries(
+      max_attempts: 3,
+      initial_delay: 30,
+      sleeper: ->(seconds) { sleeps << seconds },
+      logger: ->(message) { messages << message }
+    ) do
+      attempts += 1
+      raise "transient" if attempts < 3
+
+      :installed
+    end
+
+    assert_equal :installed, result
+    assert_equal 3, attempts
+    assert_equal [30, 60], sleeps
+    assert_equal 2, messages.length
+  end
+
+  def test_reraises_the_final_failure
+    attempts = 0
+
+    error = assert_raises(RuntimeError) do
+      DependencyUpdateResilience.with_retries(
+        max_attempts: 3,
+        initial_delay: 30,
+        sleeper: ->(_seconds) {},
+        logger: ->(_message) {}
+      ) do
+        attempts += 1
+        raise "permanent"
+      end
+    end
+
+    assert_equal "permanent", error.message
+    assert_equal 3, attempts
+  end
+
+  def test_skips_operation_when_ios_version_is_unchanged
+    result = DependencyUpdateResilience.if_ios_changed(
+      current_version: "5.83.0",
+      new_version: "5.83.0"
+    ) do
+      flunk("must not yield")
+    end
+
+    refute result
+  end
+
+  def test_runs_operation_when_ios_version_changes
+    yielded = false
+
+    result = DependencyUpdateResilience.if_ios_changed(
+      current_version: "5.82.0",
+      new_version: "5.83.0"
+    ) do
+      yielded = true
+    end
+
+    assert result
+    assert yielded
+  end
+end

--- a/scripts/wait-for-cocoapods
+++ b/scripts/wait-for-cocoapods
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+require_relative "../fastlane/lib/cocoapods_propagation"
+
+podspec_path =
+  File.expand_path("../PurchasesHybridCommon.podspec", __dir__)
+current_version_text =
+  File.read(podspec_path)[/s\.dependency 'RevenueCat', '([^']+)'/, 1]
+abort("Could not read the current RevenueCat version") unless current_version_text
+
+http = CocoaPodsPropagation::NetHttpClient.new
+release_finder = CocoaPodsPropagation::ReleaseFinder.new(
+  http: http,
+  github_token: ENV["GITHUB_TOKEN"]
+)
+cdn_checker = CocoaPodsPropagation::CdnChecker.new(http: http)
+waiter = CocoaPodsPropagation::Waiter.new(
+  release_finder: release_finder,
+  cdn_checker: cdn_checker,
+  interval_seconds:
+    Integer(ENV.fetch("COCOAPODS_WAIT_INTERVAL_SECONDS", "300")),
+  max_seconds: Integer(ENV.fetch("COCOAPODS_WAIT_MAX_SECONDS", "3600")),
+  sleeper: ->(seconds) { sleep(seconds) },
+  logger: ->(message) { puts(message) }
+)
+
+begin
+  waiter.wait(Gem::Version.new(current_version_text))
+rescue CocoaPodsPropagation::TimeoutError => error
+  warn(error.message)
+  exit(1)
+end


### PR DESCRIPTION
### Motivation

`dependency-update` can see a new `purchases-ios` release before the matching pods reach the CocoaPods CDN. This time propagation took around 45 minutes, so the single `pod install` attempt failed.

### Description

- Wait up to one hour for `RevenueCat` and `RevenueCatUI` on a small Linux executor.
- Check both the CDN version indexes and the exact podspecs before starting the macOS job.
- Retry `pod install` twice with 30 and 60 second delays for smaller transient failures.
- Skip `pod install` when the iOS dependency did not change.

The Fastlane plugin is already on its latest revision, so this does not update it.

### Testing

- `circleci config validate .circleci/config.yml`
- 10 Ruby tests, 25 assertions
- Live CocoaPods preflight against RevenueCat 5.83.0
