### PR TITLE
feat(ads): ad reward tracking support

### DIFF
--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
@@ -517,7 +517,12 @@ private class CommonApiTests {
     }
 
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
-    private fun checkPollRewardVerification(clientTransactionId: String, onResult: OnResult) {
+    private fun checkPollRewardVerification(
+        clientTransactionId: String,
+        onResult: OnResult,
+        trackingMetadata: Map<String, Any?>?,
+    ) {
         pollRewardVerification(clientTransactionId, onResult)
+        pollRewardVerification(clientTransactionId, onResult, trackingMetadata)
     }
 }

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -36,6 +36,7 @@ import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import com.revenuecat.purchases.ads.events.types.AdOpenedData
 import com.revenuecat.purchases.ads.events.types.AdRevenueData
 import com.revenuecat.purchases.ads.events.types.AdRevenuePrecision
+import com.revenuecat.purchases.ads.rewardverification.RewardedAdTrackingMetadata
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.galaxy.GalaxyBillingMode
 import com.revenuecat.purchases.getAmazonLWAConsentStatusWith
@@ -1778,15 +1779,44 @@ fun generateRewardVerificationToken(impressionId: String): Map<String, Any> {
 }
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@Suppress("ComplexCondition")
 fun pollRewardVerification(
     clientTransactionId: String,
     onResult: OnResult,
+    trackingMetadata: Map<String, Any?>? = null,
 ) {
+    val metadata = trackingMetadata?.let { data ->
+        val mediatorNameString = data["mediatorName"] as? String
+        val adFormatString = data["adFormat"] as? String
+        val adUnitId = data["adUnitId"] as? String
+        val impressionId = data["impressionId"] as? String
+
+        if (mediatorNameString == null ||
+            adFormatString == null ||
+            adUnitId == null ||
+            impressionId == null
+        ) {
+            errorLog(
+                "pollRewardVerification: Missing required trackingMetadata parameters - " +
+                    "mediatorName, adFormat, adUnitId, or impressionId",
+            )
+            null
+        } else {
+            RewardedAdTrackingMetadata(
+                networkName = data["networkName"] as? String,
+                mediatorName = AdMediatorName.fromString(mediatorNameString),
+                adFormat = AdFormat.fromString(adFormatString),
+                placement = data["placement"] as? String,
+                adUnitId = adUnitId,
+                impressionId = impressionId,
+            )
+        }
+    }
+
     Purchases.sharedInstance.pollRewardVerification(
-        clientTransactionId,
-        PollRewardVerificationCallback { result ->
-            onResult.onReceived(result.map())
-        },
+        clientTransactionId = clientTransactionId,
+        callback = { result -> onResult.onReceived(result.map()) },
+        trackingMetadata = metadata,
     )
 }
 

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -1778,6 +1778,7 @@ fun generateRewardVerificationToken(impressionId: String): Map<String, Any> {
     return Purchases.sharedInstance.generateRewardVerificationToken(impressionId).map()
 }
 
+@JvmOverloads
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Suppress("ComplexCondition")
 fun pollRewardVerification(

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -50,7 +50,6 @@ import com.revenuecat.purchases.hybridcommon.mappers.MappedProductCategory
 import com.revenuecat.purchases.hybridcommon.mappers.map
 import com.revenuecat.purchases.hybridcommon.mappers.mapAsync
 import com.revenuecat.purchases.hybridcommon.mappers.toMap
-import com.revenuecat.purchases.interfaces.PollRewardVerificationCallback
 import com.revenuecat.purchases.interfaces.RedeemWebPurchaseListener
 import com.revenuecat.purchases.interfaces.SyncAttributesAndOfferingsCallback
 import com.revenuecat.purchases.logInWith

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -169,6 +169,11 @@ NS_ASSUME_NONNULL_BEGIN
                                                                 completion:^(
                                                                     NSDictionary<NSString *, NSObject *> * _Nullable result,
                                                                     RCErrorContainer * _Nullable error) {}];
+
+    [RCCommonFunctionality pollRewardVerificationWithClientTransactionId:@""
+                                                                completion:^(
+                                                                    NSDictionary<NSString *, NSObject *> * _Nullable result,
+                                                                    RCErrorContainer * _Nullable error) {}];
 }
 
 - (void)testDeprecatedAPI {

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -165,6 +165,7 @@ NS_ASSUME_NONNULL_BEGIN
         [RCCommonFunctionality generateRewardVerificationTokenWithImpressionId:@""];
 
     [RCCommonFunctionality pollRewardVerificationWithClientTransactionId:@""
+                                                        trackingMetadata:nil
                                                                 completion:^(
                                                                     NSDictionary<NSString *, NSObject *> * _Nullable result,
                                                                     RCErrorContainer * _Nullable error) {}];

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -1267,13 +1267,37 @@ private extension CommonFunctionality {
         return Purchases.shared.generateRewardVerificationToken(impressionId: impressionId).rc_dictionary
     }
 
-    @objc(pollRewardVerificationWithClientTransactionId:completion:)
+    @objc(pollRewardVerificationWithClientTransactionId:trackingMetadata:completion:)
     static func pollRewardVerification(
         clientTransactionId: String,
+        trackingMetadata: [String: Any]?,
         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void
     ) {
+        let metadata = trackingMetadata.flatMap { data -> RewardedAdTrackingMetadata? in
+            guard let mediatorNameString = data["mediatorName"] as? String,
+                  let adFormatString = data["adFormat"] as? String,
+                  let adUnitId = data["adUnitId"] as? String,
+                  let impressionId = data["impressionId"] as? String else {
+                NSLog("[PurchasesHybridCommon] pollRewardVerification: Missing required trackingMetadata " +
+                      "parameters - mediatorName, adFormat, adUnitId, or impressionId")
+                return nil
+            }
+
+            return RewardedAdTrackingMetadata(
+                networkName: data["networkName"] as? String,
+                mediatorName: MediatorName(rawValue: mediatorNameString),
+                adFormat: AdFormat(rawValue: adFormatString),
+                placement: data["placement"] as? String,
+                adUnitId: adUnitId,
+                impressionId: impressionId
+            )
+        }
+
         _ = Task<Void, Never> {
-            let result = await Purchases.shared.pollRewardVerification(clientTransactionID: clientTransactionId)
+            let result = await Purchases.shared.pollRewardVerification(
+                clientTransactionID: clientTransactionId,
+                trackingMetadata: metadata
+            )
             completion(result.rc_dictionary, nil)
         }
     }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -1267,10 +1267,18 @@ private extension CommonFunctionality {
         return Purchases.shared.generateRewardVerificationToken(impressionId: impressionId).rc_dictionary
     }
 
+    @objc(pollRewardVerificationWithClientTransactionId:completion:)
+    static func pollRewardVerificationForObjC(
+        clientTransactionId: String,
+        completion: @escaping ([String: Any]?, ErrorContainer?) -> Void
+    ) {
+        pollRewardVerification(clientTransactionId: clientTransactionId, trackingMetadata: nil, completion: completion)
+    }
+
     @objc(pollRewardVerificationWithClientTransactionId:trackingMetadata:completion:)
     static func pollRewardVerification(
         clientTransactionId: String,
-        trackingMetadata: [String: Any]?,
+        trackingMetadata: [String: Any]? = nil,
         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void
     ) {
         let metadata = trackingMetadata.flatMap { data -> RewardedAdTrackingMetadata? in


### PR DESCRIPTION
### Description

Exposes the optional `trackingMetadata` so hybrid sdks can use ad reward tracking too.

**Do** **not** **merge** until the feature is released both on android and ios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches experimental reward-verification and ad-attribution paths; behavior is backward compatible but incorrect metadata is only logged, not surfaced to callers.
> 
> **Overview**
> Adds optional **ad reward tracking** to hybrid `pollRewardVerification` on Android and iOS so React Native and other hybrid SDKs can pass the same metadata as the native APIs.
> 
> `pollRewardVerification` now accepts an optional `trackingMetadata` map (`mediatorName`, `adFormat`, `adUnitId`, `impressionId`, plus optional `networkName` and `placement`). Hybrid common validates required keys, builds `RewardedAdTrackingMetadata`, and forwards it to `Purchases.sharedInstance.pollRewardVerification`. Invalid or incomplete metadata is logged and polling still runs with `nil` metadata.
> 
> On iOS, a separate ObjC selector `pollRewardVerificationWithClientTransactionId:trackingMetadata:completion:` is added while the existing completion-only entry point remains for compatibility. Android uses `@JvmOverloads` for the same optional parameter. API tests cover both call shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e571fe0df31585c1cb6032596c2041441d2f4bd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->