### PR TITLE
Disable update_fastlane in CI

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,7 +46,6 @@ changelog_path = './CHANGELOG.md'
 
 before_all do
   setup_circle_ci
-  update_fastlane
 end
 
 desc "Bump version, edit changelog, and create pull request"


### PR DESCRIPTION
## Summary

`update_fastlane` runs a raw `gem update fastlane` outside Bundler, ignoring Gemfile.lock entirely. 

[It broke the `automatic_bump` job:](https://app.circleci.com/pipelines/gh/RevenueCat/purchases-hybrid-common/7056/details?useNewPipelines=true&job=5cfda82d-582b-41d8-8139-b6e3ff94769d&workflowId=4675a7a6-46a4-4362-bdaf-5b2436ea7fb5&buildNumber=60605&jobType=build#step-108-) `gem update` triggers RubyGems' post-install RDoc-generation hook, and RDoc 8.0.0 (whatever's currently on the CircleCI image) requires the `rbs` gem for type-signature extraction and does a bare `require 'rbs'`. `rbs` isn't installed anywhere, so it raises `LoadError: cannot load such file -- rbs` and the whole fastlane invocation dies.

- Removes `update_fastlane` from `before_all`. Gemfile.lock already pins the exact fastlane version everyone uses; there's nothing useful to update in CI, and calling it there is inherently non-reproducible (it mutates the global gem environment independent of the lockfile).
- Android, Flutter and Unity already disable this the same way; this brings PHC in line. I've also verified this is not a problem in other repos

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line CI config change that stops an unreliable gem update; no application or release logic is modified.
> 
> **Overview**
> Removes `update_fastlane` from the Fastfile `before_all` hook so CI no longer runs a raw `gem update fastlane` outside Bundler.
> 
> That call ignored `Gemfile.lock`, mutated the global gem environment, and broke the `automatic_bump` job when RubyGems' RDoc post-install hook failed on a missing `rbs` dependency. Fastlane stays pinned by the lockfile instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5088f18c16b4d1b698eaf9cc8fca1bfca995451d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->