### PR TITLE
Add Cloud Agent development environment setup

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "purchases-hybrid-common",
+  "user": "ubuntu",
+  "install": "./.cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent install script for purchases-hybrid-common.
+#
+# Idempotent bootstrap of the Linux-buildable development experience:
+#   - mise-managed toolchain (Java 17, Ruby 3.3.0, Node 24.x) from mise.toml/mise.lock
+#   - Android SDK (command-line tools, platform 34, build-tools 34.0.0)
+#   - Ruby gems (fastlane, cocoapods, danger, lefthook, ...) via bundler
+#   - Node dependencies for the typescript and purchases-js-hybrid-mappings packages
+#
+# iOS work (PurchasesHybridCommon / PurchasesHybridCommonUI) requires macOS + Xcode
+# and cannot be built on this Linux VM; it is intentionally not set up here.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+ANDROID_HOME="${ANDROID_HOME:-$HOME/android-sdk}"
+ANDROID_CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip"
+
+log() { printf '\n=== %s ===\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# 1. mise (tool version manager)
+# ---------------------------------------------------------------------------
+log "Installing mise (if needed)"
+export PATH="$HOME/.local/bin:$PATH"
+if ! command -v mise >/dev/null 2>&1; then
+  curl -fsSL https://mise.run | sh
+fi
+
+log "Installing pinned toolchain via mise"
+mise trust --quiet "$REPO_ROOT/mise.toml"
+mise install
+
+# `mise install` may re-normalize the committed lockfile (e.g. reorder platform
+# entries) without changing the resolved tool versions. Restore the committed
+# copy so a fresh checkout keeps a clean working tree; the tools stay installed.
+if git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git -C "$REPO_ROOT" checkout -- mise.lock 2>/dev/null || true
+fi
+
+# Make the mise-managed tools available to the rest of this script.
+eval "$(mise env -s bash)"
+
+# ---------------------------------------------------------------------------
+# 2. Android SDK
+# ---------------------------------------------------------------------------
+export ANDROID_HOME
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
+SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+
+if [ ! -x "$SDKMANAGER" ]; then
+  log "Installing Android command-line tools"
+  tmpzip="$(mktemp)"
+  curl -fsSL -o "$tmpzip" "$ANDROID_CMDLINE_TOOLS_URL"
+  mkdir -p "$ANDROID_HOME/cmdline-tools"
+  rm -rf "$ANDROID_HOME/cmdline-tools/latest"
+  unzip -q -o "$tmpzip" -d "$ANDROID_HOME/cmdline-tools"
+  mv "$ANDROID_HOME/cmdline-tools/cmdline-tools" "$ANDROID_HOME/cmdline-tools/latest"
+  rm -f "$tmpzip"
+fi
+
+log "Accepting Android SDK licenses and installing packages"
+yes | "$SDKMANAGER" --licenses >/dev/null 2>&1 || true
+"$SDKMANAGER" "platform-tools" "platforms;android-34" "build-tools;34.0.0" >/dev/null
+
+# ---------------------------------------------------------------------------
+# 3. Ruby gems (fastlane and friends)
+# ---------------------------------------------------------------------------
+log "Installing Ruby gems (bundle install)"
+gem install bundler --conservative --no-document
+bundle install
+
+# ---------------------------------------------------------------------------
+# 4. Node dependencies
+# ---------------------------------------------------------------------------
+log "Installing Node dependencies (typescript)"
+corepack enable >/dev/null 2>&1 || true
+( cd typescript && yarn install --frozen-lockfile )
+
+log "Installing Node dependencies (purchases-js-hybrid-mappings)"
+( cd purchases-js-hybrid-mappings && yarn install --frozen-lockfile )
+
+# ---------------------------------------------------------------------------
+# 5. Persist environment for future interactive/agent shells
+# ---------------------------------------------------------------------------
+log "Persisting environment to ~/.bashrc"
+MARKER="# >>> purchases-hybrid-common cloud-agent env >>>"
+if ! grep -qF "$MARKER" "$HOME/.bashrc" 2>/dev/null; then
+  cat >> "$HOME/.bashrc" <<EOF
+
+$MARKER
+export PATH="\$HOME/.local/bin:\$PATH"
+eval "\$(mise activate bash)"
+export ANDROID_HOME="$ANDROID_HOME"
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
+export PATH="\$ANDROID_HOME/platform-tools:\$ANDROID_HOME/cmdline-tools/latest/bin:\$PATH"
+# <<< purchases-hybrid-common cloud-agent env <<<
+EOF
+fi
+
+log "Install complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

This adds a Cursor Cloud Agent environment so the repository is fully usable by background agents out of the box. Previously there was no `.cursor/environment.json`, so a fresh agent VM had no managed toolchain, Android SDK, gems, or Node dependencies.

New files:

- **`.cursor/environment.json`** — uses Cursor's default base image, runs as `ubuntu`, and points `install` at the bootstrap script. No `start`/`terminals` since this is a set of libraries with no long-running dev server.
- **`.cursor/install.sh`** — an idempotent bootstrap that mirrors the CI setup (`revenuecat/install-mise-tools` + gem/npm installs):
  - installs [mise](https://mise.jdx.dev/) and the pinned toolchain from `mise.toml`/`mise.lock` (Java 17, Ruby 3.3.0, Node 24.x, Yarn via corepack);
  - installs the Android SDK (command-line tools, `platforms;android-34`, `build-tools;34.0.0`) and accepts licenses;
  - runs `bundle install` (fastlane, cocoapods, danger, lefthook, …);
  - installs Node deps for `typescript/` and `purchases-js-hybrid-mappings/`;
  - persists the toolchain + `ANDROID_HOME` to `~/.bashrc` for future shells.

The script restores the committed `mise.lock` after `mise install` (mise re-normalizes it without changing resolved versions) so a fresh checkout keeps a clean working tree.

## Scope

iOS (`PurchasesHybridCommon` / `PurchasesHybridCommonUI`) requires macOS + Xcode and cannot be built on the Linux Cloud Agent VM, so it is intentionally out of scope. Everything else is set up and verified.

## Validation

Commands run on the setup VM using this environment:

| Check | Result |
| --- | --- |
| Android `./gradlew detekt lint test` | BUILD SUCCESSFUL |
| TypeScript `yarn build` / `yarn lint` / `yarn extract-api` | Pass; API report up to date |
| JS mappings `yarn build` / `format:check` / `lint` / `api-test:ci` | Pass |
| JS mappings `yarn test` (Jest) | 54/54 tests pass |
| `install.sh` idempotence | Re-run is a no-op (~2.5s), working tree stays clean |
| Fresh login shell | Resolves Java 17, Node 24.18.0, Ruby 3.3.0, Yarn, Bundler, Android SDK |

Additionally validated end-to-end in a **fresh Cloud Agent booted from a prebuilt environment build** of this branch:

| Check | Result |
| --- | --- |
| Tool versions | Java 17.0.6, Node 24.18.0, Ruby 3.3.0, Yarn 1.22.22, Bundler OK |
| Android SDK | `platforms;android-34` + `build-tools;34.0.0` present |
| `bundle check` | Dependencies satisfied (146 gems) |
| TypeScript build / lint / extract-api | Pass |
| JS mappings 54 Jest tests | 54/54 pass |
| Android `hybridcommon:testReleaseUnitTest` | BUILD SUCCESSFUL, 173 tests, 0 failures |

No application code is changed; only environment configuration is added.

- [x] A description about what and why you are contributing.
- [x] Unit/build checks run as validation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db3267ef-633d-4935-a5d0-19b016e429ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db3267ef-633d-4935-a5d0-19b016e429ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

