### PR TITLE
introduce an isPurchasesError function in the code

### DIFF
--- a/typescript/api-report/purchases-typescript-internal.api.md
+++ b/typescript/api-report/purchases-typescript-internal.api.md
@@ -87,6 +87,9 @@ export interface IntroEligibility {
 }
 
 // @public
+export function isPurchasesError(error: unknown): error is PurchasesError;
+
+// @public
 export enum LOG_LEVEL {
     // (undocumented)
     DEBUG = "DEBUG",

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -55,3 +55,43 @@ export class UnsupportedPlatformError extends Error {
         Object.setPrototypeOf(this, UnsupportedPlatformError.prototype);
     }
 }
+
+/**
+ * Returns whether the given value is a {@link PurchasesError} thrown by the SDK.
+ *
+ * A value qualifies when it's schema matches {@link PurchasesError} and a `code` that is one of the
+ * {@link PURCHASES_ERROR_CODE} values.
+ *
+ * @public
+ */
+export function isPurchasesError(error: unknown): error is PurchasesError {
+    if (typeof error !== "object" || error === null) {
+        return false;
+    }
+
+    if (!("code" in error) || typeof error.code !== "string") {
+        return false;
+    }
+
+    if (!("message" in error) || typeof error.message !== "string") {
+        return false;
+    }
+
+    if (!("userInfo" in error) || typeof error.userInfo !== "object" || error.userInfo == null) {
+        return false;
+    }
+
+    if (!(("readableErrorCode") in error.userInfo) || typeof error.userInfo.readableErrorCode !== "string") {
+        return false;
+    }
+
+    if (!("underlyingErrorMessage" in error) || typeof error.underlyingErrorMessage !== "string") {
+        return false;
+    }
+
+    const { code } = error;
+
+    const knownErrorCodes: ReadonlySet<string> = new Set(Object.values(PURCHASES_ERROR_CODE))
+
+    return typeof code === "string" && knownErrorCodes.has(code);
+}

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -17,7 +17,7 @@
     "skipLibCheck": true,
     "target": "es5",
     "module": "commonjs",
-    "lib": ["es6", "dom", "es2016", "esnext.asynciterable"],
+    "lib": ["es6", "dom", "es2016", "esnext.asynciterable", "es2017.object"],
     "declaration": true,
     "outDir": "./dist",
     "strict": true,


### PR DESCRIPTION
  - [x] A description about what and why you are contributing, even if it's trivial.

Implements an isPurchasesError function based on the current non-depracated fields in the interface and checks that it's codes match the ones expected.

I had to introduce es2017's object as a lib in the tsconfig, let me know if that is undesired, since the other solutions for creating the set from the enum values were kind of ugly, but i can bring them back

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

Fixes https://github.com/RevenueCat/react-native-purchases/issues/291

  - [ ] If applicable, unit tests.

No, but i also noticed purchases-common.test.ts is complaining about missing fields on `mockMonthlyProduct`, will write another PR to fix that

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small public API addition for error identification; no auth, data, or purchase-flow changes. TypeScript lib target is slightly expanded for Object.values.
> 
> **Overview**
> Adds a public `isPurchasesError` type guard so consumers can tell whether an unknown value is a SDK `PurchasesError`.
> 
> The helper checks non-deprecated fields (`code`, `message`, `userInfo.readableErrorCode`, `underlyingErrorMessage`) and that `code` is a known `PURCHASES_ERROR_CODE`. It is exported from the existing errors module.
> 
> `tsconfig` now includes `es2017.object` so `Object.values` can build the known-code set. No tests are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b76247544c21f01eaa61b859fc5895cbe66234. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->