### PR TITLE
chore(ads): remove experimental opt-ins for ads apis

### DIFF
--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/CommonApiTests.kt
@@ -3,7 +3,6 @@ package com.revenuecat.apitests.kotlin
 import android.app.Activity
 import android.content.Context
 import com.revenuecat.purchases.DangerousSettings
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.hybridcommon.ErrorContainer
@@ -511,12 +510,10 @@ private class CommonApiTests {
         setAppstackAttributionParams(data, onResult)
     }
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private fun checkGenerateRewardVerificationToken(impressionId: String) {
         val token: Map<String, Any> = generateRewardVerificationToken(impressionId)
     }
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private fun checkPollRewardVerification(
         clientTransactionId: String,
         onResult: OnResult,

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/common.kt
@@ -1148,7 +1148,6 @@ fun getCachedVirtualCurrencies(): Map<String, Any?>? = Purchases.sharedInstance.
 
 // region Ad Tracking
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Suppress("ComplexCondition")
 fun trackAdDisplayed(adData: Map<String, Any?>) {
     val networkName = adData["networkName"] as? String
@@ -1182,7 +1181,6 @@ fun trackAdDisplayed(adData: Map<String, Any?>) {
     Purchases.sharedInstance.adTracker.trackAdDisplayed(displayedData)
 }
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Suppress("ComplexCondition")
 fun trackAdOpened(adData: Map<String, Any?>) {
     val networkName = adData["networkName"] as? String
@@ -1216,7 +1214,6 @@ fun trackAdOpened(adData: Map<String, Any?>) {
     Purchases.sharedInstance.adTracker.trackAdOpened(openedData)
 }
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Suppress("ComplexCondition")
 fun trackAdRevenue(adData: Map<String, Any?>) {
     val networkName = adData["networkName"] as? String
@@ -1259,7 +1256,6 @@ fun trackAdRevenue(adData: Map<String, Any?>) {
     Purchases.sharedInstance.adTracker.trackAdRevenue(revenueData)
 }
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Suppress("ComplexCondition")
 fun trackAdLoaded(adData: Map<String, Any?>) {
     val networkName = adData["networkName"] as? String
@@ -1293,7 +1289,6 @@ fun trackAdLoaded(adData: Map<String, Any?>) {
     Purchases.sharedInstance.adTracker.trackAdLoaded(loadedData)
 }
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Suppress("ComplexCondition")
 fun trackAdFailedToLoad(adData: Map<String, Any?>) {
     val mediatorNameString = adData["mediatorName"] as? String
@@ -1772,13 +1767,11 @@ internal fun convertToInt(value: Any?): Int? {
 
 // region Reward verification
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 fun generateRewardVerificationToken(impressionId: String): Map<String, Any> {
     return Purchases.sharedInstance.generateRewardVerificationToken(impressionId).map()
 }
 
 @JvmOverloads
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Suppress("ComplexCondition")
 fun pollRewardVerification(
     clientTransactionId: String,

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/RewardVerificationMapper.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/mappers/RewardVerificationMapper.kt
@@ -1,18 +1,15 @@
 package com.revenuecat.purchases.hybridcommon.mappers
 
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
 import com.revenuecat.purchases.ads.rewardverification.VerifiedReward
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 fun RewardVerificationToken.map(): Map<String, Any> = mapOf(
     "customData" to customData,
     "clientTransactionId" to clientTransactionId,
     "appUserID" to appUserID,
 )
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 fun RewardVerificationResult.map(): Map<String, Any> {
     val reward = verifiedReward ?: return mapOf(
         "failed" to true,
@@ -25,7 +22,6 @@ fun RewardVerificationResult.map(): Map<String, Any> {
     )
 }
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 fun VerifiedReward.map(): Map<String, Any> = when (this) {
     is VerifiedReward.VirtualCurrency -> mapOf(
         "type" to "virtual_currency",

--- a/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/RewardVerificationMapperTests.kt
+++ b/android/hybridcommon/src/test/java/com/revenuecat/purchases/hybridcommon/mappers/RewardVerificationMapperTests.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.hybridcommon.mappers
 
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationResult
 import com.revenuecat.purchases.ads.rewardverification.RewardVerificationToken
@@ -9,7 +8,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.Date
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 class RewardVerificationMapperTests {
 
     @Test

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/AdReward+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/AdReward+HybridAdditions.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(Experimental) import RevenueCat
+import RevenueCat
 
 internal extension AdReward {
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import StoreKit
-@_spi(Internal) @_spi(Experimental) import RevenueCat
+@_spi(Internal) import RevenueCat
 
 
 @objc(RCCommonFunctionality) public class CommonFunctionality: NSObject {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RewardVerificationResult+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RewardVerificationResult+HybridAdditions.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(Experimental) import RevenueCat
+import RevenueCat
 
 internal extension RewardVerificationResult {
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/RewardVerificationToken+HybridAdditions.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/RewardVerificationToken+HybridAdditions.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(Experimental) import RevenueCat
+import RevenueCat
 
 internal extension RewardVerificationToken {
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/AdReward+HybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/AdReward+HybridAdditionsTests.swift
@@ -9,8 +9,8 @@ import Foundation
 import Quick
 import Nimble
 
-@_spi(Experimental) @testable import PurchasesHybridCommon
-@_spi(Internal) @_spi(Experimental) @testable import RevenueCat
+@testable import PurchasesHybridCommon
+@_spi(Internal) @testable import RevenueCat
 
 class AdRewardHybridAdditionsTests: QuickSpec {
     override func spec() {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/RewardVerificationResult+HybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/RewardVerificationResult+HybridAdditionsTests.swift
@@ -9,8 +9,8 @@ import Foundation
 import Quick
 import Nimble
 
-@_spi(Experimental) @testable import PurchasesHybridCommon
-@_spi(Internal) @_spi(Experimental) @testable import RevenueCat
+@testable import PurchasesHybridCommon
+@_spi(Internal) @testable import RevenueCat
 
 class RewardVerificationResultHybridAdditionsTests: QuickSpec {
     override func spec() {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/RewardVerificationToken+HybridAdditionsTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/RewardVerificationToken+HybridAdditionsTests.swift
@@ -9,8 +9,8 @@ import Foundation
 import Quick
 import Nimble
 
-@_spi(Experimental) @testable import PurchasesHybridCommon
-@_spi(Internal) @_spi(Experimental) @testable import RevenueCat
+@testable import PurchasesHybridCommon
+@_spi(Internal) @testable import RevenueCat
 
 class RewardVerificationTokenHybridAdditionsTests: QuickSpec {
     override func spec() {


### PR DESCRIPTION
## Description

Removes the experimental opt in annotations as native sdks are not experimental anymore.

## Tests

Apart from the green phc I also built and validated both an android and an ios react-native sample app with it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation and import-only changes with no logic edits; risk is mainly build breakage if hybrid common is paired with a native SDK that still marks these ads APIs experimental.
> 
> **Overview**
> Aligns **Purchases Hybrid Common** with stabilized native ads APIs by dropping experimental access gates on Android and iOS. Hybrid callers no longer need to opt into preview/experimental APIs to use ad tracking or reward verification.
> 
> On **Android**, `@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)` and related imports were removed from hybrid `common.kt` wrappers (`trackAd*`, `generateRewardVerificationToken`, `pollRewardVerification`), reward-verification mappers/tests, and Kotlin API compile tests—behavior is unchanged.
> 
> On **iOS**, `@_spi(Experimental)` was removed from RevenueCat imports in hybrid additions for ad rewards and reward verification (and matching tests); `CommonFunctionality` now imports only `@_spi(Internal)` where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 661366f9a89a16aba5379b0892fffe7ecab04f2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->