### PR TITLE
chore: don't run danger on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -595,7 +595,10 @@ workflows:
         - not:
             equal: [ update_error_codes, << pipeline.parameters.action >> ]
     jobs:
-      - revenuecat/danger
+      - revenuecat/danger:
+          filters:
+            branches:
+              ignore: main
 
   update-error-codes:
     when:


### PR DESCRIPTION
Danger runs on every push to `main`, but there's no PR there for it to comment on.

Added a branch filter to the danger job so it skips `main`. `cordova-plugin-purchases` already did this, this brings the rest of the SDK repos in line. Release and snapshot branches are unchanged.

### Verification
- [x] `circleci config validate .circleci/config.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only branch filter with no application or security impact; only reduces unnecessary Danger runs on main.
> 
> **Overview**
> **Stops the CircleCI `danger` workflow from running on `main`.** The job is now declared as `revenuecat/danger` with `filters.branches.ignore: main`, so pushes to `main` no longer trigger Danger when there is no open PR to attach comments to.
> 
> Other `danger` workflow conditions (scheduled pipelines and `update_error_codes`) are unchanged, and this matches the pattern already used in other SDK repos such as `cordova-plugin-purchases`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 012fcc9021ceb20469830a3ade6b1f474bb572a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->