### PR TITLE
feat: add onRestoreInitiated paywall listener bridge

### DIFF
--- a/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallListenerWrapper.kt
+++ b/android/hybridcommon-ui/src/main/java/com/revenuecat/purchases/hybridcommon/ui/PaywallListenerWrapper.kt
@@ -22,6 +22,11 @@ abstract class PaywallListenerWrapper : PaywallListener {
         fun resumePurchasePackageInitiated(requestId: String, shouldProceed: Boolean) {
             pendingResumeCallbacks.remove(requestId)?.invoke(shouldProceed)
         }
+
+        @JvmStatic
+        fun resumeRestoreInitiated(requestId: String, shouldProceed: Boolean) {
+            pendingResumeCallbacks.remove(requestId)?.invoke(shouldProceed)
+        }
     }
 
     override fun onPurchasePackageInitiated(rcPackage: Package, resume: Resumable) {
@@ -32,6 +37,16 @@ abstract class PaywallListenerWrapper : PaywallListener {
 
     open fun onPurchasePackageInitiated(rcPackage: Map<String, Any?>, requestId: String) {
         resumePurchasePackageInitiated(requestId, true)
+    }
+
+    override fun onRestoreInitiated(resume: Resumable) {
+        val requestId = UUID.randomUUID().toString()
+        pendingResumeCallbacks[requestId] = { resume(it) }
+        onRestoreInitiated(requestId)
+    }
+
+    open fun onRestoreInitiated(requestId: String) {
+        resumeRestoreInitiated(requestId, true)
     }
 
     override fun onPurchaseStarted(rcPackage: Package) {

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCPaywallProxyAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCPaywallProxyAPITest.m
@@ -85,6 +85,9 @@ NS_ASSUME_NONNULL_BEGIN
         paramsWithOffering.purchaseLogicBridge = bridge;
         __unused RCPaywallViewController *view5 = [proxy createPaywallViewWithParams:paramsWithOffering];
 
+        [PaywallProxy resumePurchasePackageInitiatedWithRequestId:@"request-id" shouldProceed:YES];
+        [PaywallProxy resumeRestoreInitiatedWithRequestId:@"request-id" shouldProceed:YES];
+
     }
 }
 

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallProxy.swift
@@ -80,9 +80,15 @@ import UIKit
     private var purchaseLogicBridgeByVC: [PaywallViewController: HybridPurchaseLogicBridge] = [:]
 
     private static var pendingPurchaseInitiatedCallbacks: [String: (Bool) -> Void] = [:]
+    private static var pendingRestoreInitiatedCallbacks: [String: (Bool) -> Void] = [:]
 
     @objc public static func resumePurchasePackageInitiated(requestId: String, shouldProceed: Bool) {
         guard let callback = pendingPurchaseInitiatedCallbacks.removeValue(forKey: requestId) else { return }
+        callback(shouldProceed)
+    }
+
+    @objc public static func resumeRestoreInitiated(requestId: String, shouldProceed: Bool) {
+        guard let callback = pendingRestoreInitiatedCallbacks.removeValue(forKey: requestId) else { return }
         callback(shouldProceed)
     }
 
@@ -490,7 +496,14 @@ extension PaywallProxy: PaywallViewControllerDelegate {
 
     public func paywallViewControllerDidStartRestore(_ controller: PaywallViewController) {
         self.delegate?.paywallViewControllerDidStartRestore?(controller)
-        
+    }
+
+    public func paywallViewController(_ controller: PaywallViewController,
+                                      didInitiateRestoreWith resume: @escaping (Bool) -> Void) {
+        let requestId = UUID().uuidString
+        Self.pendingRestoreInitiatedCallbacks[requestId] = resume
+        self.delegate?.paywallViewController?(controller, didInitiateRestoreWithRequestId: requestId)
+            ?? Self.resumeRestoreInitiated(requestId: requestId, shouldProceed: true)
     }
 
     public func paywallViewController(_ controller: PaywallViewController,

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallViewControllerDelegateWrapper.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallViewControllerDelegateWrapper.swift
@@ -98,6 +98,13 @@ public protocol PaywallViewControllerDelegateWrapper: AnyObject {
                                         didInitiatePurchaseWith packageDictionary: [String: Any],
                                         requestId: String)
 
+    /// Called when a restore is about to be initiated, before StoreKit restore starts.
+    /// The host must call ``PaywallProxy/resumeRestoreInitiated(requestId:shouldProceed:)`` with the
+    /// given `requestId` to continue or cancel the restore.
+    @objc(paywallViewController:didInitiateRestoreWithRequestId:)
+    optional func paywallViewController(_ controller: PaywallViewController,
+                                        didInitiateRestoreWithRequestId requestId: String)
+
     /// Called when the paywall requests a custom purchase to be performed.
     /// Used when `purchasesAreCompletedBy` is set to `.myApp`.
     @objc(paywallViewControllerDidRequestPerformPurchase:packageDictionary:requestId:)


### PR DESCRIPTION
## Summary

- [x] A description about what and why you are contributing, even if it's trivial.
- [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.
- [ ] If applicable, unit tests.

Native paywalls already gate restore before it starts:

- iOS `PaywallViewControllerDelegate.paywallViewController(_:didInitiateRestoreWith:)` (`paywallViewController:didInitiateRestoreWithResume:`, purchases-ios ≥ 5.67, see RevenueCat/purchases-ios#6392)
- Android `PaywallListener.onRestoreInitiated(resume: Resumable)` (purchases-android ≥ 9.28)

`PaywallListenerWrapper` / `PaywallProxy` never forwarded that hook. Hybrids that must `logIn` / identify the user **before** StoreKit restore (e.g. logout left RC on the previous App User ID) have no way to pause restore. Purchase already has this via `onPurchasePackageInitiated` + `resume(requestId, shouldProceed)`.

This PR mirrors that shape for restore **on `PaywallProxy` itself** (not a subclass). `PaywallProxy` is a Swift `public` class, so it is `objc_subclassing_restricted` — RN / ObjC consumers cannot subclass it to add this delegate. Putting the stash + `resumeRestoreInitiated` on the proxy is the only shape that compiles.

**iOS**
- `PaywallProxy` implements `paywallViewController(_:didInitiateRestoreWith:)`, stashes `resume` by UUID
- Wrapper: `paywallViewController:didInitiateRestoreWithRequestId:`
- `PaywallProxy.resumeRestoreInitiated(requestId:shouldProceed:)`
- If the wrapper method is unimplemented, auto-`resume(true)` (same as purchase)

**Android**
- `PaywallListenerWrapper` overrides `onRestoreInitiated(Resumable)`, converts to `onRestoreInitiated(requestId: String)` using the existing `pendingResumeCallbacks` map
- `PaywallListenerWrapper.resumeRestoreInitiated`
- Default open method auto-resumes if the hybrid SDK does not override

Follow-up RN PR: [react-native-purchases#1923](https://github.com/RevenueCat/react-native-purchases/pull/1923) (depends on a published hybrid-common version that includes this).