### PR TITLE
feat(singular): add setSingularDeviceID passthrough for Singular V2

### DIFF
--- a/android/api-tests/src/test/java/com/revenuecat/apitests/java/SubscriberAttributesApiTests.java
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/java/SubscriberAttributesApiTests.java
@@ -48,6 +48,11 @@ class SubscriberAttributesApiTests {
         SubscriberAttributesKt.setKochavaDeviceID(null);
     }
 
+    private void checkSingularDeviceID() {
+        SubscriberAttributesKt.setSingularDeviceID("singular_device_id");
+        SubscriberAttributesKt.setSingularDeviceID(null);
+    }
+
     private void checkSetPostHogUserID(String id) {
         SubscriberAttributesKt.setPostHogUserID(id);
         SubscriberAttributesKt.setPostHogUserID(null);

--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/SubscriberAttributesApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/SubscriberAttributesApiTests.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.hybridcommon.setEmail
 import com.revenuecat.purchases.hybridcommon.setFBAnonymousID
 import com.revenuecat.purchases.hybridcommon.setKeyword
 import com.revenuecat.purchases.hybridcommon.setKochavaDeviceID
+import com.revenuecat.purchases.hybridcommon.setSingularDeviceID
 import com.revenuecat.purchases.hybridcommon.setMediaSource
 import com.revenuecat.purchases.hybridcommon.setMparticleID
 import com.revenuecat.purchases.hybridcommon.setOnesignalID
@@ -77,6 +78,11 @@ private class SubscriberAttributesApiTests {
     fun checkSetAirbridgeDeviceID() {
         setAirbridgeDeviceID("airbridgeDeviceID")
         setAirbridgeDeviceID(null)
+    }
+
+    fun checkSetSingularDeviceID() {
+        setSingularDeviceID("singularDeviceID")
+        setSingularDeviceID(null)
     }
 
     // endregion

--- a/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/SubscriberAttributesApiTests.kt
+++ b/android/api-tests/src/test/java/com/revenuecat/apitests/kotlin/SubscriberAttributesApiTests.kt
@@ -16,7 +16,6 @@ import com.revenuecat.purchases.hybridcommon.setEmail
 import com.revenuecat.purchases.hybridcommon.setFBAnonymousID
 import com.revenuecat.purchases.hybridcommon.setKeyword
 import com.revenuecat.purchases.hybridcommon.setKochavaDeviceID
-import com.revenuecat.purchases.hybridcommon.setSingularDeviceID
 import com.revenuecat.purchases.hybridcommon.setMediaSource
 import com.revenuecat.purchases.hybridcommon.setMparticleID
 import com.revenuecat.purchases.hybridcommon.setOnesignalID
@@ -24,6 +23,7 @@ import com.revenuecat.purchases.hybridcommon.setOnesignalUserID
 import com.revenuecat.purchases.hybridcommon.setPhoneNumber
 import com.revenuecat.purchases.hybridcommon.setPostHogUserID
 import com.revenuecat.purchases.hybridcommon.setPushToken
+import com.revenuecat.purchases.hybridcommon.setSingularDeviceID
 import com.revenuecat.purchases.hybridcommon.setTenjinAnalyticsInstallationID
 
 @Suppress("unused")

--- a/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/subscriberAttributes.kt
+++ b/android/hybridcommon/src/main/java/com/revenuecat/purchases/hybridcommon/subscriberAttributes.kt
@@ -64,6 +64,10 @@ fun setAirbridgeDeviceID(airbridgeDeviceID: String?) {
     Purchases.sharedInstance.setAirbridgeDeviceID(airbridgeDeviceID)
 }
 
+fun setSingularDeviceID(singularDeviceID: String?) {
+    Purchases.sharedInstance.setSingularDeviceID(singularDeviceID)
+}
+
 // endregion
 // region Campaign parameters
 

--- a/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
+++ b/ios/PurchasesHybridCommon/ObjCAPITester/RCHybridCommonAPITest.m
@@ -217,6 +217,8 @@ NS_ASSUME_NONNULL_BEGIN
     [RCCommonFunctionality setTenjinAnalyticsInstallationID:nil];
     [RCCommonFunctionality setKochavaDeviceID:@""];
     [RCCommonFunctionality setKochavaDeviceID:nil];
+    [RCCommonFunctionality setSingularDeviceID:@""];
+    [RCCommonFunctionality setSingularDeviceID:nil];
     [RCCommonFunctionality setMediaSource:@""];
     [RCCommonFunctionality setMediaSource:nil];
     [RCCommonFunctionality setCampaign:@""];

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -691,6 +691,9 @@ import StoreKit
     @objc static func setAirbridgeDeviceID(_ airbridgeDeviceID: String?) {
         Self.sharedInstance.attribution.setAirbridgeDeviceID(airbridgeDeviceID)
     }
+    @objc static func setSingularDeviceID(_ singularDeviceID: String?) {
+        Self.sharedInstance.attribution.setSingularDeviceID(singularDeviceID)
+    }
 
 }
 


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for the hybrid SDKs

### Motivation

Singular's Event Endpoint V2 (mandatory for Singular accounts created on or after
2026-07-15) requires an `sdid`, generated by the Singular SDK. `collectDeviceIdentifiers()`
cannot derive it, so the app has to hand it to us.

Part of [INT-101](https://linear.app/revenuecat/issue/INT-101/support-singular-event-endpoint-v2-with-sdid)
([Slack thread](https://revenuecat.slack.com/archives/C03HPN9UE80/p1786706850769159)).

### Description

Adds the `setSingularDeviceID` passthrough on Android and iOS, following the existing
`setAirbridgeDeviceID` / `setKochavaDeviceID` pattern, plus the matching Kotlin, Java and
ObjC api-tester stubs.

No dependency changes: the pin bumps this needs (iOS 5.87.0, Android 10.19.0, JS 1.54.0)
landed on `main` in #1847, so this branch was rebased onto them and now carries only the
new setter.

Native PRs: RevenueCat/purchases-ios#7488, RevenueCat/purchases-android#4072,
RevenueCat/purchases-js#1080 — all merged and released.

Next in the chain: the five hybrid wrappers (flutter, react-native, capacitor, cordova,
unity) need their own bridge PRs once this ships in a PHC release. `purchases-kmp` is
independent and is covered by RevenueCat/purchases-kmp#996.

### Testing

Not compile-verified locally — no JDK or Xcode available in the environment I authored
this in, so CI is the first real build. Draft until it's green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin passthrough and API-test additions only; no purchase, auth, or core billing logic changes, though attribution data handling is touched.
> 
> **Overview**
> Adds **`setSingularDeviceID`** to hybrid common on **Android** and **iOS** so apps can pass Singular’s **`sdid`** (required for Singular Event Endpoint V2) into RevenueCat when `collectDeviceIdentifiers()` cannot supply it.
> 
> On Android, `subscriberAttributes.kt` exposes a nullable `setSingularDeviceID` that forwards to `Purchases.sharedInstance.setSingularDeviceID`. On iOS, `CommonFunctionality` adds an `@objc` `setSingularDeviceID` that delegates to `attribution.setSingularDeviceID`, matching existing attribution ID passthroughs like Kochava and Airbridge.
> 
> **API compile tests** are extended in Java/Kotlin subscriber-attribute tests and the ObjC API tester so the new surface is exercised with string and `null` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f242e808673f985b8503a87af4b1960da71c17ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->