### PR TITLE
chore(ads): add ios availability check

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -1267,6 +1267,11 @@ private extension CommonFunctionality {
 
     @objc(generateRewardVerificationTokenWithImpressionId:)
     static func generateRewardVerificationToken(impressionId: String) -> [String: Any] {
+        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
+            NSLog("[PurchasesHybridCommon] generateRewardVerificationToken: Reward verification requires " +
+                  "iOS 15.0 or newer")
+            return [:]
+        }
         return Purchases.shared.generateRewardVerificationToken(impressionId: impressionId).rc_dictionary
     }
 
@@ -1284,6 +1289,10 @@ private extension CommonFunctionality {
         trackingMetadata: [String: Any]? = nil,
         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void
     ) {
+        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
+            completion(nil, Self.createErrorContainer(error: ErrorCode.unsupportedError))
+            return
+        }
         let metadata = trackingMetadata.flatMap { data -> RewardedAdTrackingMetadata? in
             guard let mediatorNameString = data["mediatorName"] as? String,
                   let adFormatString = data["adFormat"] as? String,


### PR DESCRIPTION
Ad rewards availability annotation will change to ios15+ - it prepares PHC so it won't break.