### PR TITLE
fix: wait for pods to reach the CocoaPods CDN before triggering hybrid bumps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,9 +378,14 @@ jobs:
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       # Blocks the bumps rather than each hybrid waiting on its own mac executors.
+      # The lane logs on every poll, so the default 10 minute no-output timeout
+      # wouldn't fire, but set it explicitly to sit just above the lane's own 45
+      # minute cap. If the step does fail, the bump steps below still run: they
+      # are all `when: always`.
       - run:
           name: Wait for the new pods to reach the CocoaPods CDN
           command: bundle exec fastlane wait_for_pods_on_cdn
+          no_output_timeout: 50m
       - run:
           name: Kick off Flutter automatic dependency update
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,13 +379,14 @@ jobs:
           cache-version: v1
       # Blocks the bumps rather than each hybrid waiting on its own mac executors.
       # The lane logs on every poll, so the default 10 minute no-output timeout
-      # wouldn't fire, but set it explicitly to sit just above the lane's own 45
-      # minute cap. If the step does fail, the bump steps below still run: they
-      # are all `when: always`.
+      # wouldn't fire, but set it explicitly to sit just above the lane's own 3
+      # hour cap, otherwise a stalled CDN request kills the step at 10 minutes.
+      # If the step does fail, the bump steps below still run: they are all
+      # `when: always`.
       - run:
           name: Wait for the new pods to reach the CocoaPods CDN
           command: bundle exec fastlane wait_for_pods_on_cdn
-          no_output_timeout: 50m
+          no_output_timeout: 190m
       - run:
           name: Kick off Flutter automatic dependency update
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,6 +377,10 @@ jobs:
       - revenuecat/trust-github-key
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
+      # Blocks the bumps rather than each hybrid waiting on its own mac executors.
+      - run:
+          name: Wait for the new pods to reach the CocoaPods CDN
+          command: bundle exec fastlane wait_for_pods_on_cdn
       - run:
           name: Kick off Flutter automatic dependency update
           command: |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 7dd9ab9d33986d253aef7393dcc7b2097177e2f3
+  revision: 6db1da0fb9732432bdd7db7c4693546553fb9f05
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -393,18 +393,18 @@ lane :wait_for_pods_on_cdn do
   # behaviour we have today and each one can be rerun individually, whereas
   # failing here would leave every hybrid without a PR at all.
   #
-  # 45 minutes rather than the action's 3 hour default. CircleCI caps a job at
-  # 1h/3h/5h depending on plan, and blowing that cap cancels the job outright,
-  # which would skip the bump steps entirely and defeat the soft_fail above.
-  # 45m stays clear of the cap on any plan while still covering a normal
-  # propagation; a pathological one falls back to rerunning the hybrid jobs,
-  # which is what we do today anyway.
+  # Three hours. CircleCI cancels a job that exceeds its max runtime, which would
+  # skip the bump steps entirely and defeat the soft_fail above, so this has to
+  # stay clear of that cap. We're on the Scale plan, so the cap is 5 hours and
+  # three leaves a couple of hours of headroom. Set explicitly rather than
+  # inheriting the action's default so a change there can't silently push us
+  # over.
   wait_for_pods_in_cocoapods_cdn(
     pods: {
       'PurchasesHybridCommon' => version_number,
       'PurchasesHybridCommonUI' => version_number
     },
-    timeout: 45 * 60,
+    timeout: 3 * 60 * 60,
     soft_fail: true
   )
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -379,6 +379,23 @@ lane :run_pod_install do |options|
   end
 end
 
+desc "Waits until the pods for the current version are resolvable on the CocoaPods CDN"
+lane :wait_for_pods_on_cdn do
+  version_number = current_version_number
+
+  # push_pod_PHC/PHCUI have already pushed to trunk, but the CDN index takes a
+  # while to catch up and `pod install` can't resolve the new version until it
+  # does. Wait here so the hybrid bump PRs don't open against a pod their iOS
+  # jobs can't install yet, which otherwise leaves them red until someone reruns
+  # them by hand.
+  wait_for_pods_in_cocoapods_cdn(
+    pods: {
+      'PurchasesHybridCommon' => version_number,
+      'PurchasesHybridCommonUI' => version_number
+    }
+  )
+end
+
 desc "Run automatic bump in other repos"
 lane :bump_hybrid_dependencies do |options|
   version_number_for_bump = current_version_number

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -388,11 +388,16 @@ lane :wait_for_pods_on_cdn do
   # does. Wait here so the hybrid bump PRs don't open against a pod their iOS
   # jobs can't install yet, which otherwise leaves them red until someone reruns
   # them by hand.
+  #
+  # soft_fail so a timeout still opens the bump PRs. That's no worse than the
+  # behaviour we have today and each one can be rerun individually, whereas
+  # failing here would leave every hybrid without a PR at all.
   wait_for_pods_in_cocoapods_cdn(
     pods: {
       'PurchasesHybridCommon' => version_number,
       'PurchasesHybridCommonUI' => version_number
-    }
+    },
+    soft_fail: true
   )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -392,11 +392,19 @@ lane :wait_for_pods_on_cdn do
   # soft_fail so a timeout still opens the bump PRs. That's no worse than the
   # behaviour we have today and each one can be rerun individually, whereas
   # failing here would leave every hybrid without a PR at all.
+  #
+  # 45 minutes rather than the action's 3 hour default. CircleCI caps a job at
+  # 1h/3h/5h depending on plan, and blowing that cap cancels the job outright,
+  # which would skip the bump steps entirely and defeat the soft_fail above.
+  # 45m stays clear of the cap on any plan while still covering a normal
+  # propagation; a pathological one falls back to rerunning the hybrid jobs,
+  # which is what we do today anyway.
   wait_for_pods_in_cocoapods_cdn(
     pods: {
       'PurchasesHybridCommon' => version_number,
       'PurchasesHybridCommonUI' => version_number
     },
+    timeout: 45 * 60,
     soft_fail: true
   )
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -109,6 +109,14 @@ Tag current branch with current version number
 
 Run pod install
 
+### wait_for_pods_on_cdn
+
+```sh
+[bundle exec] fastlane wait_for_pods_on_cdn
+```
+
+Waits until the pods for the current version are resolvable on the CocoaPods CDN
+
 ### bump_hybrid_dependencies
 
 ```sh


### PR DESCRIPTION
## What and why

A pod pushed to trunk isn't immediately resolvable by `pod install` — `18.33.1` was on trunk at 14:35 UTC on 2026-08-27 and still wasn't on the CDN index two hours later. The hybrid bump PRs open right after the release, so their iOS jobs fail with `CocoaPods could not find compatible versions for pod "PurchasesHybridCommon"` until someone reruns them by hand.

This waits once in `trigger-dependent-updates`, before kicking off any of the bumps, instead of each hybrid waiting on its own. Per the thread with @vegaro / @tonidero / @facundoolano: waiting here means one already-provisioned `cimg/ruby` docker job blocks, rather than mac executors idling across five repos. The release PR stays open while it waits, so the tagged commit's jobs stay visible.

## Timeout behaviour

Three limits interact here, so spelling them out:

- **The wait is capped at 3 hours.** CircleCI *cancels* a job that exceeds its max runtime, which would skip the bump steps entirely, so the wait has to stay clear of that cap. We're on the Scale plan (5h), confirmed by a `purchases-ios` job that ran 5.09h, so 3 hours leaves a couple of hours of headroom. Set explicitly rather than inheriting the action's default so a change there can't silently push us over.
- **On timeout it still triggers the bumps** (`soft_fail`). Failing would leave every hybrid without a PR at all, which is worse than today; opening them means each can be rerun individually.
- **`no_output_timeout: 190m`**, above the wait. The lane logs on every poll so the 10 minute default wouldn't fire in normal operation, but a stalled CDN request would otherwise kill the step at 10 minutes. If the step does fail, the bump steps still run — they're all `when: always`.

Net: a normal propagation is absorbed silently, and every failure mode still ends with five bump PRs open.

## Contributing checklist

- [x] A description about what and why you are contributing, even if it's trivial.
- [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those. Uses `wait_for_pods_in_cocoapods_cdn` from RevenueCat/fastlane-plugin-revenuecat_internal#154; replaces the per-repo approach in RevenueCat/react-native-purchases#1930.
- [ ] If applicable, unit tests. The action's logic is unit tested in the plugin; this is the wiring.

## Verification

- [x] `circleci config validate .circleci/config.yml`
- [x] `ruby -c fastlane/Fastfile`
- [x] `bundle exec fastlane wait_for_pods_on_cdn` against the live CDN, resolving the plugin from git (not a local checkout): 18.33.1 resolved both pods and exited 0
- [x] Timeout path with an unpublished version: warns per pod, exits 0 so the bumps still run, and reports `180m remaining` confirming the cap reaches the action
- [ ] Exercised on a real release

## Follow-up, not blocking

The CDN request has no explicit HTTP timeout, so a hung connection stalls until `no_output_timeout` rather than failing fast. Harmless here given `when: always`, but worth hardening in the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the stable-release path that fans out bumps to five hybrid repos; mis-tuned timeouts could delay releases or reopen red iOS jobs, though `soft_fail` and `when: always` limit worst-case impact.
> 
> **Overview**
> Adds a **single centralized wait** in the `trigger-dependent-updates` CircleCI job so hybrid bump PRs are not opened until `PurchasesHybridCommon` and `PurchasesHybridCommonUI` for the release version resolve on the CocoaPods CDN.
> 
> The new **`wait_for_pods_on_cdn`** Fastlane lane polls via `wait_for_pods_in_cocoapods_cdn` (updated **`fastlane-plugin-revenuecat_internal`** in `Gemfile.lock`) with a **3-hour cap** and **`soft_fail: true`**, so timeouts still allow downstream bumps. CircleCI runs that lane **before** the existing `bump_hybrid_dependencies` steps (which remain **`when: always`**) and sets **`no_output_timeout: 190m`** so a hung CDN request does not fail the step at the default 10 minutes. Fastlane README documents the new lane.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c94d4e9b0af27bd8eb5da3ee49379d83eae567a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->