### PR TITLE
fix(ads): use the swift api for mediatorErrorCode

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -848,7 +848,7 @@ import StoreKit
         }
 
         let placement = adData["placement"] as? String
-        let mediatorErrorCode = adData["mediatorErrorCode"] as? Int
+        let mediatorErrorCode = (adData["mediatorErrorCode"] as? NSNumber)?.intValue
         let mediatorName = MediatorName(rawValue: mediatorNameString)
         let adFormat = AdFormat(rawValue: adFormatString)
         let adFailedToLoad = AdFailedToLoad(

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -848,7 +848,7 @@ import StoreKit
         }
 
         let placement = adData["placement"] as? String
-        let mediatorErrorCode = adData["mediatorErrorCode"] as? NSNumber
+        let mediatorErrorCode = adData["mediatorErrorCode"] as? Int
         let mediatorName = MediatorName(rawValue: mediatorNameString)
         let adFormat = AdFormat(rawValue: adFormatString)
         let adFailedToLoad = AdFailedToLoad(


### PR DESCRIPTION
The `nsnumber` variant will be removed from `purchases-ios` - so we are going to use the `Int` version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field type coercion in ad failure tracking with no change to required parameters or call sites.
> 
> **Overview**
> Updates **`trackAdFailedToLoad`** in hybrid common so **`mediatorErrorCode`** is passed as a Swift **`Int?`** instead of **`NSNumber?`**.
> 
> Bridge payloads can still supply the value as an **`NSNumber`** (e.g. from ObjC); the code now reads **`intValue`** before building **`AdFailedToLoad`**, matching the updated **`purchases-ios`** API where the **`NSNumber`** initializer is being removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7929f317b90b50c0aed30172406ef05efb548612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->