### PR TITLE
chore(ads): add ios availability check

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -1266,11 +1266,11 @@ private extension CommonFunctionality {
 @objc public extension CommonFunctionality {
 
     @objc(generateRewardVerificationTokenWithImpressionId:)
-    static func generateRewardVerificationToken(impressionId: String) -> [String: Any] {
+    static func generateRewardVerificationToken(impressionId: String) -> [String: Any]? {
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
             NSLog("[PurchasesHybridCommon] generateRewardVerificationToken: Reward verification requires " +
                   "iOS 15.0 or newer")
-            return [:]
+            return nil
         }
         return Purchases.shared.generateRewardVerificationToken(impressionId: impressionId).rc_dictionary
     }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon/CommonFunctionality.swift
@@ -1267,6 +1267,11 @@ private extension CommonFunctionality {
 
     @objc(generateRewardVerificationTokenWithImpressionId:)
     static func generateRewardVerificationToken(impressionId: String) -> [String: Any] {
+        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
+            NSLog("[PurchasesHybridCommon] generateRewardVerificationToken: Reward verification requires " +
+                  "iOS 15.0 or newer")
+            return [:]
+        }
         return Purchases.shared.generateRewardVerificationToken(impressionId: impressionId).rc_dictionary
     }
 
@@ -1284,6 +1289,10 @@ private extension CommonFunctionality {
         trackingMetadata: [String: Any]? = nil,
         completion: @escaping ([String: Any]?, ErrorContainer?) -> Void
     ) {
+        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
+            completion(nil, Self.createErrorContainer(error: ErrorCode.unsupportedError))
+            return
+        }
         let metadata = trackingMetadata.flatMap { data -> RewardedAdTrackingMetadata? in
             guard let mediatorNameString = data["mediatorName"] as? String,
                   let adFormatString = data["adFormat"] as? String,


### PR DESCRIPTION
Ad rewards availability annotation will change to ios15+ - it prepares PHC so it won't break.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change for unsupported OS versions; callers of token generation must handle a nil return, which is a minor API surface change.
> 
> **Overview**
> Prepares **Purchases Hybrid Common** for RevenueCat ad-reward APIs moving to **iOS 15+** by adding runtime availability checks on the reward verification bridge, matching how other ad-related entry points are gated.
> 
> **`generateRewardVerificationToken`** now returns an optional dictionary: on older OS versions it logs and returns **`nil`** instead of calling into the SDK. **`pollRewardVerification`** (including the ObjC overload) short-circuits on unsupported platforms and invokes the completion with **`ErrorCode.unsupportedError`**, consistent with patterns like promotional offers and win-back offers elsewhere in `CommonFunctionality`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5317c73c301f520c42fdb340040166d6b39516f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->