### PR TITLE
PW-1363 | Fix numeric custom variables 0 and 1 rendering as booleans on iOS hybrid paywalls

### DIFF
--- a/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommon.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		57E97CAD2D66236C007EB1C2 /* PaywallResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E97CA82D66236C007EB1C2 /* PaywallResult.swift */; };
 		57E97CAE2D66236C007EB1C2 /* CustomerCenterUIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E97CA52D66236C007EB1C2 /* CustomerCenterUIViewController.swift */; };
 		57E97CAF2D66236C007EB1C2 /* PaywallProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E97CA72D66236C007EB1C2 /* PaywallProxy.swift */; };
+		B7B43FFF7EF629350D68D998 /* PaywallCustomVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B4B3182448AA4307AAD265 /* PaywallCustomVariables.swift */; };
 		57FFDE19286A566D0089A57B /* BaseIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFDE18286A566D0089A57B /* BaseIntegrationTests.swift */; };
 		57FFDE1A286A566D0089A57B /* PurchasesHybridCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D54BF002437AD5800FF4EE4 /* PurchasesHybridCommon.framework */; };
 		57FFDE2B286A57580089A57B /* PurchasesHybridCommonIntegrationTestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFDE2A286A57580089A57B /* PurchasesHybridCommonIntegrationTestApp.swift */; };
@@ -76,6 +77,7 @@
 		7720A92A2D520021009EA43C /* IntroEligibility+HybridExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7720A9292D520021009EA43C /* IntroEligibility+HybridExtensions.swift */; };
 		77D5E72A2C233E2C002ECC77 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D5E7292C233E2C002ECC77 /* Constants.swift */; };
 		8D7E9A16717774CB710220ED /* PaywallPresentationStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5DB0D9EDF7E18D1D358ABE /* PaywallPresentationStyleTests.swift */; };
+		B75B0D138C7D71EE64495CC6 /* PaywallCustomVariablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA42CB2C6B5A644D147C90C /* PaywallCustomVariablesTests.swift */; };
 		A1B2C3D42026021600AABBCC /* RCHybridPurchaseLogicBridgeAPITest.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D32026021600AABBCC /* RCHybridPurchaseLogicBridgeAPITest.m */; };
 		A1B2C3D62026021600AABBCC /* HybridPurchaseLogicBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D52026021600AABBCC /* HybridPurchaseLogicBridge.swift */; };
 		A8BCCF7AC8C124FED857E2A7 /* AdReward+HybridAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FBD756B53F8ACF48839443 /* AdReward+HybridAdditions.swift */; };
@@ -220,6 +222,7 @@
 		57E97CA42D66236C007EB1C2 /* CustomerCenterProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterProxy.swift; sourceTree = "<group>"; };
 		57E97CA52D66236C007EB1C2 /* CustomerCenterUIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterUIViewController.swift; sourceTree = "<group>"; };
 		57E97CA72D66236C007EB1C2 /* PaywallProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallProxy.swift; sourceTree = "<group>"; };
+		F1B4B3182448AA4307AAD265 /* PaywallCustomVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallCustomVariables.swift; sourceTree = "<group>"; };
 		57E97CA82D66236C007EB1C2 /* PaywallResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallResult.swift; sourceTree = "<group>"; };
 		57E97CA92D66236C007EB1C2 /* PaywallViewControllerDelegateWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerDelegateWrapper.swift; sourceTree = "<group>"; };
 		57FFDE16286A566D0089A57B /* PurchasesHybridCommonIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PurchasesHybridCommonIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -250,6 +253,7 @@
 		B3105D79287E3CC200CA935B /* MockSandboxEnvironmentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSandboxEnvironmentDetector.swift; sourceTree = "<group>"; };
 		BC0A6D0871522AA838569D8B /* RewardVerificationResult+HybridAdditions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RewardVerificationResult+HybridAdditions.swift"; sourceTree = "<group>"; };
 		BE5DB0D9EDF7E18D1D358ABE /* PaywallPresentationStyleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallPresentationStyleTests.swift; sourceTree = "<group>"; };
+		2FA42CB2C6B5A644D147C90C /* PaywallCustomVariablesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallCustomVariablesTests.swift; sourceTree = "<group>"; };
 		BEA47FF2383D59FB41CA66D8 /* Pods-PurchasesHybridCommonUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommonUI.debug.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommonUI/Pods-PurchasesHybridCommonUI.debug.xcconfig"; sourceTree = "<group>"; };
 		C3DF770C345D861DE0CE6DC9 /* Pods-PurchasesHybridCommon-PurchasesHybridCommonTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommon-PurchasesHybridCommonTests.release.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommon-PurchasesHybridCommonTests/Pods-PurchasesHybridCommon-PurchasesHybridCommonTests.release.xcconfig"; sourceTree = "<group>"; };
 		C48588E24A992EC358A9B0CF /* Pods-PurchasesHybridCommonSwift-PurchasesHybridCommonSwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PurchasesHybridCommonSwift-PurchasesHybridCommonSwiftTests.debug.xcconfig"; path = "Target Support Files/Pods-PurchasesHybridCommonSwift-PurchasesHybridCommonSwiftTests/Pods-PurchasesHybridCommonSwift-PurchasesHybridCommonSwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -377,6 +381,7 @@
 				FDB8426F2E09D43E007DCB4C /* VirtualCurrency+HybridAdditionsTests.swift */,
 				FDB8426D2E09D3F4007DCB4C /* VirtualCurrencies+HybridAdditionsTests.swift */,
 				BE5DB0D9EDF7E18D1D358ABE /* PaywallPresentationStyleTests.swift */,
+				2FA42CB2C6B5A644D147C90C /* PaywallCustomVariablesTests.swift */,
 				9B6403ECC6AD3E412FA777AF /* RewardVerificationToken+HybridAdditionsTests.swift */,
 				F7FCE821769F7B4719CE2313 /* RewardVerificationResult+HybridAdditionsTests.swift */,
 				26ADD358A91D0AEFD86DB95C /* AdReward+HybridAdditionsTests.swift */,
@@ -505,6 +510,7 @@
 				5518008A2FFEC97D0055FD1B /* CommonFunctionality+PurchasesHybridCommonUI.swift */,
 				A1B2C3D52026021600AABBCC /* HybridPurchaseLogicBridge.swift */,
 				57E97CA72D66236C007EB1C2 /* PaywallProxy.swift */,
+				F1B4B3182448AA4307AAD265 /* PaywallCustomVariables.swift */,
 				57E97CA82D66236C007EB1C2 /* PaywallResult.swift */,
 				57E97CA92D66236C007EB1C2 /* PaywallViewControllerDelegateWrapper.swift */,
 			);
@@ -1039,6 +1045,7 @@
 				FD3652E12C53FA7A00B513F6 /* PurchasesAreCompletedByHybridAdditionsTests.swift in Sources */,
 				B3105D7A287E3CC200CA935B /* MockSandboxEnvironmentDetector.swift in Sources */,
 				8D7E9A16717774CB710220ED /* PaywallPresentationStyleTests.swift in Sources */,
+				B75B0D138C7D71EE64495CC6 /* PaywallCustomVariablesTests.swift in Sources */,
 				BE27455A29A0A87CFEBB7546 /* RewardVerificationToken+HybridAdditionsTests.swift in Sources */,
 				2B45C2493A8D481AEC9AA42A /* RewardVerificationResult+HybridAdditionsTests.swift in Sources */,
 				EF9D99EB4AEF99FE54B126CE /* AdReward+HybridAdditionsTests.swift in Sources */,
@@ -1056,6 +1063,7 @@
 				57E97CAE2D66236C007EB1C2 /* CustomerCenterUIViewController.swift in Sources */,
 				57DFC2762D6C915E00C93D97 /* CustomerCenterViewControllerDelegateWrapper.swift in Sources */,
 				57E97CAF2D66236C007EB1C2 /* PaywallProxy.swift in Sources */,
+				B7B43FFF7EF629350D68D998 /* PaywallCustomVariables.swift in Sources */,
 				A1B2C3D62026021600AABBCC /* HybridPurchaseLogicBridge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PaywallCustomVariablesTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PaywallCustomVariablesTests.swift
@@ -24,9 +24,6 @@ class PaywallCustomVariablesTests: QuickSpec {
 
         describe("value(from:)") {
 
-            // Hybrid SDKs (Flutter, React Native, Capacitor, Unity) hand values over as
-            // `[String: Any]`. Every scalar has crossed the Objective-C bridge by then, so
-            // numbers and booleans both arrive as `NSNumber`. These cases mirror that.
             context("when the value is a number that crossed the Objective-C bridge") {
                 it("keeps 1 as a number, not a boolean") {
                     expect(value(NSNumber(value: 1))) == .number(1)

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PaywallCustomVariablesTests.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonTests/PaywallCustomVariablesTests.swift
@@ -1,0 +1,123 @@
+//
+//  PaywallCustomVariablesTests.swift
+//  PurchasesHybridCommonTests
+//
+//  Copyright © 2026 RevenueCat. All rights reserved.
+//
+
+#if !os(macOS) && !os(tvOS) && !os(watchOS)
+
+import Quick
+import Nimble
+import RevenueCatUI
+import UIKit
+@testable import PurchasesHybridCommonUI
+
+@available(iOS 15.0, *)
+class PaywallCustomVariablesTests: QuickSpec {
+
+    override func spec() {
+
+        func value(_ raw: Any) -> CustomVariableValue? {
+            PaywallCustomVariables.value(from: raw)
+        }
+
+        describe("value(from:)") {
+
+            // Hybrid SDKs (Flutter, React Native, Capacitor, Unity) hand values over as
+            // `[String: Any]`. Every scalar has crossed the Objective-C bridge by then, so
+            // numbers and booleans both arrive as `NSNumber`. These cases mirror that.
+            context("when the value is a number that crossed the Objective-C bridge") {
+                it("keeps 1 as a number, not a boolean") {
+                    expect(value(NSNumber(value: 1))) == .number(1)
+                }
+
+                it("keeps 0 as a number, not a boolean") {
+                    expect(value(NSNumber(value: 0))) == .number(0)
+                }
+
+                it("keeps integers other than 0 and 1 as numbers") {
+                    expect(value(NSNumber(value: 2))) == .number(2)
+                    expect(value(NSNumber(value: -1))) == .number(-1)
+                }
+
+                it("keeps doubles as numbers") {
+                    expect(value(NSNumber(value: 1.0))) == .number(1)
+                    expect(value(NSNumber(value: 2.5))) == .number(2.5)
+                }
+            }
+
+            context("when the value is a boolean that crossed the Objective-C bridge") {
+                it("maps true to a boolean") {
+                    expect(value(NSNumber(value: true))) == .bool(true)
+                }
+
+                it("maps false to a boolean") {
+                    expect(value(NSNumber(value: false))) == .bool(false)
+                }
+            }
+
+            context("when the value is a native Swift scalar") {
+                it("maps Bool to a boolean") {
+                    expect(value(true)) == .bool(true)
+                    expect(value(false)) == .bool(false)
+                }
+
+                it("maps Int and Double to numbers") {
+                    expect(value(1)) == .number(1)
+                    expect(value(0)) == .number(0)
+                    expect(value(3.25)) == .number(3.25)
+                }
+            }
+
+            context("when the value is a string") {
+                it("keeps it as a string, even when it looks numeric") {
+                    expect(value("1")) == .string("1")
+                    expect(value("true")) == .string("true")
+                    expect(value(NSString(string: "GPS Max"))) == .string("GPS Max")
+                }
+            }
+
+            context("when the value is not a string, number or boolean") {
+                it("returns nil so the variable is skipped") {
+                    expect(value(Date())).to(beNil())
+                    expect(value([1, 2])).to(beNil())
+                    expect(value(["nested": 1])).to(beNil())
+                }
+            }
+        }
+
+        describe("createPaywallView(params:)") {
+            it("applies the bridged custom variables to the controller with their bridged types") {
+                let params = PaywallViewCreationParams()
+                params.customVariables = [
+                    "gps_max": NSNumber(value: 1),
+                    "is_pro": NSNumber(value: true),
+                    "tier": "premium",
+                ]
+
+                let controller = PaywallProxy().createPaywallView(params: params)
+
+                expect(controller.customVariables) == [
+                    "gps_max": .number(1),
+                    "is_pro": .bool(true),
+                    "tier": .string("premium"),
+                ]
+            }
+
+            it("skips unsupported values and keeps the rest") {
+                let params = PaywallViewCreationParams()
+                params.customVariables = [
+                    "when": Date(),
+                    "count": NSNumber(value: 3),
+                ]
+
+                let controller = PaywallProxy().createPaywallView(params: params)
+
+                expect(controller.customVariables) == ["count": .number(3)]
+            }
+        }
+    }
+}
+
+#endif

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallCustomVariables.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallCustomVariables.swift
@@ -20,7 +20,7 @@ enum PaywallCustomVariables {
         }
         if let number = raw as? NSNumber {
             // Numbers and booleans both arrive as NSNumber, and `as? Bool` succeeds for 0 and 1.
-            // Only a CFBoolean-backed NSNumber is a real boolean.
+            // Only an NSNumber that is a CFBoolean is a real boolean.
             if CFGetTypeID(number) == CFBooleanGetTypeID() {
                 return .bool(number.boolValue)
             }

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallCustomVariables.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallCustomVariables.swift
@@ -10,25 +10,17 @@
 import Foundation
 import RevenueCatUI
 
-/// Bridges the loosely typed custom variables hybrid SDKs hand over (`[String: Any]`, where every
-/// scalar has already crossed the Objective-C bridge as `NSNumber` or `NSString`) into the typed
-/// values `PaywallViewController` expects.
-///
-/// Every paywall entry point in ``PaywallProxy`` must go through ``apply(_:to:)`` so the type
-/// mapping lives in exactly one place.
+/// Maps the untyped custom variables hybrid SDKs pass to `CustomVariableValue`.
 @available(iOS 15.0, *)
 enum PaywallCustomVariables {
 
-    /// Maps a single bridged value. Returns `nil` for types the paywall cannot render.
-    ///
-    /// Booleans and numbers both arrive as `NSNumber`, and Swift happily casts an `NSNumber`
-    /// holding 0 or 1 to `Bool`. Trying `as? Bool` first is therefore wrong: a numeric `1`
-    /// would render as "true". Only an `NSNumber` backed by `CFBoolean` is a real boolean.
     static func value(from raw: Any) -> CustomVariableValue? {
         if let stringValue = raw as? String {
             return .string(stringValue)
         }
         if let number = raw as? NSNumber {
+            // Numbers and booleans both arrive as NSNumber, and `as? Bool` succeeds for 0 and 1.
+            // Only a CFBoolean-backed NSNumber is a real boolean.
             if CFGetTypeID(number) == CFBooleanGetTypeID() {
                 return .bool(number.boolValue)
             }
@@ -37,7 +29,6 @@ enum PaywallCustomVariables {
         return nil
     }
 
-    /// Applies `variables` to `controller`, skipping (and logging) any value that cannot be mapped.
     static func apply(_ variables: [String: Any]?, to controller: PaywallViewController) {
         variables?.forEach { key, raw in
             guard let value = value(from: raw) else {

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallCustomVariables.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallCustomVariables.swift
@@ -1,0 +1,51 @@
+//
+//  PaywallCustomVariables.swift
+//  PurchasesHybridCommonUI
+//
+//  Copyright © 2026 RevenueCat. All rights reserved.
+//
+
+import Foundation
+import RevenueCatUI
+
+/// Bridges the loosely typed custom variables hybrid SDKs hand over (`[String: Any]`, where every
+/// scalar has already crossed the Objective-C bridge as `NSNumber` or `NSString`) into the typed
+/// values `PaywallViewController` expects.
+///
+/// Every paywall entry point in ``PaywallProxy`` must go through ``apply(_:to:)`` so the type
+/// mapping lives in exactly one place.
+@available(iOS 15.0, *)
+enum PaywallCustomVariables {
+
+    /// Maps a single bridged value. Returns `nil` for types the paywall cannot render.
+    ///
+    /// Booleans and numbers both arrive as `NSNumber`, and Swift happily casts an `NSNumber`
+    /// holding 0 or 1 to `Bool`. Trying `as? Bool` first is therefore wrong: a numeric `1`
+    /// would render as "true". Only an `NSNumber` backed by `CFBoolean` is a real boolean.
+    static func value(from raw: Any) -> CustomVariableValue? {
+        if let stringValue = raw as? String {
+            return .string(stringValue)
+        }
+        if let number = raw as? NSNumber {
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return .bool(number.boolValue)
+            }
+            return .number(number.doubleValue)
+        }
+        return nil
+    }
+
+    /// Applies `variables` to `controller`, skipping (and logging) any value that cannot be mapped.
+    static func apply(_ variables: [String: Any]?, to controller: PaywallViewController) {
+        variables?.forEach { key, raw in
+            guard let value = value(from: raw) else {
+                NSLog("Custom variable '%@' has unsupported type %@. " +
+                      "Only String, Number, and Boolean values are supported. This variable will be ignored.",
+                      key, String(describing: type(of: raw)))
+                return
+            }
+            controller.customVariables[key] = value
+        }
+    }
+
+}

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallCustomVariables.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallCustomVariables.swift
@@ -5,6 +5,8 @@
 //  Copyright © 2026 RevenueCat. All rights reserved.
 //
 
+#if !os(macOS) && !os(tvOS) && !os(watchOS)
+
 import Foundation
 import RevenueCatUI
 
@@ -49,3 +51,5 @@ enum PaywallCustomVariables {
     }
 
 }
+
+#endif

--- a/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallProxy.swift
+++ b/ios/PurchasesHybridCommon/PurchasesHybridCommonUI/Paywalls/PaywallProxy.swift
@@ -128,19 +128,7 @@ import UIKit
             )
         }
 
-        params.customVariables?.forEach { key, value in
-            if let stringValue = value as? String {
-                controller.setCustomVariable(stringValue, forKey: key)
-            } else if let boolValue = value as? Bool {
-                controller.setCustomVariableBool(boolValue, forKey: key)
-            } else if let numberValue = (value as? NSNumber)?.doubleValue {
-                controller.setCustomVariableNumber(numberValue, forKey: key)
-            } else {
-                NSLog("Custom variable '%@' has unsupported type %@. " +
-                      "Only String, Number, and Boolean values are supported. This variable will be ignored.",
-                      key, String(describing: type(of: value)))
-            }
-        }
+        PaywallCustomVariables.apply(params.customVariables, to: controller)
 
         controller.delegate = self
         if let bridge = params.purchaseLogicBridge {
@@ -287,19 +275,7 @@ import UIKit
                                                performRestore: performRestore)
         }
 
-        params.customVariables?.forEach { key, value in
-            if let stringValue = value as? String {
-                controller.setCustomVariable(stringValue, forKey: key)
-            } else if let boolValue = value as? Bool {
-                controller.setCustomVariableBool(boolValue, forKey: key)
-            } else if let numberValue = (value as? NSNumber)?.doubleValue {
-                controller.setCustomVariableNumber(numberValue, forKey: key)
-            } else {
-                NSLog("Custom variable '%@' has unsupported type %@. " +
-                      "Only String, Number, and Boolean values are supported. This variable will be ignored.",
-                      key, String(describing: type(of: value)))
-            }
-        }
+        PaywallCustomVariables.apply(params.customVariables, to: controller)
 
         controller.delegate = self
         controller.modalPresentationStyle = params.modalPresentationStyle


### PR DESCRIPTION
### What

Numeric custom variables with the value 0 or 1 rendered as `false` / `true` on iOS paywalls opened from a hybrid SDK. They now render as numbers.

### Why

Hybrid SDKs hand custom variables over untyped so a number and a boolean look the same to the iOS bridge. Extracted the code into a helper and fixed it.

Reported in Flutter [PW-1363](https://linear.app/revenuecat/issue/PW-1363/fix-gps-max-variable-rendering-as-true-on-ios).

<details>
<summary>AI session context</summary>

- Agent: Claude Code (Claude Fable 5.1), current session. PR #1874.
- Asked: triage the Natlink report, then fix it so it does not recur, with tests and no public API change.
- Agent did: found the duplicated mapping in the paywall proxy, wrote the tests first (compile RED), moved the old mapping into one shared helper (4 of 12 RED), fixed the boolean detection (133 of 133 GREEN), registered the two new files in the Xcode project.
- Human decided: fix in hybrid-common, one shared path, nothing new made public. Diff review pending.
- Rejected: a new UI test target. The existing one already covers the UI module.
- Gaps: the modal presentation path is covered only through the shared helper. Not run on a real Flutter or React Native app. CI not captured at generation.
- Review focus: a hybrid that delivers booleans as plain numbers would now render 1 / 0.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall custom-variable typing for all hybrid iOS entry points; a hybrid that encodes booleans as plain numeric 0/1 would now render as numbers instead of booleans.
> 
> **Overview**
> Fixes hybrid iOS paywalls misclassifying numeric custom variables **0** and **1** as booleans when values cross the Obj‑C bridge (e.g. Flutter `gps_max: 1` showing as `true`).
> 
> Introduces internal **`PaywallCustomVariables`** to map untyped `[String: Any]` into `CustomVariableValue`, using **`CFBooleanGetTypeID()`** so only real bridged booleans become `.bool` while other `NSNumber` values stay `.number`. **`PaywallProxy`** now calls this helper in both `createPaywallView` and modal `presentPaywall` instead of duplicated `as? Bool` / `setCustomVariable*` logic, and sets `controller.customVariables` directly. Adds **`PaywallCustomVariablesTests`** and Xcode project entries; no public API change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edeec7152d13b99f426df7fa677d7e0f8be2c65e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->